### PR TITLE
test(core): script phase coverage + ship README with published packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 *.log
 .DS_Store
 
+# Generated at build time from the root README (single source of truth)
+packages/*/README.md
+
 # Runtime state (never commit)
 .pi/taskflows/
 .pi/teams/

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/copy-readme.mjs codex-taskflow",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -37,7 +37,7 @@
     "skills"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/copy-readme.mjs pi-taskflow",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -39,7 +39,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node ../../scripts/copy-agents.mjs",
+    "build": "tsc -p tsconfig.build.json && node ../../scripts/copy-agents.mjs && node ../../scripts/copy-readme.mjs taskflow-core",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/taskflow-core/test/compile.test.ts
+++ b/packages/taskflow-core/test/compile.test.ts
@@ -77,8 +77,9 @@ test("compile: each phase type gets its distinct Mermaid shape", () => {
 		{ id: "r", type: "reduce", from: ["m"], task: "merge" },
 		{ id: "ap", type: "approval", task: "ok?", dependsOn: ["g"] },
 		{ id: "lp", type: "loop", task: "iter", until: "{steps.lp.output} contains DONE" },
-		{ id: "tn", type: "tournament", task: "compete", variants: 3, final: true, dependsOn: ["r"] },
+		{ id: "tn", type: "tournament", task: "compete", variants: 3, dependsOn: ["r"] },
 		{ id: "fl", type: "flow", use: "sub", dependsOn: ["p"] },
+		{ id: "sc", type: "script", run: ["echo", "x"], final: true, dependsOn: ["tn"] },
 	];
 	const r = compileTaskflow(flow(phases));
 	assert.match(r.mermaid, /\bg\{"/, "gate → rhombus");
@@ -89,6 +90,7 @@ test("compile: each phase type gets its distinct Mermaid shape", () => {
 	assert.match(r.mermaid, /\blp\(\["/, "loop → stadium");
 	assert.match(r.mermaid, /\btn\{\{"/, "tournament → hexagon");
 	assert.match(r.mermaid, /\bfl\[\["/, "flow → subroutine");
+	assert.match(r.mermaid, /\bsc\[\("/, "script → cylinder");
 });
 
 test("compile: type tags appear in node bodies", () => {
@@ -98,6 +100,12 @@ test("compile: type tags appear in node bodies", () => {
 	]));
 	assert.match(r.mermaid, /map over/);
 	assert.match(r.mermaid, /tournament ×4/);
+});
+
+test("compile: script node shows the ⚡ tag and legend entry", () => {
+	const r = compileTaskflow(flow([{ id: "sc", type: "script", run: "echo hi", final: true }]));
+	assert.match(r.mermaid, /⚡ script/);
+	assert.match(r.markdown, /⚡ script/);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/taskflow-core/test/script.test.ts
+++ b/packages/taskflow-core/test/script.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import type { AgentConfig } from "../src/agents.ts";
+import type { RunOptions, RunResult } from "../src/runner-core.ts";
+import { executeTaskflow, type RuntimeDeps } from "../src/runtime.ts";
+import { type Taskflow, validateTaskflow } from "../src/schema.ts";
+import type { RunState } from "../src/store.ts";
+import { emptyUsage } from "../src/usage.ts";
+
+// The script phase shells out, so tests invoke `node -e` (guaranteed on PATH in
+// CI) rather than assuming any particular unix utility. String-form `run` uses
+// the shell; array-form is a direct execvp-style spawn (no shell, injection-safe).
+
+const AGENTS: AgentConfig[] = [
+	{ name: "a", description: "test agent", systemPrompt: "", source: "user", filePath: "" },
+];
+
+function mkState(def: Taskflow, args: Record<string, unknown> = {}): RunState {
+	return {
+		runId: "test-run",
+		flowName: def.name,
+		def,
+		args,
+		status: "running",
+		phases: {},
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		cwd: process.cwd(),
+	};
+}
+
+/** A runner that must never fire — script phases spend zero tokens and never
+ *  touch the agent runner. If a test trips this, the phase was misrouted. */
+const agentRunnerMustNotRun: RuntimeDeps["runTask"] = async () => {
+	throw new Error("agent runner should not be called for a script phase");
+};
+
+function baseDeps(runTask: RuntimeDeps["runTask"] = agentRunnerMustNotRun, signal?: AbortSignal): RuntimeDeps {
+	return { cwd: process.cwd(), agents: AGENTS, runTask, persist: () => {}, onProgress: () => {}, signal };
+}
+
+/** An agent runner returning canned output — used by the agent→script chain. */
+function cannedRunner(output: string): RuntimeDeps["runTask"] {
+	return async (_cwd, _agents, agentName, task, _o: RunOptions): Promise<RunResult> => ({
+		agent: agentName,
+		task,
+		exitCode: 0,
+		output,
+		stderr: "",
+		usage: { ...emptyUsage(), output: 10, cost: 0.001, turns: 1 },
+		stopReason: "end",
+	});
+}
+
+// ---------------------------------------------------------------------------
+// validation
+// ---------------------------------------------------------------------------
+
+test("script validate: requires 'run'", () => {
+	const r = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", final: true }] });
+	assert.equal(r.ok, false);
+	assert.match(r.errors.join("\n"), /Phase 'a' \(script\) requires 'run'/);
+});
+
+test("script validate: array 'run' must be non-empty with a valid first element", () => {
+	const empty = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: [], final: true }] });
+	assert.equal(empty.ok, false);
+	assert.match(empty.errors.join("\n"), /array must be non-empty/);
+
+	const blankHead = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: ["", "x"], final: true }] });
+	assert.equal(blankHead.ok, false);
+	assert.match(blankHead.errors.join("\n"), /array must be non-empty/);
+});
+
+test("script validate: string 'run' with an interpolation placeholder is rejected (injection guard)", () => {
+	for (const run of ["echo {steps.gen.output}", "echo {args.name}", "cat {steps.a.b.c}"]) {
+		const r = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run, final: true }] });
+		assert.equal(r.ok, false, `expected rejection for ${JSON.stringify(run)}`);
+		assert.match(r.errors.join("\n"), /must not contain interpolation placeholders/);
+	}
+});
+
+test("script validate: array 'run' with placeholders is allowed (safe by argv isolation)", () => {
+	const r = validateTaskflow({
+		name: "s",
+		phases: [
+			{ id: "gen", type: "agent", agent: "a", task: "draft" },
+			{ id: "a", type: "script", run: ["echo", "{steps.gen.output}"], dependsOn: ["gen"], final: true },
+		],
+	});
+	assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+test("script validate: plain string 'run' without placeholders is allowed", () => {
+	const r = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: "echo hi && ls", final: true }] });
+	assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+test("script validate: retry, output:json, and out-of-range timeout are rejected", () => {
+	const retry = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: "echo x", retry: { max: 2 }, final: true }] });
+	assert.match(retry.errors.join("\n"), /'retry' is not supported for script phases/);
+
+	const json = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: "echo x", output: "json", final: true }] });
+	assert.match(json.errors.join("\n"), /'output:"json"' is not supported/);
+
+	for (const timeout of [999, 300001, "5s"]) {
+		const r = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: "echo x", timeout, final: true }] });
+		assert.equal(r.ok, false, `timeout ${timeout} should be rejected`);
+		assert.match(r.errors.join("\n"), /'timeout' must be a number between 1000 and 300000/);
+	}
+
+	const ok = validateTaskflow({ name: "s", phases: [{ id: "a", type: "script", run: "echo x", timeout: 5000, final: true }] });
+	assert.equal(ok.ok, true, ok.errors.join("; "));
+});
+
+test("script validate: run/input/timeout are rejected on non-script phases", () => {
+	const run = validateTaskflow({ name: "s", phases: [{ id: "a", type: "agent", agent: "a", task: "t", run: "echo x", final: true }] });
+	assert.match(run.errors.join("\n"), /'run' is only valid for script phases/);
+
+	const input = validateTaskflow({ name: "s", phases: [{ id: "a", type: "agent", agent: "a", task: "t", input: "hi", final: true }] });
+	assert.match(input.errors.join("\n"), /'input' is only valid for script phases/);
+
+	const timeout = validateTaskflow({ name: "s", phases: [{ id: "a", type: "agent", agent: "a", task: "t", timeout: 5000, final: true }] });
+	assert.match(timeout.errors.join("\n"), /'timeout' is only valid for script phases/);
+});
+
+// ---------------------------------------------------------------------------
+// runtime — happy paths
+// ---------------------------------------------------------------------------
+
+test("script run: string form captures stdout (trimmed) with zero token usage", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: "echo hello world", final: true }],
+	};
+	const res = await executeTaskflow(mkState(def), baseDeps());
+	assert.equal(res.ok, true);
+	assert.equal(res.state.phases.a.status, "done");
+	assert.equal(res.finalOutput, "hello world");
+	assert.equal(res.state.phases.a.usage?.output ?? 0, 0);
+	assert.equal(res.totalUsage.output ?? 0, 0);
+});
+
+test("script run: array form spawns directly (no shell)", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", "process.stdout.write('arr-ok')"], final: true }],
+	};
+	const res = await executeTaskflow(mkState(def), baseDeps());
+	assert.equal(res.ok, true);
+	assert.equal(res.finalOutput, "arr-ok");
+});
+
+test("script run: 'input' is piped to stdin with interpolation", async () => {
+	const echoStdin = "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write('in['+d+']'))";
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", echoStdin], input: "payload-{args.n}", final: true }],
+	};
+	const res = await executeTaskflow(mkState(def, { n: "7" }), baseDeps());
+	assert.equal(res.ok, true);
+	assert.equal(res.finalOutput, "in[payload-7]");
+});
+
+test("script run: array element interpolation resolves upstream refs", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", "process.stdout.write('n='+process.argv[1])", "{args.n}"], final: true }],
+	};
+	const res = await executeTaskflow(mkState(def, { n: "42" }), baseDeps());
+	assert.equal(res.ok, true);
+	assert.equal(res.finalOutput, "n=42");
+});
+
+// ---------------------------------------------------------------------------
+// integration with other phases
+// ---------------------------------------------------------------------------
+
+test("script integration: agent output flows into a script via stdin", async () => {
+	const echoStdin = "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write('SAVED:'+d))";
+	const def: Taskflow = {
+		name: "s",
+		phases: [
+			{ id: "gen", type: "agent", agent: "a", task: "draft" },
+			{ id: "save", type: "script", run: ["node", "-e", echoStdin], input: "{steps.gen.output}", dependsOn: ["gen"], final: true },
+		],
+	};
+	const res = await executeTaskflow(mkState(def), baseDeps(cannedRunner("DRAFT_TEXT")));
+	assert.equal(res.ok, true);
+	assert.equal(res.finalOutput, "SAVED:DRAFT_TEXT");
+});
+
+test("script integration: skipped by an unmet 'when' condition", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: "echo should-not-run", when: "{args.go} == 'yes'", final: true }],
+	};
+	const res = await executeTaskflow(mkState(def, { go: "no" }), baseDeps());
+	assert.equal(res.state.phases.a.status, "skipped");
+});
+
+// ---------------------------------------------------------------------------
+// security — injection isolation at runtime
+// ---------------------------------------------------------------------------
+
+test("script security: array form isolates shell metacharacters in interpolated args", async () => {
+	// A malicious upstream value flows into an array-form argv. execvp passes it
+	// as a single argument, so the embedded `; touch <marker>` is never parsed by
+	// a shell. We prove isolation via a side effect: the marker must NOT appear.
+	const marker = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-")), "pwned");
+	const printArg = "process.stdout.write('arg=['+process.argv[1]+']')";
+	const evil = `; touch ${marker} #`;
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", printArg, "{args.evil}"], final: true }],
+	};
+	const res = await executeTaskflow(mkState(def, { evil }), baseDeps());
+	assert.equal(res.ok, true);
+	// The whole payload arrives verbatim as one argv element...
+	assert.equal(res.finalOutput, `arg=[${evil}]`);
+	// ...and the injected `touch` never ran — no shell interpreted the `;`.
+	assert.equal(fs.existsSync(marker), false, "injected command executed — argv isolation broken");
+});
+
+// ---------------------------------------------------------------------------
+// robustness — failures, limits, timeout
+// ---------------------------------------------------------------------------
+
+test("script robustness: non-zero exit fails the phase and captures stderr", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", "process.stderr.write('boom');process.exit(3)"], final: true }],
+	};
+	const res = await executeTaskflow(mkState(def), baseDeps());
+	assert.equal(res.ok, false);
+	assert.equal(res.state.phases.a.status, "failed");
+	assert.match(res.state.phases.a.error ?? "", /exited with code 3/);
+	assert.match(res.state.phases.a.error ?? "", /boom/);
+});
+
+test("script robustness: a missing binary fails the phase (spawn error)", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["this-binary-does-not-exist-xyz-42"], final: true }],
+	};
+	const res = await executeTaskflow(mkState(def), baseDeps());
+	assert.equal(res.ok, false);
+	assert.equal(res.state.phases.a.status, "failed");
+	assert.match(res.state.phases.a.error ?? "", /Script error/);
+});
+
+test("script robustness: stdout is capped at 1 MB with a truncation marker", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", "process.stdout.write('x'.repeat(3*1024*1024))"], final: true }],
+	};
+	const res = await executeTaskflow(mkState(def), baseDeps());
+	assert.equal(res.ok, true);
+	assert.ok(res.finalOutput.length <= 1_048_576 + 64, `output length ${res.finalOutput.length} exceeds cap`);
+	assert.match(res.finalOutput, /\[stdout truncated at 1 MB\]/);
+});
+
+test("script robustness: a runaway process is killed at the timeout", async () => {
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", "setInterval(()=>{},1e9)"], timeout: 1000, final: true }],
+	};
+	const t0 = Date.now();
+	const res = await executeTaskflow(mkState(def), baseDeps());
+	const elapsed = Date.now() - t0;
+	assert.equal(res.ok, false);
+	assert.equal(res.state.phases.a.status, "failed");
+	assert.match(res.state.phases.a.error ?? "", /timed out after 1000ms/);
+	assert.ok(elapsed < 5000, `timeout took too long: ${elapsed}ms`);
+});
+
+// ---------------------------------------------------------------------------
+// cancellation
+// ---------------------------------------------------------------------------
+
+test("script cancellation: an abort mid-run fails the phase without waiting for it", async () => {
+	const ac = new AbortController();
+	const def: Taskflow = {
+		name: "s",
+		phases: [{ id: "a", type: "script", run: ["node", "-e", "setTimeout(()=>process.stdout.write('done'),4000)"], final: true }],
+	};
+	const p = executeTaskflow(mkState(def), baseDeps(agentRunnerMustNotRun, ac.signal));
+	setTimeout(() => ac.abort(), 150);
+	const t0 = Date.now();
+	const res = await p;
+	const elapsed = Date.now() - t0;
+	assert.equal(res.ok, false);
+	assert.ok(elapsed < 3000, `abort did not interrupt the child promptly: ${elapsed}ms`);
+});

--- a/scripts/copy-readme.mjs
+++ b/scripts/copy-readme.mjs
@@ -1,0 +1,70 @@
+// Copy the repo-root README into each publishable package so npm shows it on
+// the package page. The root README is the single source of truth; these copies
+// are generated at build time and git-ignored (like dist/). npm automatically
+// includes a package-root README.md in the tarball, so no `files` entry needed.
+//
+// The root README uses root-relative paths (./assets/hero.png, ./LICENSE, doc
+// links). npm resolves relative paths against each package's
+// repository.directory (packages/<pkg>), so they would 404 on the npm page.
+// We rewrite root-relative links to absolute GitHub URLs: image/raw files to
+// raw.githubusercontent.com, everything else to github.com/.../blob/<branch>.
+// Anchor (#...) and absolute (http...) links are left untouched.
+//
+// Usage:
+//   node scripts/copy-readme.mjs                 → copy into all publishable packages
+//   node scripts/copy-readme.mjs pi-taskflow     → copy into one package (used per-package build)
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+
+// Packages that are published to npm and should carry the README.
+const PUBLISHABLE = new Set(["taskflow-core", "pi-taskflow", "codex-taskflow"]);
+
+const REPO = "heggria/taskflow";
+const BRANCH = "main";
+const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
+const BLOB_BASE = `https://github.com/${REPO}/blob/${BRANCH}`;
+
+// Paths that point at binary/raw assets render inline; everything else is a
+// browsable file/dir and should open on github.com.
+const RAW_EXT = /\.(png|jpe?g|gif|svg|webp)$/i;
+
+/** Turn a root-relative target ("./assets/x.png", "examples") into an absolute URL. */
+function absolutize(target) {
+	const clean = target.replace(/^\.\//, "").replace(/^\//, "");
+	return (RAW_EXT.test(clean) ? RAW_BASE : BLOB_BASE) + "/" + clean;
+}
+
+function rewrite(md) {
+	// HTML attributes: src="./..." / href="./..."
+	md = md.replace(/(\b(?:src|href)=")(\.\/[^"]+)"/g, (_m, pre, target) => `${pre}${absolutize(target)}"`);
+	// Markdown links/images: ](./...) or ](examples) — skip anchors (#) and absolute (http).
+	md = md.replace(/\]\((\.\/?[^)#][^)]*)\)/g, (_m, target) => `](${absolutize(target)})`);
+	return md;
+}
+
+const rootReadme = join(repoRoot, "README.md");
+let content;
+try {
+	content = readFileSync(rootReadme, "utf8");
+} catch {
+	console.error(`[copy-readme] root README not found: ${rootReadme}`);
+	process.exit(1);
+}
+const rewritten = rewrite(content);
+
+const arg = process.argv[2];
+if (arg && !PUBLISHABLE.has(arg)) {
+	console.error(`[copy-readme] unknown package '${arg}' (expected one of: ${[...PUBLISHABLE].join(", ")})`);
+	process.exit(1);
+}
+const targets = arg ? [arg] : [...PUBLISHABLE];
+
+for (const pkg of targets) {
+	const dest = join(repoRoot, "packages", pkg, "README.md");
+	writeFileSync(dest, rewritten);
+	console.log(`[copy-readme] README.md → packages/${pkg}/`);
+}


### PR DESCRIPTION
## What

Two independent maintenance items for the `script` phase merged in #4:

### 1. `test(core)`: cover the script phase (`bbf1f0b`)
Adds `packages/taskflow-core/test/script.test.ts` (19 cases) — #4 shipped the feature with **zero tests**. Covers:
- **validation**: required `run`, non-empty array, string-`run` injection guard (placeholders rejected), array-`run` allowed, `retry`/`output:json`/timeout-range rejection, `run`/`input`/`timeout` rejected on non-script phases
- **execution**: string form, array form, stdin `input` with interpolation, array-element interpolation, zero token usage
- **integration**: agent output piped into a script via stdin, `when`-condition skip
- **security**: array-form argv isolation proven via a side effect (an injected `; touch <marker>` never runs)
- **robustness**: non-zero exit + stderr capture, missing binary, 1 MB stdout cap, timeout kill
- **cancellation**: mid-run abort interrupts the child

Also extends `compile.test.ts` to assert the `script` node shape (cylinder) + the `⚡` tag/legend.

### 2. `build`: ship the README with each package (`97fe9b1`)
The rebrand left all three publishable packages without a README, so their npm pages show *"This package does not have a README."* Adds `scripts/copy-readme.mjs` (run at build / prepublish) that copies the root README into each package, rewriting root-relative links to absolute GitHub URLs so they resolve on npm. Generated `packages/*/README.md` are git-ignored. Verified via `npm pack --dry-run`.

## Verify
`npm run typecheck` clean; full core suite green (this branch: 917 tests). No runtime behavior change.

## Related
Pairs with the docs+security PR (branch `docs/script-phase-pr`) — together they bring the test count to **918 / 52 files**, which that PR's doc badges reflect. Merge this one first (or both together).
