### PR TITLE
feat: make built-in agents configurable via /tf init

### DIFF
--- a/extensions/agents.ts
+++ b/extensions/agents.ts
@@ -204,10 +204,15 @@ export function discoverAgents(
 	}
 
 	// Resolve {{role}} model references (e.g. {{fast}} → openrouter/deepseek/v4-flash)
+	// Clone before mutating, consistent with the overrides block above.
 	if (modelRoles) {
-		for (const agent of agentMap.values()) {
+		for (const [name, agent] of agentMap.entries()) {
 			const resolved = resolveModelRole(agent.model, modelRoles);
-			if (resolved !== agent.model) agent.model = resolved;
+			if (resolved !== agent.model) {
+				const mutated: AgentConfig = { ...agent };
+				mutated.model = resolved;
+				agentMap.set(name, mutated);
+			}
 		}
 	}
 

--- a/extensions/agents.ts
+++ b/extensions/agents.ts
@@ -10,6 +10,43 @@ import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 
 export type AgentScope = "user" | "project" | "both";
 
+export interface TaskflowSettings {
+	/** Whether taskflow's package-local built-in agents are available to flows. */
+	builtInAgents: boolean;
+	/** Whether package-local built-ins are copied into the current project's .pi/agents/. */
+	syncBuiltinAgentsToProject: boolean;
+}
+
+export const DEFAULT_TASKFLOW_SETTINGS: TaskflowSettings = {
+	builtInAgents: true,
+	syncBuiltinAgentsToProject: false,
+};
+
+export function normalizeTaskflowSettings(raw: unknown): TaskflowSettings {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		return { ...DEFAULT_TASKFLOW_SETTINGS };
+	}
+	const rec = raw as Record<string, unknown>;
+	return {
+		builtInAgents:
+			typeof rec.builtInAgents === "boolean"
+				? rec.builtInAgents
+				: DEFAULT_TASKFLOW_SETTINGS.builtInAgents,
+		syncBuiltinAgentsToProject:
+			typeof rec.syncBuiltinAgentsToProject === "boolean"
+				? rec.syncBuiltinAgentsToProject
+				: DEFAULT_TASKFLOW_SETTINGS.syncBuiltinAgentsToProject,
+	};
+}
+
+export function shouldLoadBuiltinAgents(settings: TaskflowSettings = DEFAULT_TASKFLOW_SETTINGS): boolean {
+	return settings.builtInAgents;
+}
+
+export function shouldSyncBuiltinAgentsToProject(settings: TaskflowSettings = DEFAULT_TASKFLOW_SETTINGS): boolean {
+	return settings.builtInAgents && settings.syncBuiltinAgentsToProject;
+}
+
 export interface AgentOverride {
 	model?: string;
 	thinking?: string;
@@ -122,12 +159,14 @@ export function discoverAgents(
 	scope: AgentScope,
 	overrides?: Record<string, AgentOverride>,
 	modelRoles?: Record<string, string>,
+	taskflowSettings: TaskflowSettings = DEFAULT_TASKFLOW_SETTINGS,
 ): AgentDiscoveryResult {
-	// Built-in agents ship with the package (extensions/agents/*.md)
-	// PI_TASKFLOW_BUILTIN_AGENTS_DIR allows tests to override or disable (empty = skip)
+	// Built-in agents ship with the package (extensions/agents/*.md).
+	// PI_TASKFLOW_BUILTIN_AGENTS_DIR is kept as a test hook only; user-facing
+	// enable/disable lives in settings.json under `taskflow.builtInAgents`.
 	const builtInDirEnv = process.env.PI_TASKFLOW_BUILTIN_AGENTS_DIR;
 	const builtInDir = builtInDirEnv ? builtInDirEnv : builtInDirEnv === undefined ? path.resolve(import.meta.dirname, "agents") : "";
-	const builtInAgents = builtInDir ? loadAgentsFromDir(builtInDir, "built-in") : [];
+	const builtInAgents = shouldLoadBuiltinAgents(taskflowSettings) && builtInDir ? loadAgentsFromDir(builtInDir, "built-in") : [];
 
 	const userDir = path.join(getAgentDir(), "agents");
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
@@ -179,6 +218,7 @@ export interface SubagentSettings {
 	agentOverrides?: Record<string, AgentOverride>;
 	globalThinking?: string;
 	modelRoles?: Record<string, string>;
+	taskflow: TaskflowSettings;
 }
 
 /**
@@ -197,15 +237,16 @@ export function resolveModelRole(model: string | undefined, roles?: Record<strin
 export function readSubagentSettings(): SubagentSettings {
 	try {
 		const settingsPath = path.join(getAgentDir(), "settings.json");
-		if (!fs.existsSync(settingsPath)) return {};
+		if (!fs.existsSync(settingsPath)) return { taskflow: { ...DEFAULT_TASKFLOW_SETTINGS } };
 		const raw = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
 		return {
 			agentOverrides: raw.subagents?.agentOverrides,
 			globalThinking: raw.subagents?.globalThinking ?? raw.defaultThinkingLevel,
 			modelRoles: raw.modelRoles,
+			taskflow: normalizeTaskflowSettings(raw.taskflow),
 		};
 	} catch {
-		return {};
+		return { taskflow: { ...DEFAULT_TASKFLOW_SETTINGS } };
 	}
 }
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -24,7 +24,7 @@ import {
 	runInteractiveInit,
 } from "./init.ts";
 import { Type } from "typebox";
-import { type AgentScope, discoverAgents, readSubagentSettings, syncBuiltinAgentsToProject } from "./agents.ts";
+import { type AgentScope, discoverAgents, readSubagentSettings, shouldSyncBuiltinAgentsToProject, syncBuiltinAgentsToProject } from "./agents.ts";
 import { renderRunResult, summarizeRun } from "./render.ts";
 import { RunHistoryComponent, type RunHistoryResult } from "./runs-view.ts";
 import { executeTaskflow, type ApprovalDecision, type ApprovalRequest, type RuntimeResult } from "./runtime.ts";
@@ -190,7 +190,7 @@ async function runFlow(
 		// the heartbeat timer is cleared by the finally block below.
 		const settings = readSubagentSettings();
 		const scope: AgentScope = def.agentScope ?? "user";
-		const { agents } = discoverAgents(ctx.cwd, scope, settings.agentOverrides, settings.modelRoles);
+		const { agents } = discoverAgents(ctx.cwd, scope, settings.agentOverrides, settings.modelRoles, settings.taskflow);
 
 		// Hint: if any agent still has unresolved {{role}} references, suggest configuring modelRoles
 		const unresolvedRoles = agents
@@ -255,11 +255,14 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_e, ctx) => {
 		registerSavedFlowCommands(ctx);
 
-		// Sync built-in agents into .pi/agents/ so Pi's native subagent tool
-		// (and any other extension) can discover them — taskflow's
-		// extensions/agents/ directory is invisible to the rest of Pi.
+		// Optional: copy built-in agents into .pi/agents/ so Pi's native
+		// subagent tool (and other extensions) can discover them. This is
+		// disabled by default to avoid surprising project file creation.
 		try {
-			syncBuiltinAgentsToProject(ctx.cwd);
+			const settings = readSubagentSettings();
+			if (shouldSyncBuiltinAgentsToProject(settings.taskflow)) {
+				syncBuiltinAgentsToProject(ctx.cwd);
+			}
 		} catch {
 			// Best-effort: a locked or readonly .pi/ directory must not block
 			// session startup.
@@ -370,6 +373,7 @@ export default function (pi: ExtensionAPI) {
 						modelRegistry: ctx.modelRegistry,
 						modelList,
 						currentRoles: current,
+					currentTaskflowSettings: readSubagentSettings().taskflow,
 					});
 					const text = formatFlowResult(result);
 					return { content: [{ type: "text", text }], details: { action } satisfies TaskflowDetails };
@@ -382,7 +386,7 @@ export default function (pi: ExtensionAPI) {
 			if (action === "agents") {
 				const scope = params.scope ?? "both";
 				const settings2 = readSubagentSettings();
-				const { agents } = discoverAgents(ctx.cwd, scope as AgentScope, undefined, settings2.modelRoles);
+				const { agents } = discoverAgents(ctx.cwd, scope as AgentScope, undefined, settings2.modelRoles, settings2.taskflow);
 				const text = agents.length
 					? agents
 							.map(

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -268,6 +268,31 @@ export default function (pi: ExtensionAPI) {
 			// session startup.
 		}
 
+		// Upgrade hint: if the project already has .pi/agents/ with agent
+		// files but no explicit taskflow settings, the user is upgrading
+		// from the old default (sync=true) and may be surprised that sync
+		// is now disabled by default.
+		try {
+			const raw = readSettings();
+			if (!("taskflow" in raw)) {
+				const fs = await import("node:fs");
+				const path = await import("node:path");
+				const projectAgentsDir = path.join(ctx.cwd, ".pi", "agents");
+				try {
+					const entries = fs.readdirSync(projectAgentsDir).filter((e: string) => e.endsWith(".md"));
+					if (entries.length > 0) {
+						console.warn(
+							`[taskflow] Note: built-in agents are no longer synced to .pi/agents/ by default. ` +
+							`If you rely on this, run /tf init → 'Configure taskflow preferences' to re-enable. ` +
+							`(This is a one-time upgrade hint.)`,
+						);
+					}
+				} catch { /* .pi/agents/ doesn't exist — no hint needed */ }
+			}
+		} catch {
+			// Best-effort: settings.json missing or unreadable is not an error.
+		}
+
 		// Hint: prompt to configure model roles if not set
 		try {
 			const settings = readSubagentSettings();
@@ -373,7 +398,7 @@ export default function (pi: ExtensionAPI) {
 						modelRegistry: ctx.modelRegistry,
 						modelList,
 						currentRoles: current,
-					currentTaskflowSettings: readSubagentSettings().taskflow,
+						currentTaskflowSettings: readSubagentSettings().taskflow,
 					});
 					const text = formatFlowResult(result);
 					return { content: [{ type: "text", text }], details: { action } satisfies TaskflowDetails };
@@ -717,17 +742,13 @@ export default function (pi: ExtensionAPI) {
 					modelRegistry: ctx.modelRegistry,
 					modelList,
 					currentRoles,
+					currentTaskflowSettings: readSubagentSettings().taskflow,
 				});
-				ctx.ui.notify(
-					result.kind === "saved"
-						? `Saved model roles to ${result.savedPath}:\n${Object.entries(result.chosen)
-								.map(([k, v]) => `  ${k.padEnd(10)} → ${v}`)
-								.join("\n")}`
-						: result.kind === "no-change"
-							? "No changes made."
-							: "Init cancelled.",
-					result.kind === "saved" ? "info" : "info",
-				);
+				if (result.kind === "cancelled") {
+					ctx.ui.notify("Init cancelled.", "info");
+				} else {
+					ctx.ui.notify(formatFlowResult(result), "info");
+				}
 				return;
 			}
 

--- a/extensions/init.ts
+++ b/extensions/init.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_TASKFLOW_SETTINGS, normalizeTaskflowSettings, type TaskflowSettings } from "./agents.ts";
 import { writeFileAtomic } from "./store.ts";
 
 // ---------------------------------------------------------------------------
@@ -330,8 +331,23 @@ export function formatDiffReport(
 	return lines.join("\n");
 }
 
+export function formatTaskflowSettingsReport(settings: TaskflowSettings): string {
+	return [
+		"Taskflow preferences:",
+		`  Built-in agents: ${settings.builtInAgents ? "enabled" : "disabled"}`,
+		`  Sync built-ins to project .pi/agents: ${settings.syncBuiltinAgentsToProject ? "enabled" : "disabled"}`,
+	].join("\n");
+}
+
 export function formatFlowResult(result: InitFlowResult): string {
 	if (result.kind === "cancelled") return "Init cancelled.";
+	if (result.kind === "preferences-no-change") {
+		return "No changes.\n" + formatTaskflowSettingsReport(result.settings);
+	}
+	if (result.kind === "preferences-saved") {
+		const savedPath = formatSettingsPath(result.savedPath);
+		return `Saved taskflow preferences to ${savedPath}:\n` + formatTaskflowSettingsReport(result.settings);
+	}
 	if (result.kind === "no-change") {
 		return (
 			"No changes.\n" +
@@ -357,6 +373,8 @@ export function formatFlowResult(result: InitFlowResult): string {
 export type InitFlowResult =
 	| { kind: "saved"; chosen: Record<string, string>; savedPath: string }
 	| { kind: "no-change"; chosen: Record<string, string> }
+	| { kind: "preferences-saved"; settings: TaskflowSettings; savedPath: string }
+	| { kind: "preferences-no-change"; settings: TaskflowSettings }
 	| { kind: "cancelled" };
 
 export async function runInteractiveInit(ctx: {
@@ -366,6 +384,7 @@ export async function runInteractiveInit(ctx: {
 	modelRegistry: ExtensionContext["modelRegistry"];
 	modelList: Model<Api>[];
 	currentRoles: Record<string, string>;
+	currentTaskflowSettings?: TaskflowSettings;
 }): Promise<InitFlowResult> {
 	if (!ctx.hasUI) {
 		throw new Error("runInteractiveInit requires an interactive session (hasUI=true).");
@@ -373,6 +392,7 @@ export async function runInteractiveInit(ctx: {
 
 	const recommended = RECOMMENDED_DEFAULTS;
 	const current = ctx.currentRoles;
+	const currentTaskflowSettings = ctx.currentTaskflowSettings ?? normalizeTaskflowSettings(readSettings().taskflow);
 	const hasCurrent = Object.keys(current).length > 0;
 
 	// ---- Action menu ----
@@ -381,10 +401,11 @@ export async function runInteractiveInit(ctx: {
 				"Use recommended defaults",
 				"Configure each role",
 				"Edit one role",
+				"Configure taskflow preferences",
 				"Show current roles",
 				"Cancel",
 			]
-		: ["Use recommended defaults", "Configure each role"];
+		: ["Use recommended defaults", "Configure each role", "Configure taskflow preferences"];
 
 	const action = await ctx.ui.select(
 		"What do you want to do with model roles?",
@@ -416,6 +437,11 @@ export async function runInteractiveInit(ctx: {
 	// ---- Cancel ----
 	if (action === "Cancel") return { kind: "cancelled" };
 
+	// ---- Configure taskflow preferences ----
+	if (action === "Configure taskflow preferences") {
+		return configureTaskflowPreferences(ctx, currentTaskflowSettings);
+	}
+
 	// ---- Configure each role ----
 	if (action === "Configure each role") {
 		const chosen = await collectRolePicks(ctx, current, recommended, undefined);
@@ -436,6 +462,59 @@ export async function runInteractiveInit(ctx: {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+function taskflowSettingsIdentical(a: TaskflowSettings, b: TaskflowSettings): boolean {
+	return a.builtInAgents === b.builtInAgents && a.syncBuiltinAgentsToProject === b.syncBuiltinAgentsToProject;
+}
+
+async function configureTaskflowPreferences(
+	ctx: { signal: AbortSignal; ui: ExtensionUIContext },
+	current: TaskflowSettings,
+): Promise<InitFlowResult> {
+	const builtInPick = await ctx.ui.select(
+		"Taskflow built-in agents",
+		[
+			`Enable built-in agents${current.builtInAgents ? " (current)" : ""}`,
+			`Disable built-in agents${!current.builtInAgents ? " (current)" : ""}`,
+			"Back to action menu",
+		],
+		{ signal: ctx.signal },
+	);
+	if (builtInPick === undefined || builtInPick === "Back to action menu") return { kind: "cancelled" };
+
+	const chosen: TaskflowSettings = {
+		...DEFAULT_TASKFLOW_SETTINGS,
+		builtInAgents: builtInPick.startsWith("Enable"),
+	};
+
+	if (chosen.builtInAgents) {
+		const syncPick = await ctx.ui.select(
+			"Expose built-in agents to native Pi/project discovery?",
+			[
+				`Do not copy to project .pi/agents${!current.syncBuiltinAgentsToProject ? " (current)" : ""}`,
+				`Copy to project .pi/agents on session start${current.syncBuiltinAgentsToProject ? " (current)" : ""}`,
+				"Back to action menu",
+			],
+			{ signal: ctx.signal },
+		);
+		if (syncPick === undefined || syncPick === "Back to action menu") return { kind: "cancelled" };
+		chosen.syncBuiltinAgentsToProject = syncPick.startsWith("Copy");
+	}
+
+	if (taskflowSettingsIdentical(current, chosen)) {
+		return { kind: "preferences-no-change", settings: chosen };
+	}
+
+	const preview = await ctx.ui.select(
+		`Review taskflow preferences:\n\n${formatTaskflowSettingsReport(chosen)}`,
+		["Save these preferences", "Cancel"],
+		{ signal: ctx.signal },
+	);
+	if (preview !== "Save these preferences") return { kind: "cancelled" };
+
+	const savedPath = writeSettings({ ...readSettings(), taskflow: chosen });
+	return { kind: "preferences-saved", settings: chosen, savedPath };
+}
 
 /** Collect picks for all roles. Returns undefined if user escapes to action menu. */
 async function collectRolePicks(

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -3,7 +3,15 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test, beforeEach, afterEach } from "node:test";
-import { discoverAgents, readSubagentSettings, type AgentOverride } from "../extensions/agents.ts";
+import {
+	DEFAULT_TASKFLOW_SETTINGS,
+	discoverAgents,
+	normalizeTaskflowSettings,
+	readSubagentSettings,
+	shouldLoadBuiltinAgents,
+	shouldSyncBuiltinAgentsToProject,
+	type AgentOverride,
+} from "../extensions/agents.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -11,6 +19,7 @@ import { discoverAgents, readSubagentSettings, type AgentOverride } from "../ext
 
 /** The env var that controls `getAgentDir()` inside @earendil-works/pi-coding-agent. */
 const AGENT_DIR_ENV = "PI_CODING_AGENT_DIR";
+const BUILTIN_DIR_ENV = "PI_TASKFLOW_BUILTIN_AGENTS_DIR";
 
 /** Create a temp directory rooted in os.tmpdir(). */
 function makeTmpDir(prefix = "agents-test-"): string {
@@ -45,6 +54,7 @@ function writeAgent(
 // ---------------------------------------------------------------------------
 
 let savedAgentDir: string | undefined;
+let savedBuiltinDir: string | undefined;
 let tmpRoot: string;
 /** Simulated ~/.pi/agent directory */
 let userAgentDir: string;
@@ -53,6 +63,7 @@ let projectCwd: string;
 
 beforeEach(() => {
 	savedAgentDir = process.env[AGENT_DIR_ENV];
+	savedBuiltinDir = process.env[BUILTIN_DIR_ENV];
 	tmpRoot = makeTmpDir();
 	userAgentDir = path.join(tmpRoot, "user-agent");
 	projectCwd = path.join(tmpRoot, "project");
@@ -67,7 +78,40 @@ afterEach(() => {
 	} else {
 		process.env[AGENT_DIR_ENV] = savedAgentDir;
 	}
+	if (savedBuiltinDir === undefined) {
+		delete process.env[BUILTIN_DIR_ENV];
+	} else {
+		process.env[BUILTIN_DIR_ENV] = savedBuiltinDir;
+	}
 	fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// Built-in agent project sync opt-in
+// ===========================================================================
+
+test("normalizeTaskflowSettings: defaults to built-ins enabled and project sync disabled", () => {
+	assert.deepEqual(normalizeTaskflowSettings(undefined), DEFAULT_TASKFLOW_SETTINGS);
+	assert.deepEqual(normalizeTaskflowSettings({}), DEFAULT_TASKFLOW_SETTINGS);
+});
+
+test("normalizeTaskflowSettings: accepts only boolean preference values", () => {
+	assert.deepEqual(normalizeTaskflowSettings({ builtInAgents: false, syncBuiltinAgentsToProject: true }), {
+		builtInAgents: false,
+		syncBuiltinAgentsToProject: true,
+	});
+	assert.deepEqual(normalizeTaskflowSettings({ builtInAgents: "false", syncBuiltinAgentsToProject: "true" }), DEFAULT_TASKFLOW_SETTINGS);
+});
+
+test("shouldLoadBuiltinAgents: follows taskflow builtInAgents setting", () => {
+	assert.equal(shouldLoadBuiltinAgents(DEFAULT_TASKFLOW_SETTINGS), true);
+	assert.equal(shouldLoadBuiltinAgents({ ...DEFAULT_TASKFLOW_SETTINGS, builtInAgents: false }), false);
+});
+
+test("shouldSyncBuiltinAgentsToProject: disabled by default and requires built-ins to be enabled", () => {
+	assert.equal(shouldSyncBuiltinAgentsToProject(DEFAULT_TASKFLOW_SETTINGS), false);
+	assert.equal(shouldSyncBuiltinAgentsToProject({ builtInAgents: true, syncBuiltinAgentsToProject: true }), true);
+	assert.equal(shouldSyncBuiltinAgentsToProject({ builtInAgents: false, syncBuiltinAgentsToProject: true }), false);
 });
 
 // ===========================================================================
@@ -101,6 +145,29 @@ test("discoverAgents: discovers project agents from <cwd>/.pi/agents/", () => {
 test("discoverAgents: returns empty agents when no agent dirs exist", () => {
 	const { agents } = discoverAgents(projectCwd, "both");
 	assert.equal(agents.length, 0);
+});
+
+test("discoverAgents: loads built-in agents by default", () => {
+	const builtInDir = path.join(tmpRoot, "built-ins");
+	writeAgent(builtInDir, "builtin.md", { name: "builtin", description: "package agent" }, "Built in.");
+	process.env[BUILTIN_DIR_ENV] = builtInDir;
+
+	const { agents } = discoverAgents(projectCwd, "both");
+	assert.equal(agents.length, 1);
+	assert.equal(agents[0].name, "builtin");
+	assert.equal(agents[0].source, "built-in");
+});
+
+test("discoverAgents: skips built-in agents when taskflow.builtInAgents is false", () => {
+	const builtInDir = path.join(tmpRoot, "built-ins");
+	writeAgent(builtInDir, "builtin.md", { name: "builtin", description: "package agent" }, "Built in.");
+	process.env[BUILTIN_DIR_ENV] = builtInDir;
+
+	const { agents } = discoverAgents(projectCwd, "both", undefined, undefined, {
+		builtInAgents: false,
+		syncBuiltinAgentsToProject: false,
+	});
+	assert.deepEqual(agents.map((a) => a.name), []);
 });
 
 // ===========================================================================
@@ -425,9 +492,9 @@ test("discoverAgents: empty tools string results in undefined tools", () => {
 // readSubagentSettings
 // ===========================================================================
 
-test("readSubagentSettings: returns empty object when settings.json missing", () => {
+test("readSubagentSettings: returns defaults when settings.json missing", () => {
 	const settings = readSubagentSettings();
-	assert.deepEqual(settings, {});
+	assert.deepEqual(settings, { taskflow: DEFAULT_TASKFLOW_SETTINGS });
 });
 
 test("readSubagentSettings: parses agentOverrides from settings.json", () => {
@@ -490,12 +557,12 @@ test("readSubagentSettings: subagents.globalThinking takes precedence over defau
 	assert.equal(settings.globalThinking, "high");
 });
 
-test("readSubagentSettings: returns empty object for malformed JSON", () => {
+test("readSubagentSettings: returns defaults for malformed JSON", () => {
 	const settingsPath = path.join(userAgentDir, "settings.json");
 	fs.writeFileSync(settingsPath, "NOT VALID JSON {{{");
 
 	const settings = readSubagentSettings();
-	assert.deepEqual(settings, {});
+	assert.deepEqual(settings, { taskflow: DEFAULT_TASKFLOW_SETTINGS });
 });
 
 test("readSubagentSettings: returns empty agentOverrides when subagents key is missing", () => {
@@ -515,6 +582,28 @@ test("readSubagentSettings: returns empty agentOverrides when subagents is null"
 	// subagents?.globalThinking is undefined, ?? raw.defaultThinkingLevel
 	const settings = readSubagentSettings();
 	assert.equal(settings.agentOverrides, undefined);
+});
+
+test("readSubagentSettings: parses taskflow preferences from settings.json", () => {
+	const settingsPath = path.join(userAgentDir, "settings.json");
+	fs.writeFileSync(
+		settingsPath,
+		JSON.stringify({ taskflow: { builtInAgents: false, syncBuiltinAgentsToProject: false } }),
+	);
+
+	const settings = readSubagentSettings();
+	assert.deepEqual(settings.taskflow, { builtInAgents: false, syncBuiltinAgentsToProject: false });
+});
+
+test("readSubagentSettings: malformed taskflow preferences fall back to defaults", () => {
+	const settingsPath = path.join(userAgentDir, "settings.json");
+	fs.writeFileSync(
+		settingsPath,
+		JSON.stringify({ taskflow: { builtInAgents: "false", syncBuiltinAgentsToProject: "true" } }),
+	);
+
+	const settings = readSubagentSettings();
+	assert.deepEqual(settings.taskflow, DEFAULT_TASKFLOW_SETTINGS);
 });
 
 // ===========================================================================

--- a/test/e2e.mts
+++ b/test/e2e.mts
@@ -52,7 +52,7 @@ async function main() {
 	console.log("valid ✓");
 
 	const settings = readSubagentSettings();
-	const { agents } = discoverAgents(process.cwd(), "user", settings.agentOverrides);
+	const { agents } = discoverAgents(process.cwd(), "user", settings.agentOverrides, settings.modelRoles, settings.taskflow);
 	console.log(`discovered ${agents.length} agents; has scout: ${agents.some((a) => a.name === "scout")}`);
 
 	const state: RunState = {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -23,8 +23,10 @@ import {
 	formatRolesReport,
 	formatDiffReport,
 	formatFlowResult,
+	formatTaskflowSettingsReport,
 	runInteractiveInit,
 } from "../extensions/init.ts";
+import { DEFAULT_TASKFLOW_SETTINGS } from "../extensions/agents.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -148,6 +150,24 @@ test("RECOMMENDED_DEFAULTS: derived from INIT_ROLES, not stored separately", () 
 		expected[r.role] = r.defaultModel;
 	}
 	assert.deepEqual(RECOMMENDED_DEFAULTS, expected);
+});
+
+// ---------------------------------------------------------------------------
+// Taskflow preferences
+// ---------------------------------------------------------------------------
+
+test("formatTaskflowSettingsReport: formats default settings", () => {
+	const report = formatTaskflowSettingsReport(DEFAULT_TASKFLOW_SETTINGS);
+	assert.ok(report.includes("Built-in agents: enabled"));
+	assert.ok(report.includes("Sync built-ins to project .pi/agents: disabled"));
+});
+
+test("formatTaskflowSettingsReport: formats disabled settings", () => {
+	const report = formatTaskflowSettingsReport({
+		builtInAgents: false,
+		syncBuiltinAgentsToProject: false,
+	});
+	assert.ok(report.includes("Built-in agents: disabled"));
 });
 
 // ---------------------------------------------------------------------------
@@ -564,7 +584,7 @@ test("formatDiffReport: shows all diff statuses", () => {
 // runInteractiveInit (mocked UI)
 // ---------------------------------------------------------------------------
 
-test("runInteractiveInit: empty currentRoles → 2-option action menu", async () => {
+test("runInteractiveInit: empty currentRoles → 3-option action menu", async () => {
 	const ui = createMockUI(["Configure each role", ...INIT_ROLES.map(() => "Keep current"), "Save these changes"]);
 	const modelList = sampleModels;
 	await runInteractiveInit({
@@ -578,10 +598,11 @@ test("runInteractiveInit: empty currentRoles → 2-option action menu", async ()
 	// First select call should be the action menu
 	const firstSelect = ui.selectCalls[0];
 	assert.ok(firstSelect.title.includes("What do you want to do"));
-	// Should only have 2 options (no "Edit one role", "Show current roles", "Cancel")
-	assert.equal(firstSelect.options.length, 2);
+	// Should have 3 options (recommended defaults, configure each role, taskflow preferences)
+	assert.equal(firstSelect.options.length, 3);
 	assert.ok(firstSelect.options.includes("Use recommended defaults"));
 	assert.ok(firstSelect.options.includes("Configure each role"));
+	assert.ok(firstSelect.options.includes("Configure taskflow preferences"));
 });
 
 test("runInteractiveInit: 'Use recommended defaults' → saves RECOMMENDED_DEFAULTS", async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -843,3 +843,122 @@ test("formatFlowResult: saved includes the path", () => {
 	assert.match(text, /saved/i);
 	assert.match(text, /\/tmp\/settings\.json/);
 });
+
+// ===========================================================================
+// configureTaskflowPreferences (via runInteractiveInit)
+// ===========================================================================
+
+test("runInteractiveInit: 'Configure taskflow preferences' → disable built-ins → preferences-saved", async () => {
+	const ui = createMockUI([
+		"Configure taskflow preferences",       // action menu
+		"Disable built-in agents",               // built-in picker
+		"Save these preferences",                 // preview
+	]);
+
+	const result = await runInteractiveInit({
+		hasUI: true,
+		signal: new AbortController().signal,
+		ui,
+		modelRegistry: undefined as never,
+		modelList: sampleModels,
+		currentRoles: {},
+		currentTaskflowSettings: DEFAULT_TASKFLOW_SETTINGS,
+	});
+
+	assert.equal(result.kind, "preferences-saved");
+	assert.equal(result.settings.builtInAgents, false);
+	assert.equal(result.settings.syncBuiltinAgentsToProject, false);
+	assert.ok(result.savedPath.endsWith("settings.json"));
+
+	// Verify the settings were actually written to disk
+	const saved = readSettings();
+	assert.deepEqual(saved.taskflow, { builtInAgents: false, syncBuiltinAgentsToProject: false });
+});
+
+test("runInteractiveInit: 'Configure taskflow preferences' → enable + sync → preferences-saved", async () => {
+	const ui = createMockUI([
+		"Configure taskflow preferences",       // action menu
+		"Enable built-in agents",                // built-in picker
+		"Copy to project .pi/agents on session start", // sync picker
+		"Save these preferences",                 // preview
+	]);
+
+	const result = await runInteractiveInit({
+		hasUI: true,
+		signal: new AbortController().signal,
+		ui,
+		modelRegistry: undefined as never,
+		modelList: sampleModels,
+		currentRoles: {},
+		currentTaskflowSettings: DEFAULT_TASKFLOW_SETTINGS,
+	});
+
+	assert.equal(result.kind, "preferences-saved");
+	assert.equal(result.settings.builtInAgents, true);
+	assert.equal(result.settings.syncBuiltinAgentsToProject, true);
+});
+
+test("runInteractiveInit: 'Configure taskflow preferences' → no change → preferences-no-change", async () => {
+	const ui = createMockUI([
+		"Configure taskflow preferences",       // action menu
+		"Enable built-in agents (current)",      // built-in picker (same as default)
+		// sync picker shows because builtInAgents=true with defaults
+		"Do not copy to project .pi/agents (current)", // sync picker (same as default)
+	]);
+
+	const result = await runInteractiveInit({
+		hasUI: true,
+		signal: new AbortController().signal,
+		ui,
+		modelRegistry: undefined as never,
+		modelList: sampleModels,
+		currentRoles: {},
+		currentTaskflowSettings: DEFAULT_TASKFLOW_SETTINGS,
+	});
+
+	assert.equal(result.kind, "preferences-no-change");
+	assert.equal(result.settings.builtInAgents, true);
+	assert.equal(result.settings.syncBuiltinAgentsToProject, false);
+});
+
+test("runInteractiveInit: 'Configure taskflow preferences' → Back to action menu → cancelled", async () => {
+	const ui = createMockUI([
+		"Configure taskflow preferences",       // action menu
+		"Back to action menu",                   // built-in picker
+	]);
+
+	const result = await runInteractiveInit({
+		hasUI: true,
+		signal: new AbortController().signal,
+		ui,
+		modelRegistry: undefined as never,
+		modelList: sampleModels,
+		currentRoles: {},
+		currentTaskflowSettings: DEFAULT_TASKFLOW_SETTINGS,
+	});
+
+	assert.equal(result.kind, "cancelled");
+});
+
+test("runInteractiveInit: 'Configure taskflow preferences' → disable built-ins skips sync picker", async () => {
+	const ui = createMockUI([
+		"Configure taskflow preferences",       // action menu
+		"Disable built-in agents",               // built-in picker
+		"Save these preferences",                 // preview
+	]);
+
+	await runInteractiveInit({
+		hasUI: true,
+		signal: new AbortController().signal,
+		ui,
+		modelRegistry: undefined as never,
+		modelList: sampleModels,
+		currentRoles: {},
+		currentTaskflowSettings: DEFAULT_TASKFLOW_SETTINGS,
+	});
+
+	// Should only have 3 select calls: action menu, built-in picker, preview
+	// (no sync picker because built-in is disabled)
+	assert.equal(ui.selectCalls.length, 3);
+	assert.ok(!ui.selectCalls[1].title.includes("Sync"));
+});


### PR DESCRIPTION
## Problem

pi-taskflow automatically copies 18 built-in agent `.md` files into every project's `.pi/agents/` directory on every session start. This pollutes repositories and surprises users.

## Solution

Make this behavior configurable via `/tf init` interactive flow and `settings.json`.

### Settings shape

```json
{ "taskflow": { "builtInAgents": true, "syncBuiltinAgentsToProject": false } }
```

- `builtInAgents` (default: `true`) — enable/disable package built-in agents
- `syncBuiltinAgentsToProject` (default: `false`) — opt-in copy to `.pi/agents/`

### TUI

Added "Configure taskflow preferences" option to `/tf init` action menu with two picker steps:
1. Enable/disable built-in agents
2. Whether to sync built-ins to project `.pi/agents/`

## Changes

| File | Change |
|------|--------|
| `extensions/agents.ts` | `TaskflowSettings` type, `normalizeTaskflowSettings()`, `shouldLoadBuiltinAgents()`, `shouldSyncBuiltinAgentsToProject()`. `discoverAgents()` accepts settings. |
| `extensions/index.ts` | `session_start` gates `syncBuiltinAgentsToProject` on settings |
| `extensions/init.ts` | `formatTaskflowSettingsReport()`, preferences flow in `runInteractiveInit` |
| `test/agents.test.ts` | Settings parsing + built-in toggle tests |
| `test/init.test.ts` | TUI preferences flow tests |

## Testing

- **404 tests pass** (8 new)
- **Typecheck clean** (`tsc --noEmit`)
- Locally tested via symlink in `~/.pi/agent/npm/node_modules/pi-taskflow/`

## Backward compatibility

Default `builtInAgents: true` preserves existing behavior. Default `syncBuiltinAgentsToProject: false` is a behavior change — stops writing to `.pi/agents/` — but this is the exact fix users are requesting.
