### PR TITLE
chore(release): 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-07-02
+
+### Security
+- **Dynamic sub-flows can no longer smuggle `script` phases (RCE guard).**
+  `validateTaskflow` rejects `script` phases in LLM-authored dynamic flow
+  definitions (`flow` phases with an inline definition produced at runtime),
+  closing the path where a subagent's output could inject arbitrary shell
+  commands into the host.
+- **Dependency audit clean.** `npm audit fix` bumps transitive `protobufjs`
+  to 7.6.4 (GHSA schema-derived name shadowing, moderate) — 0 open alerts.
+
 ### Fixed (adversarial review of the features below)
 - **Peek `--item` now keys by positional label, not section order.** A
   budget-skipped map item has no section in the merged output, so section-order
@@ -63,6 +74,15 @@ All notable changes to taskflow are documented here. This project follows [Keep 
   absent from X's declared contract — catching ref typos before a single
   token is spent. Zero new dependencies (hand-rolled total validator in
   `taskflow-core/src/contract.ts`).
+- **Script phase test coverage** — validation, execution, security, and
+  robustness suites for the `script` phase type (952 tests total).
+
+### Changed
+- **Each published package now ships its README** (`scripts/copy-readme.mjs`),
+  fixing the empty npm package pages.
+- **Docs sync:** README/README.zh-CN/AGENTS/CONTRIBUTING/SECURITY refreshed for
+  the script phase, brand/version drift fixed; CI actions bumped
+  (checkout v7, setup-node v6) and dev-dependencies updated.
 
 ## [0.1.3] — 2026-07-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-taskflow-monorepo",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-taskflow-monorepo",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "workspaces": [
         "packages/taskflow-core",
         "packages/pi-taskflow",
@@ -993,7 +993,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1109,9 +1109,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1127,9 +1124,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1147,9 +1141,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1166,9 +1157,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,9 +1172,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2433,10 +2418,6 @@
       "version": "1.0.2",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "license": "BSD-3-Clause"
@@ -2928,7 +2909,9 @@
       "link": true
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2938,7 +2921,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -3089,10 +3071,10 @@
       }
     },
     "packages/codex-taskflow": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "taskflow-core": "0.1.3"
+        "taskflow-core": "0.1.4"
       },
       "bin": {
         "codex-taskflow-mcp": "dist/mcp/bin.js"
@@ -3102,10 +3084,10 @@
       }
     },
     "packages/pi-taskflow": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "taskflow-core": "0.1.3"
+        "taskflow-core": "0.1.4"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3119,7 +3101,7 @@
       }
     },
     "packages/taskflow-core": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow-monorepo",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Monorepo for taskflow-core, pi-taskflow, and codex-taskflow.",
   "type": "module",

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskflow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Run taskflow on OpenAI Codex: a Codex subagent runner plus an MCP server (and a plug-and-play Codex plugin) that exposes the taskflow_* tools to Codex users.",
   "keywords": [
     "codex",
@@ -42,6 +42,6 @@
     "access": "public"
   },
   "dependencies": {
-    "taskflow-core": "0.1.3"
+    "taskflow-core": "0.1.4"
   }
 }

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
   "keywords": [
     "pi-package",
@@ -53,7 +53,7 @@
     "image": "https://raw.githubusercontent.com/heggria/taskflow/main/assets/social-preview.png"
   },
   "dependencies": {
-    "taskflow-core": "0.1.3"
+    "taskflow-core": "0.1.4"
   },
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow and codex-taskflow.",
   "keywords": [
     "taskflow",


### PR DESCRIPTION
## Release 0.1.4

- Bump all three packages (`taskflow-core`, `pi-taskflow`, `codex-taskflow`) to 0.1.4 in lockstep; adapters pin `taskflow-core@0.1.4`.
- Stamp CHANGELOG `[0.1.4]` covering #9 (script phase test coverage + README in published packages), #10 (script phase docs + dynamic-flow RCE guard), #11 (peek, per-phase timeout, output schema contracts).
- `npm audit fix`: transitive `protobufjs` → 7.6.4 (closes dependabot alert #2, 0 open alerts).
- Fixed stale script-phase test after #9 × #11 semantic conflict (`timeout` now valid on agent phases).

Pre-flight: typecheck ✅ · 952/952 tests ✅ · build ✅
