### PR TITLE
chore(release): bump codex plugin manifest to 0.1.4

### DIFF
--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.1.3", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.1.4", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }


### PR DESCRIPTION
Fixes the v0.1.4 publish failure: plugin.json + .mcp.json still said 0.1.3 (they are not covered by npm version --workspaces). After merge, the v0.1.4 tag will be moved to the new main head and re-pushed.