### PR TITLE
feat(skills): single-source skill compilation for pi + codex hosts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ packages/
 │  │  ├─ render.ts / runs-view.ts / approval-view.ts  ← pi-tui rendering + interactive views
 │  │  └─ init.ts           ← /tf init command: scaffolds a taskflow / model roles interactively
 │  ├─ test/              ← pi-adapter unit tests + .mts e2e scripts
-│  └─ skills/            ← SKILL.md files that teach the LLM how to write taskflows
+│  └─ skills/            ← GENERATED per-host skill files (do not edit; see skills-src/)
 └─ codex-taskflow/         ← Codex adapter (depends on taskflow-core)
    ├─ src/
    │  ├─ codex-runner.ts   ← codex subagent runner (`codex exec --json`) + CodexSubagentRunner
@@ -52,13 +52,18 @@ packages/
    ├─ plugin/            ← Codex plugin scaffold (`codex plugin add taskflow@taskflow`)
    │  ├─ .codex-plugin/plugin.json  ← plugin manifest (skills + mcpServers pointers)
    │  ├─ .mcp.json         ← declares the taskflow MCP server via `npx codex-taskflow`
-   │  ├─ skills/taskflow/  ← SKILL.md (trigger) + agents/openai.yaml (Codex interface)
+   │  ├─ skills/taskflow/  ← GENERATED per-host skill files (do not edit; see skills-src/)
    │  └─ assets/           ← plugin icons (taskflow.svg, taskflow-small.svg)
    └─ test/              ← codex-adapter unit tests + .mts e2e scripts
 
 .claude-plugin/           ← marketplace.json (repo-root; `codex plugin marketplace add heggria/taskflow`)
 
-scripts/                  ← build helpers (copy-agents.mjs copies agent .md into dist)
+skills-src/taskflow/      ← SINGLE SOURCE for both hosts' skills: entry.pi.md + entry.codex.md
+                            (frontmatter + host binding) + core.md/patterns.md/advanced.md/
+                            configuration.md (shared body with <!-- host:pi/codex --> blocks).
+                            Compiled by scripts/build-skills.mjs (npm run build:skills);
+                            drift-guarded by packages/pi-taskflow/test/skills-build.test.ts.
+scripts/                  ← build helpers (copy-agents.mjs, build-skills.mjs)
 examples/                 ← runnable flow definitions (.json)
 docs/                     ← design docs, RFCs, dogfooding reports, codex-mcp guide
 tsconfig.base.json        ← shared compiler options; per-package tsconfig.build.json emits dist
@@ -174,7 +179,7 @@ npm run test:e2e-codex-mcp-full  # codex MCP comprehensive e2e against the built
 2. Add per-type validation in `validateTaskflow()`.
 3. Add the execution branch in `executePhase()` in `runtime.ts`.
 4. Add tests in `packages/taskflow-core/test/runtime-branches.test.ts` (or a new file).
-5. Update `SKILL.md` with usage guidance.
+5. Update the skill sources in `skills-src/taskflow/` (never the generated files) and run `node scripts/build-skills.mjs`.
 
 ### Adding a New Condition Operator
 1. Add the token to `OPS` in `interpolate.ts`.
@@ -192,7 +197,7 @@ npm run test:e2e-codex-mcp-full  # codex MCP comprehensive e2e against the built
 2. Update `validateTaskflow()` if new constraints are needed.
 3. Update `desugar()` if the shorthand needs to emit the new field.
 4. Update `interpolate.ts` if new placeholder paths are introduced.
-5. Update `SKILL.md` and `README.md`.
+5. Update the skill sources in `skills-src/taskflow/` and `README.md`, then run `node scripts/build-skills.mjs`.
 
 > All of `schema.ts`, `runtime.ts`, `interpolate.ts`, `cache.ts`, `agents.ts` live in `packages/taskflow-core/src/`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,28 @@ npm test               # 918/918 green
 npm run build          # emit dist/ for all three packages (tsc → .js + .d.ts)
 ```
 
+### Skill coverage check (before every release)
+
+The skills are the LLM-facing API surface — an engine feature the skill doesn't
+teach effectively does not exist. **Skills are authored ONCE in
+`skills-src/taskflow/` and compiled per host** by `scripts/build-skills.mjs`
+(pi → `packages/pi-taskflow/skills/taskflow/`, codex →
+`packages/codex-taskflow/plugin/skills/taskflow/`). Never edit the generated
+files — `skills-build.test.ts` fails CI on drift. For every feature/change in
+this release's CHANGELOG section, verify:
+
+- [ ] New DSL fields, phase types, actions, and commands appear in the right
+      **source** layer: `core.md` (core DSL + actions), `patterns.md` (if it
+      changes best practice), `advanced.md` (context sharing / dynamic flows /
+      isolation / recompute), `configuration.md` (knobs), or the per-host
+      entry files (`entry.pi.md` / `entry.codex.md`) for host bindings.
+- [ ] Host-only capabilities are wrapped in `<!-- host:pi -->` /
+      `<!-- host:codex -->` blocks — never teach a host a tool it can't reach.
+- [ ] `node scripts/build-skills.mjs` ran and the generated files are committed.
+- [ ] The `taskflow` tool description in the pi adapter (`src/index.ts`) lists
+      any new `action` values.
+- [ ] Removed/renamed fields are purged from `skills-src/` (grep the old name).
+
 > **Why a build step.** Node refuses to type-strip `.ts` files under
 > `node_modules`, so the published packages ship compiled `dist/*.js` + `.d.ts`.
 > `prepublishOnly` runs `npm run build` automatically, so `npm publish` always

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "packages/codex-taskflow"
   ],
   "scripts": {
-    "build": "npm run build -w taskflow-core && npm run build -w pi-taskflow && npm run build -w codex-taskflow",
+    "build": "npm run build:skills && npm run build -w taskflow-core && npm run build -w pi-taskflow && npm run build -w codex-taskflow",
+    "build:skills": "node scripts/build-skills.mjs",
     "typecheck": "tsc --noEmit",
     "test": "PI_TASKFLOW_BUILTIN_AGENTS_DIR= node --conditions=development --experimental-strip-types --test 'packages/*/test/*.test.ts'",
     "test:core": "PI_TASKFLOW_BUILTIN_AGENTS_DIR= node --conditions=development --experimental-strip-types --test 'packages/taskflow-core/test/*.test.ts'",

--- a/packages/codex-taskflow/plugin/skills/taskflow/advanced.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/advanced.md
@@ -1,0 +1,86 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/advanced.md (npm run build:skills) -->
+
+# Taskflow Advanced — dynamic sub-flows & workspace isolation
+
+Load this when a flow needs: runtime-generated work (`flow{def}`) or isolated
+working directories (`cwd: temp/dedicated/worktree`).
+
+---
+
+## Dynamic sub-flows (`flow{def}`) — the full contract
+
+A `flow` phase with `def` resolves a sub-flow **at runtime**, usually from an
+upstream phase's JSON output. The runtime interpolates + JSON-parses the `def`,
+validates it, then runs it nested. This is how a planner decides at runtime
+what work to spawn — with each generated plan checked before it spends a token.
+
+```jsonc
+{ "id": "plan", "type": "agent", "agent": "planner", "output": "json",
+  "task": "Scan the repo. Output ONLY JSON {\"name\":\"audit\",\"phases\":[...]} — one audit phase per file." },
+{ "id": "run", "type": "flow", "def": "{steps.plan.json}", "optional": true,
+  "dependsOn": ["plan"], "final": true }
+```
+
+**LLM output contract for `def`** (put this in the planner's task):
+- A *full* Taskflow `{"name":"...","phases":[...]}`, a bare `phases` array, or
+  `{"phases":[...]}` — pure JSON (a ```json fence is tolerated and stripped).
+- Hyphens in ids, never underscores.
+- Sub-flow phases reference each other in their **own** `{steps.x.output}`
+  namespace (no parent-id prefixing).
+- An **empty** `phases` array is a valid no-op (the planner decided there's
+  nothing to do).
+
+**Security caps on generated flows** (validation rejects; tell the planner not
+to emit these so a retry isn't wasted):
+- **No `script` phases** — shell execution from an LLM-authored plan is an RCE
+  vector; only author-written flows may use `script`.
+- **No workspace `cwd` keywords** (`temp`/`dedicated`/`worktree`) and no `cwd`
+  escaping the run directory.
+- Breadth caps: ≤100 phases, concurrency ≤16 (flow and per-phase).
+- Depth: inline nesting capped at 5 (shared with `ctx_spawn` subflows).
+
+**Fail-open semantics:** if the `def` doesn't parse, has the wrong shape, or
+fails validation, the phase completes with `status: "done"` and a `defError`
+diagnostic field; downstream phases receive empty output and the run continues.
+Design for it:
+- Add `optional: true` on the flow phase so a bad plan never aborts the run.
+- Want a hard stop instead? Add a downstream gate:
+  `{ "type": "gate", "eval": ["{steps.run.output} != "], "task": "…VERDICT: BLOCK if the plan failed." }`
+
+**Iterative replanning** — pair `flow{def}` with a `loop` whose body emits the
+next plan from the previous round's result: the declarative equivalent of
+`for (...) { read result; decide next }`. See `examples/dynamic-plan-execute.json`
+and `examples/iterative-replan.json`.
+
+---
+
+## Workspace isolation (`cwd` keywords)
+
+A phase's `cwd` is normally a literal path (or inherited from the run). Three
+**reserved keywords** ask the runtime to allocate an isolated working directory
+for the phase's subagent and tear it down afterwards — scratch work or file
+mutation without touching the main tree:
+
+| `cwd` value | what the runtime does | lifecycle |
+|-------------|-----------------------|-----------|
+| `"temp"` | ephemeral dir under the OS tmpdir | removed when the phase finishes |
+| `"dedicated"` | persistent dir under the run state (`runs/ws/<runId>/<phaseId>`) | **kept** for inspection; deterministic per phase (resume reuses it) |
+| `"worktree"` | `git worktree add` on a throwaway branch off `HEAD` | `git worktree remove` + branch delete when the phase finishes |
+
+```jsonc
+{ "id": "experiment", "type": "agent", "agent": "executor", "cwd": "worktree",
+  "task": "Try the risky refactor and run the tests. Your edits are isolated in a git worktree." }
+```
+
+- **Fail-open.** If allocation fails (e.g. `worktree` outside a git tree), the
+  phase degrades — `worktree`→`temp`, any other failure → the base cwd — with a
+  `warnings` diagnostic. A phase never fails to run because of isolation.
+- **Security.** Keywords are honoured only in **author-written** flows; a
+  generated plan (`flow{def}` / `ctx_spawn` subflow) requesting one is rejected
+  at validation.
+- A literal path passes through unchanged.
+
+**Pattern — competing experiments in worktrees:** run two `parallel` branches,
+each `cwd: "worktree"`, each attempting a different refactor strategy and
+reporting its test results; a downstream gate/judge picks which diff to apply
+for real. The main tree is never touched by the losers.

--- a/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
@@ -169,13 +169,7 @@ still reach `{args.X}`).
 
 **Passing args:**
 
-```
-/tf run audit-endpoints {"dir":"packages/api"}     # JSON
-/tf run audit-endpoints dir=packages/api depth=3   # key=value pairs
-/tf run audit-endpoints packages/api               # single positional → first declared arg
-```
-
-Via the tool: `{ "action": "run", "name": "audit-endpoints", "args": { "dir": "packages/api" } }`.
+Via the MCP tool: `taskflow_run` with `{ "name": "audit-endpoints", "args": { "dir": "packages/api" } }`.
 
 ---
 
@@ -218,8 +212,9 @@ For any phase, the effective value is resolved in this **precedence order**
 
 Notes:
 - `tools` is a **whitelist**. Omit it to allow all.
-- Each phase runs as an isolated process:
-  `pi --mode json -p --no-session [--model …] [--thinking …] [--tools …] [--append-system-prompt <agent>] "Task: …"`.
+- Each phase runs as an isolated `codex exec --json` session. A model id that
+  still looks like a pi-provider path (contains `/`) or an unresolved
+  `{{placeholder}}` is dropped so codex falls back to its configured default.
 - The agent's markdown body becomes the subagent's appended system prompt.
 
 ---
@@ -370,8 +365,6 @@ Each entry is one of:
 | Run state (resume) | `<project .pi>/taskflows/runs/<flowName>/<runId>.json` | ❌ gitignore |
 
 - `action: "save"` takes `scope: "project"` (default) or `"user"`.
-- Saved flows auto-register as `/tf:<name>` (immediately for the current session,
-  and on future `session_start`).
 - Project flows override user flows on a name collision.
 - Add `.pi/taskflows/runs/` to `.gitignore`.
 

--- a/packages/codex-taskflow/plugin/skills/taskflow/patterns.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/patterns.md
@@ -1,0 +1,289 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/patterns.md (npm run build:skills) -->
+
+# Taskflow Patterns — proven archetypes & the production checklist
+
+Read this when designing a flow with ≥ 4 phases, a gate, or any fan-out.
+Each archetype below is a complete, runnable shape distilled from real runs.
+Copy the closest one and adapt — don't design from a blank page.
+
+---
+
+## The production-flow checklist
+
+Before running a flow you designed, check it against this list. Every item is
+cheap to add and each one has prevented a real failure class:
+
+- [ ] **`verify` first.** Run the static verifier (pi: `action: "verify"` /
+      Codex: `taskflow_verify`) — zero tokens,
+      catches cycles / missing deps / ref typos / contract mismatches.
+- [ ] **Every JSON-emitting phase has `expect` + `retry`.** "Output ONLY JSON"
+      in the task text is a request; `expect` is enforcement. Without it, a
+      malformed router output silently skips both branches.
+- [ ] **Machine checks before LLM checks.** `script` phases for build/test
+      ground truth; gate `eval` assertions before the gate's LLM `task`. A
+      token spent verifying what a shell command can verify is a wasted token.
+- [ ] **`budget` on any flow with a fan-out.** A map over a mis-discovered
+      500-item array is unbounded spend without one.
+- [ ] **`optional: true` + a fallback for degradable phases.** An enrichment
+      phase that times out shouldn't sink the run — pair `timeout` +
+      `optional` with a downstream `when`-guarded fallback.
+- [ ] **Exactly one `final: true`** on the result-bearing phase.
+- [ ] **`strictInterpolation: true` on any flow you save.** Saved flows run
+      later with args you're not watching; unresolved placeholders must be
+      errors, not empty strings.
+- [ ] **Discovery phases are cheap and sandboxed.** `agent: "scout"`,
+      `tools: ["read","grep","ls"]`, low thinking. Don't pay executor prices
+      for `ls`.
+- [ ] **The reviewer is not the producer.** A gate reviewing phase X uses a
+      different agent (ideally a different model) than X. Self-review passes
+      ~everything.
+- [ ] **Re-runnable flows are `incremental: true`** with `fingerprint` entries
+      on phases that read the world (`git:HEAD`, `glob!:src/**/*.ts`). See
+      `advanced.md`.
+
+---
+
+## Archetype 1: Audit fan-out (discover → map → gate → reduce)
+
+The workhorse. Use for: audit every endpoint / migrate every file /
+summarize every module.
+
+```jsonc
+{
+  "name": "audit-endpoints",
+  "strictInterpolation": true,
+  "budget": { "maxUSD": 3.00 },
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout",
+      "tools": ["read", "grep", "ls"],
+      "task": "List every HTTP endpoint under src/routes. Output ONLY a JSON array [{\"route\":\"...\",\"file\":\"...\"}]. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object", "required": ["route", "file"] } },
+      "retry": { "max": 2, "backoffMs": 0 } },
+
+    { "id": "audit", "type": "map", "over": "{steps.discover.json}", "as": "item",
+      "agent": "analyst", "concurrency": 4,
+      "task": "Audit {item.route} in {item.file} for missing auth. Report: SEVERITY (high/med/low/none), evidence (file:line), fix.",
+      "dependsOn": ["discover"] },
+
+    { "id": "screen", "type": "gate", "agent": "reviewer",
+      "task": "Cross-check the findings below. Delete false positives (cite why). If ANY confirmed HIGH remains, end with VERDICT: BLOCK and list them; else VERDICT: PASS.\n\n{steps.audit.output}",
+      "dependsOn": ["audit"] },
+
+    { "id": "report", "type": "reduce", "from": ["screen"], "agent": "doc-writer",
+      "task": "Write a prioritized remediation report from:\n{steps.screen.output}",
+      "dependsOn": ["screen"], "final": true }
+  ]
+}
+```
+
+Why each piece: `expect`+`retry` on discover means a chatty scout gets a second
+chance instead of feeding garbage to the map; `concurrency: 4` protects rate
+limits; the gate is a *different* agent than the auditor; `budget` bounds the
+fan-out.
+
+**Variant — per-item caching for repeated audits:** add
+`"cache": { "scope": "cross-run" }` to the map phase. On the next run, only
+items whose task text changed re-execute; the rest are $0 cache hits.
+(Details: `configuration.md` §8.)
+
+---
+
+## Archetype 2: Self-healing implement→verify→rework
+
+Use for: implement against acceptance criteria, fix-until-green.
+The gate re-runs its upstream on BLOCK — a generate→critique→regenerate loop
+without you writing a loop.
+
+```jsonc
+{
+  "name": "implement-verified",
+  "budget": { "maxUSD": 5.00 },
+  "phases": [
+    { "id": "implement", "type": "agent", "agent": "executor-code",
+      "task": "Implement the feature per the spec in docs/spec.md. Run nothing; just edit." },
+
+    { "id": "build-test", "type": "script",
+      "run": "npx tsc --noEmit && npm test 2>&1 | tail -20",
+      "timeout": 180000, "dependsOn": ["implement"] },
+
+    { "id": "spec-gate", "type": "gate", "agent": "reviewer",
+      "onBlock": "retry", "retry": { "max": 3 },
+      "eval": ["{steps.build-test.output} contains pass"],
+      "task": "Build/test output:\n{steps.build-test.output}\n\nDoes the implementation satisfy ALL acceptance criteria in docs/spec.md? VERDICT: PASS, or VERDICT: BLOCK with a precise list of what to fix.",
+      "dependsOn": ["implement", "build-test"] },
+
+    { "id": "summary", "type": "agent", "agent": "doc-writer",
+      "task": "Summarize what was implemented and the verification result:\n{steps.spec-gate.output}",
+      "dependsOn": ["spec-gate"], "final": true }
+  ]
+}
+```
+
+Key mechanics: on BLOCK, `spec-gate` re-runs **both** its `dependsOn` upstreams
+(`implement` gets the blocker's reasons via re-interpolation, `build-test`
+re-verifies), up to 3 rounds. The `eval` line means a green build+test skips
+the LLM review entirely on the happy path.
+
+**Verification phases: force structured output.** LLMs are bad at
+*summarizing* shell output (234 tests read as 230) but good at *copying*
+structured data. If a verification step must go through an agent (not a
+`script`), demand `key=value` lines:
+
+```
+Report EXACTLY in this format (one key=value per line, no prose):
+typecheck=PASS|FAIL
+tests_total=N
+tests_fail=N
+If any field is missing, you failed the task — re-run and re-read.
+```
+
+Prefer a `script` phase whenever the check is a command — exact, free, fast.
+
+---
+
+## Archetype 3: Plan → human approval → execute
+
+Use for: anything expensive or destructive where a human should see the plan
+before the spend. The approval's **Edit** option injects mid-run guidance.
+
+> **Codex caveat:** approval phases auto-reject in MCP-driven (non-interactive)
+> runs. This archetype only works when a human runs the flow interactively;
+> for tool-driven runs, replace the approval with a strict `gate`.
+
+```jsonc
+{
+  "name": "guarded-migration",
+  "phases": [
+    { "id": "plan", "type": "agent", "agent": "planner",
+      "task": "Plan the migration of src/legacy/* to the new API. List each file, the change, and the risk." },
+
+    { "id": "checkpoint", "type": "approval",
+      "task": "Migration plan:\n\n{steps.plan.output}\n\nApprove to execute, reject to abort, or edit to add constraints.",
+      "dependsOn": ["plan"] },
+
+    { "id": "execute", "type": "agent", "agent": "executor-code",
+      "task": "Execute the migration plan:\n{steps.plan.output}\n\nOperator guidance (if any): {steps.checkpoint.output}",
+      "dependsOn": ["checkpoint"] },
+
+    { "id": "verify", "type": "script", "run": "npx tsc --noEmit && npm test 2>&1 | tail -5",
+      "timeout": 180000, "dependsOn": ["execute"], "final": true }
+  ]
+}
+```
+
+Note `{steps.checkpoint.output}` — on Edit it carries the operator's note; on
+Approve it's `(approve)`. Don't use approval in detached/headless runs (it
+auto-rejects there — by design).
+
+---
+
+## Archetype 4: Dynamic plan → execute (`flow{def}`)
+
+Use when the *work itself* must be discovered at runtime — the planner emits a
+whole sub-flow as JSON and the runtime validates + runs it. The declarative
+answer to "loop over whatever we find".
+
+```jsonc
+{
+  "name": "dynamic-audit",
+  "budget": { "maxUSD": 4.00 },
+  "phases": [
+    { "id": "plan", "type": "agent", "agent": "planner", "output": "json",
+      "task": "Scan this repo. Output ONLY a JSON taskflow {\"name\":\"sub\",\"phases\":[...]} with one 'agent' phase per module that needs auditing (agent: \"analyst\"), plus a final 'reduce' phase (agent: \"doc-writer\", from: [all audit ids], final: true). Use hyphens in ids. No script phases, no cwd fields.",
+      "expect": { "type": "object", "required": ["name", "phases"] },
+      "retry": { "max": 2, "backoffMs": 0 } },
+
+    { "id": "run-plan", "type": "flow", "def": "{steps.plan.json}",
+      "optional": true, "dependsOn": ["plan"] },
+
+    { "id": "deliver", "type": "agent", "agent": "doc-writer",
+      "task": "Final result (empty means the plan failed validation — say so):\n{steps.run-plan.output}",
+      "dependsOn": ["run-plan"], "final": true }
+  ]
+}
+```
+
+Critical details (full contract in `advanced.md`): a bad plan **fails open**
+(`defError` diagnostic, empty output downstream) — `optional: true` + the
+`deliver` phase turn that into a graceful report instead of a dead run. The
+planner prompt must forbid what validation will reject anyway (`script`
+phases, workspace `cwd` keywords) so the plan doesn't waste a retry.
+
+**Iterative replanning:** wrap a plan-emitting body in a `loop` so round N's
+plan reacts to round N−1's result — see `examples/iterative-replan.json`.
+
+---
+
+## Archetype 5: Tournament for one-shot-unreliable work
+
+Use when quality varies run-to-run (naming, copywriting, tricky refactor
+strategy, root-cause hypotheses). Branches > variants when you want genuinely
+different *approaches* judged against each other.
+
+```jsonc
+{
+  "id": "strategy", "type": "tournament", "mode": "best",
+  "judgeAgent": "final-arbiter",
+  "judge": "Judge on: correctness under concurrent access, blast radius, migration cost. Quote evidence. End with WINNER: <n>.",
+  "branches": [
+    { "task": "Design the cache-invalidation fix with a conservative approach: minimal diff, no schema change.", "agent": "analyst" },
+    { "task": "Design the fix assuming we can change the schema: optimal correctness.", "agent": "analyst" },
+    { "task": "Design the fix as an adversary: what will break each obvious approach? Then propose the one that survives.", "agent": "critic" }
+  ],
+  "dependsOn": ["context"], "final": true
+}
+```
+
+Give the judge a **rubric with named criteria**, a stronger model
+(`judgeAgent`), and an exact terminator (`WINNER: <n>`). `mode: "aggregate"`
+instead merges all variants — good for research synthesis, bad for decisions.
+
+---
+
+## Archetype 6: Incremental repo-watch audit (cross-run)
+
+Use for flows you'll re-run as the repo evolves. First run pays full price;
+subsequent runs re-pay only for what changed.
+
+```jsonc
+{
+  "name": "security-sweep",
+  "incremental": true,
+  "budget": { "maxUSD": 3.00 },
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "output": "json",
+      "task": "List all files handling user input. Output ONLY a JSON array of paths.",
+      "expect": { "type": "array" },
+      "cache": { "scope": "cross-run", "fingerprint": ["glob!:src/**/*.ts"] } },
+    { "id": "audit", "type": "map", "over": "{steps.discover.json}",
+      "agent": "security-reviewer", "task": "Audit {item} for injection/authz issues.",
+      "cache": { "scope": "cross-run" },
+      "dependsOn": ["discover"] },
+    { "id": "report", "type": "reduce", "from": ["audit"], "agent": "doc-writer",
+      "task": "Prioritized findings report:\n{steps.audit.output}",
+      "dependsOn": ["audit"], "final": true }
+  ]
+}
+```
+
+The `glob!:` fingerprint makes `discover` a cache miss only when file
+*contents* change; the map's per-item cache means one changed file re-audits
+one item.
+
+---
+
+## Anti-patterns (seen in real flows)
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|--------------|-----|
+| One mega-phase doing discover+audit+report | No parallelism, no caching granularity, one failure loses everything | Split along the archetype-1 shape |
+| Gate whose task doesn't demand a `VERDICT:` terminator | Ambiguity fails open → gate silently always passes | End every gate task with the exact verdict instruction |
+| Router phase without `expect` enum | `"Deep"` vs `"deep"` → both `when` branches skip, `join:"any"` reduce gets nothing | `expect: { properties: { route: { enum: [...] } } }` + `retry` |
+| Agent phase that just runs a shell command | Tokens spent, output paraphrased inaccurately | `script` phase |
+| Same agent produces and reviews | Self-review passes everything | Different agent (ideally model) for the gate |
+| Fan-out with no `budget` and no `concurrency` cap | Unbounded spend + rate-limit storms | `budget` + `phase.concurrency` |
+| `dependsOn` declared but output never referenced | The downstream agent doesn't see the upstream's work — dependency ≠ data flow | Interpolate `{steps.X.output}` into the task (or `context`) |
+| Saving a flow without `strictInterpolation` | Later invocations with wrong args silently run on empty strings | `strictInterpolation: true` before saving |
+| `map` over `{steps.X.output}` (text, not json) | `over` must resolve to an array | `output: "json"` upstream + `over: "{steps.X.json}"` |
+| Deep `chain` where steps don't need each other's output | Serialized latency for no reason | `tasks` (parallel) or a DAG with real edges only |

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -317,38 +317,42 @@ test("mcp: taskflow_compile falls back to text-only (with outline) for a huge fl
 
 // The bundled skill is the plugin's primary authoring surface — a flow example
 // that fails taskflow_verify would teach Codex to emit rejected flows. Extract
-// every self-contained JSON(c) flow block from SKILL.md and assert it validates.
-test("skill: every complete flow example in SKILL.md passes taskflow_verify", async () => {
-	const { readFileSync } = await import("node:fs");
+// every self-contained JSON(c) flow block from every bundled skill file and
+// assert it validates.
+test("skill: every complete flow example in the bundled skill files passes taskflow_verify", async () => {
+	const { readFileSync, readdirSync } = await import("node:fs");
 	const { fileURLToPath } = await import("node:url");
-	const skillPath = fileURLToPath(new URL("../plugin/skills/taskflow/SKILL.md", import.meta.url));
-	const src = readFileSync(skillPath, "utf8");
+	const path = await import("node:path");
+	const skillDir = fileURLToPath(new URL("../plugin/skills/taskflow/", import.meta.url));
 	const tools = makeToolHandlers(process.cwd());
 
-	const re = /```jsonc?\n([\s\S]*?)```/g;
-	let m: RegExpExecArray | null;
 	let checked = 0;
-	while ((m = re.exec(src)) !== null) {
-		const body = m[1];
-		if (!body.includes('"phases"')) continue;
-		// Strip // comments + trailing commas so the jsonc example parses as JSON.
-		const cleaned = body
-			.replace(/(^|[^:])\/\/.*$/gm, "$1")
-			.replace(/,(\s*[}\]])/g, "$1");
-		let obj: { phases?: unknown[] };
-		try {
-			obj = JSON.parse(cleaned);
-		} catch {
-			continue; // fragment / placeholder block, not a full flow
+	for (const file of readdirSync(skillDir).filter((f) => f.endsWith(".md"))) {
+		const src = readFileSync(path.join(skillDir, file), "utf8");
+		const re = /```jsonc?\n([\s\S]*?)```/g;
+		let m: RegExpExecArray | null;
+		while ((m = re.exec(src)) !== null) {
+			const body = m[1];
+			if (!body.includes('"phases"')) continue;
+			// Strip // comments + trailing commas so the jsonc example parses as JSON.
+			const cleaned = body
+				.replace(/(^|[^:])\/\/.*$/gm, "$1")
+				.replace(/,(\s*[}\]])/g, "$1");
+			let obj: { phases?: unknown[]; name?: unknown };
+			try {
+				obj = JSON.parse(cleaned);
+			} catch {
+				continue; // fragment / placeholder block, not a full flow
+			}
+			if (!obj || !Array.isArray(obj.phases) || !obj.name) continue;
+			checked++;
+			const res = (await tools.taskflow_verify({ define: obj })) as {
+				content: { type: string; text?: string }[];
+				isError: boolean;
+			};
+			const text = res.content.find((c) => c.type === "text")?.text ?? "";
+			assert.equal(res.isError, false, `${file} flow example "${obj.name}" must verify cleanly, got: ${text}`);
 		}
-		if (!obj || !Array.isArray(obj.phases)) continue;
-		checked++;
-		const res = (await tools.taskflow_verify({ define: obj })) as {
-			content: { type: string; text?: string }[];
-			isError: boolean;
-		};
-		const text = res.content.find((c) => c.type === "text")?.text ?? "";
-		assert.equal(res.isError, false, `SKILL.md flow example must verify cleanly, got: ${text}`);
 	}
-	assert.ok(checked >= 1, "expected at least one complete flow example in SKILL.md");
+	assert.ok(checked >= 5, `expected at least 5 complete flow examples across the skill files, found ${checked}`);
 });

--- a/packages/pi-taskflow/skills/taskflow/SKILL.md
+++ b/packages/pi-taskflow/skills/taskflow/SKILL.md
@@ -3,27 +3,74 @@ name: taskflow
 description: Orchestrate multi-phase subagent workflows with pi-taskflow. Use whenever a request spans a whole project or many items — deeply exploring / 探索 / auditing / 审计 / analyzing a codebase, reviewing or migrating many files or modules in parallel, cross-checked/adversarial review, codebase-wide research, or any repeatable orchestration you want to save and rerun. Prefer this over ad-hoc parallel subagents when the work has multiple phases or dynamic fan-out over a discovered list. Also supports subagent-style shorthand (single / parallel / chain) for simple non-DAG delegations you want tracked, resumable, or saveable.
 ---
 
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/entry.pi.md + core.md (npm run build:skills) -->
+
 # Taskflow
+
+**Host binding (pi):** everything below is driven through the `taskflow` tool
+(`action: "run" | "verify" | …`) and the `/tf` slash commands. Where an example
+shows a host-neutral invocation like `verify`, use the pi form
+(`action: "verify"` or `/tf verify`).
 
 Build and run **declarative, multi-phase workflows** of subagents. The runtime
 holds intermediate results and the phase DAG, so your main context only receives
 the final answer — not every step's transcript.
+
+## Documentation map (progressive loading)
+
+This file teaches the core: phase types, control flow, interpolation, and the
+mistakes that break flows. Load the companion files **only when needed**:
+
+| File | Load when you need |
+|------|--------------------|
+| `patterns.md` | **Designing a non-trivial flow.** Proven flow archetypes (audit fan-out, self-healing rework, plan→approve→execute, dynamic replanning, tournament synthesis, incremental audit), anti-patterns, and the production-flow quality checklist. |
+| `advanced.md` | Shared Context Tree (`ctx_*` tools, `ctx_spawn` sub-graphs), workspace isolation (`cwd: temp/dedicated/worktree`), dynamic sub-flow (`flow{def}`) contracts & security caps, and the **incremental recompute suite** (`ir` / `provenance` / `why-stale` / `recompute` / `cache-clear`). |
+| `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
+
+> Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
+> **Read `patterns.md` first** — it will make the flow better, not just valid.
 
 ## When to use
 
 - A task needs **several coordinated steps** (discover → work → review → report).
 - You need to **fan out over many items** (audit every endpoint, summarize every file).
 - You want **cross-checked / adversarial review** before reporting.
-- You want a **repeatable** orchestration saved as a `/tf:<name>` command.
+- You want a **repeatable** orchestration you can save and rerun by name.
+- The same expensive analysis will be **re-run as the repo evolves** (use
+  `incremental: true` + fingerprints — see `configuration.md` §8).
 
-For a single quick delegation you can use the **shorthand modes** below (no DSL),
-or the plain `subagent` tool. Use the shorthand when you want the run tracked,
-resumable, or saveable as a `/tf` command.
+## When NOT to use
 
-## Shorthand (non-DAG) — like the subagent tool
+- A **single-file, single-step** change you can do directly — just do it.
+- **Interactive debugging** where each step depends on watching live output.
+- Work that is **one bash command** — run it yourself, don't wrap it in a flow.
+- A single quick delegation with no tracking needs — the plain `subagent` tool
+  is fine (though the shorthand below gives you resume + save for free).
+
+## Flow design ladder
+
+Match the flow's sophistication to the task. Don't stop at level 1 when the
+task deserves level 3 — the higher levels are where taskflow pays for itself.
+
+| Level | Shape | Reach for it when |
+|-------|-------|-------------------|
+| 0 | shorthand `task` / `tasks` / `chain` | one-off delegation, simple sequence |
+| 1 | linear DAG with `dependsOn` | fixed steps, each consuming the last |
+| 2 | discover → `map` fan-out → `gate` → `reduce` | many items, needs review before reporting |
+| 3 | + `eval` zero-token gates, `expect` contracts, `retry`, `onBlock: "retry"`, `budget`, `optional` fallbacks | production-grade: self-healing, cost-capped, fails precisely |
+| 4 | + `loop`, `tournament`, `flow{def}` dynamic planning | the work itself is discovered at runtime; one shot is unreliable |
+| 5 | + `incremental: true`, `cache.fingerprint` | the flow re-runs as the repo changes; only re-pay for what changed |
+
+**A production-grade flow (level 3+) usually has:** machine checks before LLM
+checks (`eval`, `script`), an `expect` contract on every JSON-emitting phase,
+`retry` on contract-checked phases, a `budget`, `optional: true` on
+degradable phases with a downstream fallback, and exactly one `final` phase.
+`patterns.md` shows each of these composed into full archetypes.
+
+## Shorthand (non-DAG)
 
 Skip the DSL entirely for simple delegations. The runtime desugars these into a
-proper flow, so you still get progress, persistence, resume, and `save`.
+proper flow, so you still get progress, persistence, and resume.
 
 ```jsonc
 // single  — one agent, one task
@@ -46,26 +93,18 @@ proper flow, so you still get progress, persistence, resume, and `save`.
 - `context` (optional, per step or top-level in single mode): file paths to
   pre-read and inject before the task — same as the full-DSL `Phase.context`
   (per-file `contextLimit`, default 8000 chars). In **parallel `tasks` mode**
-  all branches SHARE the union of step contexts (the runtime pre-reads per
-  phase, not per branch). In **chain mode** declare `context` on individual
-  steps; a top-level `context` is ignored (with a warning).
-- Add `name` to label the run (and to `save` it as a `/tf:<name>` command).
+  all branches SHARE the union of step contexts. In **chain mode** declare
+  `context` on individual steps; a top-level `context` is ignored (with a warning).
+- Add `name` to label the run.
 - Precedence if several are given: `chain` > `tasks` > `task`.
 - You can pass these as top-level tool params **or** inside `define`.
-
-```jsonc
-// context pre-read in shorthand — the file content is injected before the task
-{ "chain": [
-  { "task": "Map the public API of src/lib", "agent": "scout" },
-  { "task": "Write docs for:\n{previous.output}", "agent": "doc-writer",
-    "context": ["AGENTS.md", "docs/style-guide.md"] }
-] }
-```
 
 ## How to author a taskflow
 
 Call the `taskflow` tool. To run a brand-new flow you write inline, pass
 `action: "run"` with a `define` object. To run a saved flow, pass `name`.
+**Before running a non-trivial flow, `action: "verify"` it — zero tokens,
+catches cycles / missing deps / undefined refs / contract typos.**
 
 ### DSL shape
 
@@ -75,16 +114,20 @@ Call the `taskflow` tool. To run a brand-new flow you write inline, pass
   "description": "Audit API endpoints for missing auth",
   "args": { "dir": { "default": "src/routes" } },
   "concurrency": 8,
+  "budget": { "maxUSD": 2.00 },
   "agentScope": "user",            // user | project | both
   "phases": [
     { "id": "discover", "type": "agent", "agent": "scout",
       "task": "List endpoints under {args.dir}. Output ONLY a JSON array [{\"route\":\"\",\"file\":\"\"}].",
-      "output": "json" },
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object", "required": ["route", "file"] } },
+      "retry": { "max": 2, "backoffMs": 0 } },
     { "id": "audit", "type": "map", "over": "{steps.discover.json}", "as": "item",
       "agent": "analyst", "task": "Audit {item.route} ({item.file}) for missing auth.",
       "dependsOn": ["discover"] },
     { "id": "review", "type": "gate", "agent": "reviewer",
-      "task": "Remove false positives from:\n{steps.audit.output}", "dependsOn": ["audit"] },
+      "task": "Remove false positives from:\n{steps.audit.output}\nVERDICT: PASS or BLOCK.",
+      "dependsOn": ["audit"] },
     { "id": "report", "type": "reduce", "from": ["review"], "agent": "writer",
       "task": "Write a final report:\n{steps.review.output}", "dependsOn": ["review"],
       "final": true }
@@ -92,20 +135,20 @@ Call the `taskflow` tool. To run a brand-new flow you write inline, pass
 }
 ```
 
-### Phase types
+### Phase types (10)
 
 | type | meaning | details |
 |------|---------|---------|
-| `agent` | one subagent runs `task` | DSL shape |
-| `parallel` | run `branches[]` concurrently | Conditional routing |
-| `map` | fan out over `over` (an array) — one subagent per item, `{item}` bound | DSL shape |
-| `gate` | quality/review step that can **halt the flow** | Gate phases |
-| `reduce` | aggregate `from[]` phases into one output | DSL shape |
-| `approval` | **human-in-the-loop** pause: ask a person to approve / reject / edit before continuing | Approval phases |
-| `flow` | run a **sub-flow** as one phase — **saved** (`use`) or **runtime-generated** (`def`) | Sub-flows |
-| `loop` | repeat a body until a condition / convergence / `maxIterations` | Loop phases |
-| `tournament` | run N competing `variants`, a `judge` picks the best or aggregates | Tournament phases |
-| `script` | run a **shell command** (no LLM, zero tokens) — captures stdout as the output | Script phases |
+| `agent` | one subagent runs `task` | this file |
+| `parallel` | run static `branches[]` concurrently | this file |
+| `map` | fan out over `over` (an array) — one subagent per item, `{item}` bound | this file |
+| `gate` | quality/review step that can **halt the flow** | Gate phases below |
+| `reduce` | aggregate `from[]` phases into one output | this file |
+| `approval` | **human-in-the-loop** pause: approve / reject / edit | Approval phases below |
+| `flow` | run a **sub-flow** as one phase — saved (`use`) or runtime-generated (`def`) | summary below; deep contract in `advanced.md` |
+| `loop` | repeat a body until a condition / convergence / `maxIterations` | Loop phases below |
+| `tournament` | run N competing `variants`, a `judge` picks best or aggregates | Tournament phases below |
+| `script` | run a **shell command** (no LLM, zero tokens) — stdout is the output | Script phases below |
 
 ### Control-flow fields (any phase)
 
@@ -114,19 +157,22 @@ Call the `taskflow` tool. To run a brand-new flow you write inline, pass
 | `when` | conditional guard — skip the phase unless the expression is truthy. Supports `{refs}`, `== != < > <= >=`, `&& \|\| !`, parentheses, quoted strings/numbers. Parse errors fail **open** (phase runs). |
 | `join` | dependency join: `"all"` (default — wait for every dep) or `"any"` (OR-join — run as soon as one dep completes). |
 | `retry` | `{ "max": N, "backoffMs": ms, "factor": k }` — retry a failing subagent up to N times; delay is `backoffMs * factor^attempt` (`factor:1`=fixed, `2`=exponential). |
-| `timeout` | max ms per subagent call (>= 1000). On expiry the subagent is aborted and the phase fails with a `timedOut` marker — deterministic, **never retried**. Valid on any agent-running phase; note it caps EACH call, so a map/parallel/loop/tournament phase's wall time is per item/iteration/variant (a tournament's judge call gets its own cap too). Script phases keep their own child-process timeout (default 60s, max 300s). Not supported on approval/flow. Pair with `optional: true` + a downstream fallback phase to degrade instead of failing the run. |
-| `expect` | output contract for `output: "json"` phases (agent/gate/reduce/loop): a JSON-Schema-like shape `{type, properties, required, items, enum}` validated the moment the subagent finishes. A violation fails the phase with a precise diagnostic (e.g. `$.score: required key is missing`) and is retryable under the phase's explicit `retry`. `verify`/`compile` also statically warn when a `{steps.X.json.field}` ref names a field absent from X's declared contract. |
+| `timeout` | max ms per subagent call (>= 1000). On expiry the subagent is aborted and the phase fails with a `timedOut` marker — deterministic, **never retried**. Caps EACH call, so a map/parallel/loop/tournament phase's wall time is per item/iteration/variant (a tournament's judge call gets its own cap too). Script phases keep their own child-process timeout (default 60s, max 300s). Not supported on approval/flow. Pair with `optional: true` + a downstream fallback phase to degrade instead of failing the run. |
+| `expect` | output contract for `output: "json"` phases (agent/gate/reduce/loop): a JSON-Schema-like shape `{type, properties, required, items, enum}` validated the moment the subagent finishes. A violation fails the phase with per-path diagnostics (e.g. `$.score: required key is missing`) and is retryable under the phase's explicit `retry`. `verify`/`compile` also statically warn when a `{steps.X.json.field}` ref names a field absent from X's declared contract. |
+| `optional` | fail-soft — a failed/blocked phase won't abort the run; downstream sees empty output. Pair with a fallback phase guarded by `when`. |
+| `cache` | per-phase reuse policy (`run-only` default / `cross-run` / `off`). See `configuration.md` §8. |
 
 ### Conditional routing (when + gate/branches)
 
 Pair `when` with an upstream phase that emits a decision to build real if/else
-routing. Use `join: "any"` on the merge phase so it runs whichever branch fired. For
-static (non-conditional) concurrency, a `parallel` phase runs fixed `branches[]`
-instead — `{ "type": "parallel", "branches": [{"task":"..."}, {"task":"...","agent":"reviewer"}] }`.
+routing. Use `join: "any"` on the merge phase so it runs whichever branch fired.
+For static (non-conditional) concurrency, a `parallel` phase runs fixed
+`branches[]` instead — `{ "type": "parallel", "branches": [{"task":"..."}, {"task":"...","agent":"reviewer"}] }`.
 
 ```jsonc
 { "id": "triage", "type": "agent", "agent": "analyst", "output": "json",
-  "task": "Classify the task. Output ONLY {\"route\":\"deep\"} or {\"route\":\"quick\"}." },
+  "task": "Classify the task. Output ONLY {\"route\":\"deep\"} or {\"route\":\"quick\"}.",
+  "expect": { "type": "object", "required": ["route"], "properties": { "route": { "enum": ["deep", "quick"] } } } },
 { "id": "deep",  "when": "{steps.triage.json.route} == deep",  "dependsOn": ["triage"], "agent": "analyst", "task": "..." },
 { "id": "quick", "when": "{steps.triage.json.route} == quick", "dependsOn": ["triage"], "agent": "executor-fast", "task": "..." },
 { "id": "report", "type": "reduce", "from": ["deep","quick"], "join": "any",
@@ -134,189 +180,10 @@ instead — `{ "type": "parallel", "branches": [{"task":"..."}, {"task":"...","a
 ```
 
 > `when` should reference **upstream** (`dependsOn`) phases — a ref to a phase
-> that hasn't completed resolves empty and the guard is treated as false.
-
-### Approval phases (human-in-the-loop)
-
-An `approval` phase pauses the run and asks the operator to **Approve / Reject /
-Edit**. Distinct from `gate` (which is an *agent* reviewing): this is a *human*
-deciding. The (interpolated) `task` is the prompt shown.
-
-- **Approve** → continue; the phase output is `(approve)`.
-- **Reject** → halt the flow (same mechanism as a blocking gate).
-- **Edit** → the typed note becomes this phase's `output`, so you can inject
-  guidance mid-run: reference it downstream with `{steps.<id>.output}`.
-- **Non-interactive** runs (headless/CI/print mode) **auto-reject** and record it — approval gates are safety boundaries that must never be silently bypassed.
-- **Background (detached)** runs **auto-reject** (no interactive approver) — downstream sees the rejection; the flow continues (fail-open).
-
-```jsonc
-{ "id": "checkpoint", "type": "approval", "dependsOn": ["plan"],
-  "task": "Review the plan above before the expensive fan-out. Approve, reject, or add guidance." }
-```
-
-### Sub-flows (composition)
-
-A `flow` phase runs another taskflow as a single phase and bubbles up its final
-output. Two sources, **mutually exclusive**:
-
-**Saved** (`use`) — run a previously saved flow by name. Pass args via `with`
-(string values interpolate). Recursion is detected and rejected.
-
-```jsonc
-{ "id": "research", "type": "flow", "use": "deep-research",
-  "with": { "topic": "{item}" }, "dependsOn": ["plan"] }
-```
-
-**Runtime-generated** (`def`) — resolve a sub-flow *at runtime*, usually from an
-upstream phase's JSON output. The runtime interpolates + JSON-parses the `def`,
-**validates it** (cycles / dangling refs / duplicate ids), then runs it as a
-nested sub-flow. This is how a planner decides *at runtime* what work to spawn —
-the declarative answer to a code-mode `for`/`if` loop, with each generated plan
-checked before it spends a token.
-
-```jsonc
-// 1) A planner emits a plan as JSON. 2) flow{def} runs it.
-{ "id": "plan", "type": "agent", "agent": "planner", "output": "json",
-  "task": "Scan the repo. Output ONLY JSON {\"name\":\"audit\",\"phases\":[...]} — one audit phase per file." },
-{ "id": "run", "type": "flow", "def": "{steps.plan.json}", "dependsOn": ["plan"], "final": true }
-```
-
-**LLM output contract for `def`:** the upstream phase must output a *full*
-Taskflow `{"name":"...","phases":[...]}`, a bare `phases` array, or
-`{"phases":[...]}` — pure JSON (a ```json fence is tolerated and stripped).
-Use hyphens in ids, never underscores. Sub-flow phases reference each other in
-their **own** `{steps.x.output}` namespace (no parent-id prefixing needed).
-
-**Fail-open & limits:** if the `def` doesn't parse, has the wrong shape, or fails
-validation, the phase completes with `status: "done"` and carries a `defError`
-diagnostic field; downstream phases receive empty output. Authors who want a
-hard failure can add a gate that checks for `defError`. The run continues
-(add `optional: true` on the flow phase so a bad plan never aborts the run). An **empty** `phases` array is a
-valid no-op (the planner decided there's nothing to do). Inline nesting is capped
-at `MAX_DYNAMIC_NESTING` (5) to bound runaway self-spawning.
-
-**Iterative replanning** — pair `flow{def}` (or a JSON-emitting body) with `loop`
-so round N's plan depends on round N-1's **result** (not a one-shot fan-out):
-the declarative equivalent of `for (...) { read result; decide next }`. See
-`examples/dynamic-plan-execute.json` and `examples/iterative-replan.json`.
-
-### Loop phases (iterate until done)
-
-A `loop` phase runs its body repeatedly, exposing each iteration's output as
-`{steps.<thisId>.output}` / `.json` so the next round can react to the last. It
-stops on the first of: `until` truthy, **convergence** (output stops changing),
-or `maxIterations` (hard cap). This is the declarative "keep going until good
-enough" — the runtime always terminates (the cap is mandatory).
-
-- `until` — stop condition, same operators as `when` (a parse error stops the loop, fail-safe).
-- `maxIterations` — hard iteration cap (required to bound the loop).
-- `convergence` — `true` to stop early when an iteration's output equals the previous one.
-
-```jsonc
-{
-  "id": "refine",
-  "type": "loop",
-  "agent": "executor",
-  "maxIterations": 5,
-  "until": "{steps.refine.json.done} == true",
-  "convergence": true,
-  "task": "Improve the draft. When nothing else needs fixing, output JSON {\"done\":true,\"draft\":\"...\"}; otherwise {\"done\":false,\"draft\":\"...\"}.",
-  "output": "json",
-  "final": true
-}
-```
-
-For data-dependent **replanning** each round, pair a `loop` body that emits a
-plan with `flow{def}` (see Sub-flows above). See `examples/iterative-replan.json`.
-
-### Tournament phases (N variants, judge picks best)
-
-A `tournament` phase runs `variants` competing attempts in parallel, then a
-**judge** sub-phase selects the winner (`mode: "best"`) or merges them
-(`mode: "aggregate"`). Use it when one shot is unreliable and you want the best
-of several drafts, or a synthesis of diverse approaches.
-
-- `variants` — a number specifying how many competing variants to spawn from 'task' (default 3, max 20). For genuinely different approaches, use the `branches` field instead — an explicit array of `{task, agent?}` definitions.
-- `mode` — `"best"` (judge picks one winner, default) or `"aggregate"` (judge merges all into one output).
-- `judge` — the judge's rubric/instructions (how to choose or merge).
-- `judgeAgent` — *(optional)* the agent that runs the judge step; defaults to the phase `agent`.
-- Fail-open: if the judge's pick is unparseable, variant 1 is returned (work is never lost).
-
-```jsonc
-{
-  "id": "headline",
-  "type": "tournament",
-  "agent": "executor",
-  "variants": 3,
-  "mode": "best",
-  "judge": "Pick the clearest, most accurate headline. End with: WINNER: <n>.",
-  "task": "Write one headline for the article below.\n\n{steps.draft.output}",
-  "dependsOn": ["draft"],
-  "final": true
-}
-```
-
-### Script phases (shell commands, zero tokens)
-
-A `script` phase runs a **shell command** directly — no subagent, no tokens — and
-captures its stdout as the phase output. Use it to glue LLM phases to real tools:
-run a build/test/format, `git`, a webhook, or pipe an upstream phase through a
-script.
-
-- `run` — **required**. A **string** runs through a shell; an **array** is
-  spawned directly (execvp, no shell). A string `run` that contains an
-  interpolation placeholder is **rejected at validation** (shell-injection
-  guard) — use the array form or `input` for dynamic values.
-- `input` — optional text piped to stdin (supports interpolation).
-- `timeout` — optional ms cap (1000–300000, default 60000); on timeout the child
-  is SIGTERM'd then SIGKILL'd and the phase fails.
-- A non-zero exit fails the phase (stderr captured); stdout is capped at 1 MB.
-  No `retry`, no `output: "json"`; **excluded from `cross-run` cache** (may have
-  side effects). Compiles to a `⚡ script` node.
-
-```jsonc
-{ "id": "build", "type": "script", "run": "npm run build", "timeout": 120000 },
-{ "id": "score", "type": "script", "run": ["python", "score.py"],
-  "input": "{steps.analyze.output}", "dependsOn": ["analyze"], "final": true }
-```
-
-### Workspace isolation (`cwd` keywords)
-
-A phase's `cwd` is normally a literal path (or inherited from the run). Three
-**reserved keywords** instead ask the runtime to allocate an isolated working
-directory for the phase's subagent and tear it down afterwards — so a phase can
-do scratch work, or mutate files, without touching the main tree:
-
-| `cwd` value | what the runtime does | lifecycle |
-|-------------|-----------------------|-----------|
-| `"temp"` | makes an ephemeral dir under the OS tmpdir | removed when the phase finishes |
-| `"dedicated"` | makes a persistent dir under the run state (`runs/ws/<runId>/<phaseId>`) | **kept** for inspection; deterministic per phase (resume reuses it) |
-| `"worktree"` | `git worktree add` on a throwaway branch off `HEAD` | `git worktree remove` + branch delete when the phase finishes |
-
-```jsonc
-{ "id": "experiment", "type": "agent", "agent": "executor", "cwd": "worktree",
-  "task": "Try the risky refactor and run the tests. Your edits are isolated in a git worktree." }
-```
-
-- **Fail-open.** If allocation fails (e.g. `worktree` requested but the repo
-  isn't a git work tree), the phase degrades — `worktree`→`temp`, and any other
-  failure → the base cwd — and records a `warnings` diagnostic. A phase never
-  fails to run because of isolation.
-- **Security.** The keywords are honoured only in **author-written** flows.
-  An LLM-authored sub-flow (`flow{def}` / `ctx_spawn` subflow) that asks for a
-  reserved keyword is **rejected at validation** — generated plans cannot
-  allocate worktrees or temp dirs that mutate the repo.
-- A literal path is passed through unchanged (fully backward-compatible).
-
-### Budget (cost / token caps)
-
-Add a run-wide ceiling at the top level. When accumulated cost/tokens exceed it,
-remaining phases are skipped (and an in-flight `map`/`parallel` stops spawning
-new items); the run ends as `blocked`.
-
-```jsonc
-{ "name": "...", "budget": { "maxUSD": 1.50, "maxTokens": 2000000 }, "phases": [ ... ] }
-```
+> that hasn't completed resolves empty and the guard is treated as false. Note
+> the `expect` enum on the router: it converts "the router said `Deep` with a
+> capital D and both branches silently skipped" into an immediate retryable
+> failure at the router.
 
 ### Gate phases (quality control)
 
@@ -329,21 +196,13 @@ verdict the runtime can read:
 
 On **BLOCK**, downstream phases are skipped and the run ends as `blocked` with the
 reason surfaced. Ambiguous output **fails open** (treated as PASS) so a gate never
-halts the flow by accident. Example gate task:
+halts the flow by accident.
 
-```
-Review the audit results below. If any endpoint is missing auth, end with
-"VERDICT: BLOCK" and a one-line reason; otherwise end with "VERDICT: PASS".
-
-{steps.audit.output}
-```
-
-**Zero-token machine checks (`eval`).** Before spending a token on the LLM gate,
-list machine-checkable assertions in `eval`. If **all** pass, the gate
+**Zero-token machine checks (`eval`) — use these before spending tokens.**
+List machine-checkable assertions in `eval`. If **all** pass, the gate
 auto-passes with **no LLM call**; if any fails, it falls through to the LLM
 `task` (the qualitative residue). Each entry supports the `when` operators plus
-`X contains Y` (substring). A parse error fails **open** (consistent with the
-gate invariant).
+`X contains Y` (substring). A parse error fails **open**.
 
 ```jsonc
 { "id": "quality", "type": "gate", "dependsOn": ["build","test"],
@@ -354,7 +213,8 @@ gate invariant).
 **Self-healing (`onBlock: "retry"`).** By default a blocking gate halts the run
 (`onBlock: "halt"`). With `onBlock: "retry"` the gate instead **re-runs its
 upstream `dependsOn` phases and re-evaluates**, up to `retry.max` rounds (or
-until PASS / budget / abort) — a generate→critique→regenerate rework loop.
+until PASS / budget / abort) — a generate→critique→regenerate rework loop. See
+`patterns.md` for the full archetype.
 
 ```jsonc
 { "id": "spec-gate", "type": "gate", "onBlock": "retry", "retry": { "max": 3 },
@@ -362,37 +222,137 @@ until PASS / budget / abort) — a generate→critique→regenerate rework loop.
   "task": "Does the implementation satisfy ALL acceptance criteria? VERDICT: PASS or BLOCK with reasons." }
 ```
 
-### Structured-verify phases (v0.0.8.1)
+### Approval phases (human-in-the-loop)
 
-A "verify" phase typically runs `npx tsc --noEmit && npm test && git diff --stat`
-and reports whether everything is green. **Don't** delegate this to a generic
-verifier subagent that summarizes the output in prose — LLMs commonly misread
-shell output (e.g., 234 tests reported as 230, 745 insertions as 599, "1 type
-error" reported as "clean"). Instead, **use a dedicated agent whose task is a
-structured shell pipeline** that echoes structured key/value lines the next
-phase can parse directly. Recommended pattern:
+An `approval` phase pauses the run and asks the operator to **Approve / Reject /
+Edit**. Distinct from `gate` (an *agent* reviewing): this is a *human* deciding.
+The (interpolated) `task` is the prompt shown.
+
+- **Approve** → continue; the phase output is `(approve)`.
+- **Reject** → halt the flow (same mechanism as a blocking gate).
+- **Edit** → the typed note becomes this phase's `output` — inject guidance
+  mid-run and reference it downstream with `{steps.<id>.output}`.
+- **Non-interactive** runs (headless/CI/print mode) **auto-reject** and record it.
+- **Background (detached)** runs **auto-reject** (no interactive approver);
+  downstream sees the rejection; the flow continues (fail-open).
+
+Place one before the expensive part of a flow (a big fan-out, a mutation) —
+see the plan→approve→execute archetype in `patterns.md`.
+
+### Sub-flows (composition) — summary
+
+A `flow` phase runs another taskflow as a single phase and bubbles up its final
+output. Two mutually-exclusive sources:
+
+- **Saved** (`use`): `{ "type": "flow", "use": "deep-research", "with": { "topic": "{item}" } }`
+  — args via `with` (string values interpolate); recursion is detected and rejected.
+- **Runtime-generated** (`def`): `{ "type": "flow", "def": "{steps.plan.json}" }`
+  — an upstream planner emits a whole flow as JSON; the runtime validates it
+  (cycles / dangling refs / security caps) then runs it nested. This is how a
+  planner decides *at runtime* what work to spawn — the declarative answer to a
+  code-mode `for`/`if` loop.
+
+The `def` output contract, fail-open semantics (`defError`), nesting/breadth
+caps, and the iterative-replanning pattern (`loop` + `flow{def}`) are in
+`advanced.md`. The plan→execute and replan archetypes are in `patterns.md`.
+
+### Loop phases (iterate until done)
+
+A `loop` phase runs its body repeatedly, exposing each iteration's output as
+`{steps.<thisId>.output}` / `.json` so the next round can react to the last. It
+stops on the first of: `until` truthy, **convergence** (output stops changing),
+or `maxIterations` (hard cap, required). The runtime always terminates.
+
+- `until` — stop condition, same operators as `when` (a parse error stops the loop, fail-safe).
+- `maxIterations` — hard iteration cap (required).
+- `convergence` — `true` to stop early when an iteration's output equals the previous one.
 
 ```jsonc
 {
-  "id": "verify",
-  "type": "agent",
-  "agent": "verifier",
-  "dependsOn": ["apply-fixes"],
-  "task": "Run the verification pipeline and report structured results.\n\nExecute:\n```bash\ncd $REPO && npx tsc --noEmit 2>&1 | tee /tmp/tsc.log\ncd $REPO && npm test 2>&1 | tee /tmp/test.log | tail -10\ncd $REPO && git diff --shortstat HEAD | tee /tmp/diff.log\n```\n\nReport EXACTLY in this format (one key=value pair per line, no prose):\ntypecheck=PASS|FAIL\ntests_total=N\ntests_pass=N\ntests_fail=N\ninsertions=N\ndeletions=N\nfiles_changed=N\n\nIf any field is missing, you failed the task — re-run the command and re-read the output.",
-  "tools": ["read", "edit", "write", "bash"]
+  "id": "refine", "type": "loop", "agent": "executor",
+  "maxIterations": 5,
+  "until": "{steps.refine.json.done} == true",
+  "convergence": true,
+  "task": "Improve the draft. When nothing else needs fixing, output JSON {\"done\":true,\"draft\":\"...\"}; otherwise {\"done\":false,\"draft\":\"...\"}.",
+  "output": "json",
+  "expect": { "type": "object", "required": ["done", "draft"] },
+  "final": true
 }
 ```
 
-The key insight: **LLMs are bad at summarizing shell output, good at copying
-structured data**. Asking for `key=value` pairs with explicit fields and "if
-missing, you failed" forces the agent to read each field carefully. Downstream
-phases that consume `{steps.verify.output}` can then `safeParse`-it into a
-JSON object and assert against expected values.
+### Tournament phases (N variants, judge picks best)
 
-For audits where the upstream is LLM-generated prose (not shell output), use a
-plain `gate` phase with `VERDICT:` instead.
+A `tournament` phase runs `variants` competing attempts in parallel, then a
+**judge** sub-phase selects the winner (`mode: "best"`) or merges them
+(`mode: "aggregate"`). Use it when one shot is unreliable and you want the best
+of several drafts, or a synthesis of diverse approaches.
 
-### Interpolation
+- `variants` — number of competing variants spawned from `task` (default 3, max 20).
+  For genuinely different *approaches*, use `branches` instead — an explicit
+  array of `{task, agent?}` definitions (e.g. one conservative, one aggressive).
+- `mode` — `"best"` (judge picks one winner, default) or `"aggregate"` (judge merges all).
+- `judge` — the judge's rubric/instructions. `judgeAgent` — optional judge agent
+  (defaults to the phase `agent`; use a stronger model here).
+- Fail-open: if the judge's pick is unparseable, variant 1 is returned (work is never lost).
+
+```jsonc
+{
+  "id": "headline", "type": "tournament", "agent": "executor",
+  "variants": 3, "mode": "best",
+  "judge": "Pick the clearest, most accurate headline. End with: WINNER: <n>.",
+  "task": "Write one headline for the article below.\n\n{steps.draft.output}",
+  "dependsOn": ["draft"], "final": true
+}
+```
+
+### Script phases (shell commands, zero tokens)
+
+A `script` phase runs a **shell command** directly — no subagent, no tokens — and
+captures its stdout as the phase output. Use it to anchor LLM phases to ground
+truth: builds, tests, `git`, formatters, scoring scripts. **Prefer a `script`
+phase over asking an agent to run a command** — it is cheaper, faster, and the
+output is exact.
+
+- `run` — **required**. A **string** runs through a shell; an **array** is
+  spawned directly (execvp, no shell). A string `run` containing an
+  interpolation placeholder is **rejected at validation** (shell-injection
+  guard) — use the array form or `input` for dynamic values.
+- `input` — optional text piped to stdin (supports interpolation).
+- `timeout` — optional ms cap (1000–300000, default 60000); SIGTERM → SIGKILL on expiry.
+- A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
+  No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
+  side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+
+```jsonc
+{ "id": "build", "type": "script", "run": "npm run build", "timeout": 120000 },
+{ "id": "score", "type": "script", "run": ["python", "score.py"],
+  "input": "{steps.analyze.output}", "dependsOn": ["analyze"], "final": true }
+```
+
+### Budget (cost / token caps)
+
+Add a run-wide ceiling at the top level. When accumulated cost/tokens exceed it,
+remaining phases are skipped (and an in-flight `map`/`parallel` stops spawning
+new items); the run ends as `blocked` with partial outputs preserved.
+
+```jsonc
+{ "name": "...", "budget": { "maxUSD": 1.50, "maxTokens": 2000000 }, "phases": [ ... ] }
+```
+
+**Any flow with a fan-out should have a `budget`** — a map over a
+mis-discovered 500-item array is otherwise unbounded spend.
+
+### Strict interpolation
+
+By default an unresolved placeholder (typo'd `{steps.X.output}`, missing
+`{args.Y}`) resolves to an empty string and validation issues a *warning* —
+the flow still runs, possibly doing subtly wrong work. Set
+`"strictInterpolation": true` at the flow level to promote unresolved
+placeholders and missing-dep/arg warnings to **hard errors**. Recommended for
+any flow you save — a saved flow will be run later with args you're not
+watching.
+
+## Interpolation
 
 - `{args.X}` — invocation argument
 - `{steps.ID.output}` — a prior phase's text output
@@ -403,281 +363,116 @@ plain `gate` phase with `VERDICT:` instead.
 ## Rules that make flows work
 
 1. For a `map` phase, make the upstream phase **emit a JSON array** and set
-   `output: "json"` on it. Tell that agent to output **only** JSON.
+   `output: "json"` on it. Tell that agent to output **only** JSON, and pin the
+   shape with an `expect` contract + `retry`.
 2. Give each phase a clear, single responsibility.
 3. Reference upstream results explicitly with `{steps.ID...}` and set `dependsOn`.
 4. Mark the result-bearing phase with `"final": true` (else the last phase wins).
+5. Machine checks before LLM checks: `script` for ground truth, gate `eval`
+   before gate `task`, `expect` before a downstream "did it parse?" phase.
+6. `verify` before `run` for anything non-trivial (zero tokens).
 
-## Common mistakes (the runtime will reject these at validation time)
-
-The runtime validates your flow at startup. As of v0.0.8.1, the two most
-common authoring mistakes below are **hard validation errors** (the flow
-refuses to start). Fix the flow before running it.
+## Common mistakes (the runtime rejects these at validation time)
 
 ### 1. Referencing `{steps.X}` without `dependsOn: ["X"]`
 
 ```jsonc
-// ❌ WRONG — 'fix-issues' will run in parallel with 'code-review-1' and see the
+// ❌ WRONG — 'fix-issues' runs in parallel with 'code-review-1' and sees the
 // literal string "{steps.code-review-1.output}" instead of the review text.
-{
-  "id": "code-review-1", "type": "agent", "task": "review code"
-},
-{
-  "id": "fix-issues", "type": "agent",
-  "task": "fix {steps.code-review-1.output}"   // ← no dependsOn!
-}
+{ "id": "code-review-1", "type": "agent", "task": "review code" },
+{ "id": "fix-issues", "type": "agent",
+  "task": "fix {steps.code-review-1.output}" }   // ← no dependsOn!
 ```
 
-Validation now rejects this with: `Phase 'fix-issues': task references
+Validation rejects this: `Phase 'fix-issues': task references
 {steps.code-review-1.*} but 'code-review-1' is not in dependsOn. ...`
 **Always declare the chain:**
 
 ```jsonc
 // ✅ RIGHT
-{
-  "id": "code-review-1", "type": "agent", "task": "review code"
-},
-{
-  "id": "fix-issues", "type": "agent",
+{ "id": "code-review-1", "type": "agent", "task": "review code" },
+{ "id": "fix-issues", "type": "agent",
   "task": "fix {steps.code-review-1.output}",
-  "dependsOn": ["code-review-1"]                // ← declared
-},
-{
-  "id": "code-review-2", "type": "agent",
-  "task": "re-review {steps.fix-issues.output}",
-  "dependsOn": ["fix-issues"]
-}
+  "dependsOn": ["code-review-1"] }
 ```
 
 Tip: write the `task` first (it tells you what each phase needs), then scan for
-`{steps.*}` references and add the matching `dependsOn`. If a phase truly does
-not depend on anything in its task, you can omit the reference.
-
-Exception: phases with `join: "any"` are exempt from this check, since they
-deliberately wait for only one of their declared deps to complete and may
-reference others as informational context.
+`{steps.*}` references and add the matching `dependsOn`.
+Exception: phases with `join: "any"` are exempt (they deliberately wait for only
+one dep and may reference others as informational context).
 
 ### 2. Assuming the runtime knows "this is a chain"
 
 Phase order in the `phases` array is **documentation, not execution order**.
-The DAG comes from `dependsOn`. If you list `code-review-1`, `fix-issues`,
-`code-review-2`, `fix-final` in that order with no `dependsOn`, the runtime
-treats them as four independent phases and runs all of them in **layer 0** in
-parallel. A phase that finishes first may not be the one you expected.
+The DAG comes from `dependsOn`. Four phases listed in order with no `dependsOn`
+are four **parallel** phases, all racing in layer 0. Use the shorthand `chain`
+if you literally want `a → b → c → d`, or write explicit `dependsOn`.
 
-```jsonc
-// ❌ This is not a chain — it's 4 parallel phases, all racing.
-"phases": [
-  { "id": "code-review-1", ... },
-  { "id": "fix-issues",    ... },
-  { "id": "code-review-2", ... },
-  { "id": "fix-final",     ... }
-]
-```
+### 3. Underscores in ids / invented agent names
 
-Use the shorthand if you literally just want `a → b → c → d`:
+Phase ids and agent names use **hyphens** (`audit-each`, `risk-reviewer`).
+An unknown agent name fails the phase with the list of available agents.
+Check with `action: "agents"` instead of guessing.
 
-```jsonc
-{ "chain": [
-  { "agent": "reviewer", "task": "review code" },
-  { "agent": "executor", "task": "fix {previous.output}" },
-  { "agent": "reviewer", "task": "re-review" },
-  { "agent": "executor", "task": "apply final fixes" }
-] }
-```
+## Actions (all 13)
 
-…or write the full DAG with explicit `dependsOn` (so reviewers/fixers can run
-in parallel against multiple review streams when you want that).
+| action | what it does |
+|--------|--------------|
+| `run` | Run an inline `define` or a saved `name` (+ optional `args`). Add `detach: true` for background (returns runId immediately). Add `incremental: true` to default every phase to cross-run cache reuse. |
+| `save` | Persist `define` (scope `project` default / `user`); becomes `/tf:<name>`. Project overrides user on collision. |
+| `resume` | Continue a paused/failed run by `runId`. Cache-aware: `done` phases are reused, only the unfinished tail re-runs. |
+| `list` | List saved flows. |
+| `agents` | List available agents (never invent names). |
+| `verify` | Static-check a `define` or saved `name` — cycles, missing deps, undefined refs, contract-ref typos. Zero tokens. |
+| `compile` | Render a flow as a Mermaid diagram + verification report. Zero tokens. |
+| `ir` | Compile to **FlowIR** — the canonical intermediate representation with a content hash per phase. Use to diff two versions of a flow or confirm a definition change actually changed a phase's fingerprint. Zero tokens. |
+| `provenance` | Show a completed run's **observed read-sets** — which phases actually read which upstream outputs at runtime (may be narrower than `dependsOn`). Requires `runId`. Zero tokens. |
+| `why-stale` | Given `runId` (+ optional `phaseId` as the assumed-changed seed): with no seed, prints the observed dependency graph; with a seed, computes the **transitive stale frontier** — exactly which phases would need re-running and why (observed ∪ declared edges). Zero tokens. |
+| `recompute` | Re-run **only the stale frontier** of a stored run from a seed `phaseId`. **Defaults to `dryRun: true`** (reports what would re-run, zero tokens). Pass `dryRun: false` to actually re-execute the seed + frontier and persist the updated run. |
+| `cache-clear` | Clear the cross-run memoization store. |
+| `init` | Model-roles configuration. `mode: "show"` is read-only; `apply-defaults` requires `force: true`; `interactive` needs a UI session. |
 
-### Shared Context Tree (blackboard + supervision) — opt-in
-
-By default subagents are fully isolated: they share nothing and only return a
-final output string. Opt a phase into the **Shared Context Tree** with
-`shareContext: true` (or set `contextSharing: true` at the flow level for every
-phase) to give its subagent four extra tools backed by a per-run, file-based
-blackboard:
-
-| tool | direction | use |
-|------|-----------|-----|
-| `ctx_write(key, value)` | horizontal | publish a finding so siblings/descendants can reuse it (avoid re-reading the same files) |
-| `ctx_read(key?)` | horizontal | read findings visible to this node: its own + ancestors' + **completed** other nodes' (omit `key` to list all) |
-| `ctx_report(summary, structured?)` | vertical ↑ | report a result upward to the parent |
-| `ctx_spawn(assignments[])` | vertical ↓ | delegate child tasks; after this node finishes the runtime runs each child (isolated) and **folds their reports into this phase's output**. Each assignment is either a flat `{task, agent?}` OR a `{subflow, defaultAgent?}` — an inline plan `{phases:[...]}` (a dependency-bearing DAG) the runtime validates and runs as a nested sub-flow |
-
-Visibility is eventually-consistent: a sibling's findings become visible once
-that sibling **completes** (a running sibling's half-written blackboard is
-hidden). Own findings beat ancestors' beat completed-others' on key conflicts.
-
-Use it when fan-out items share expensive context (one map item maps the repo,
-the rest read its findings), or when a task should discover work at runtime and
-delegate it (`ctx_spawn`) rather than the author pre-declaring every branch.
-
-**Spawning a sub-graph (not just flat tasks).** A `ctx_spawn` assignment can be
-a whole inline plan instead of a single task — use `subflow` when the delegated
-work has multiple coordinated steps with dependencies:
-
-```jsonc
-ctx_spawn({ assignments: [
-  { task: "quick standalone check", agent: "analyst" },          // flat task
-  { subflow: {                                                   // a DAG
-      phases: [
-        { id: "scan",  type: "agent",  agent: "scout",  task: "list endpoints" },
-        { id: "audit", type: "map",    over: "{steps.scan.json}", task: "audit {item}", dependsOn: ["scan"] },
-        { id: "sum",   type: "reduce", from: ["audit"], task: "summarize", dependsOn: ["audit"], final: true }
-      ]
-    },
-    defaultAgent: "analyst"   // inner phases without their own `agent` use this
-  }
-] })
-```
-
-The subflow is validated (cycles / dangling refs / dead-ends) before it runs;
-a bad plan fails **open** (a diagnostic is folded into the report, the run
-continues). `agent` (flat task) = who executes; `defaultAgent` (subflow) =
-fallback for inner phases — different fields because the semantics differ.
-Nesting is bounded: spawn-subflows and `flow{def}` share one depth counter
-capped at `MAX_DYNAMIC_NESTING` (5), so neither can multiply with the other.
-
-```jsonc
-{ "id": "survey", "type": "agent", "agent": "scout", "shareContext": true,
-  "task": "Map the API surface. ctx_write key 'endpoints' with the JSON list so the auditors don't re-scan." },
-{ "id": "audit", "type": "map", "over": "{steps.survey.json}", "shareContext": true,
-  "dependsOn": ["survey"], "agent": "analyst",
-  "task": "ctx_read 'endpoints' for shared context, then audit {item} for missing auth." }
-```
-
-Guards & limits: ids used with sharing must match `[A-Za-z0-9._-]+`; keys are
-`[A-Za-z0-9._-]` (≤128 chars); values ≤256 KB; ≤256 keys/node; `ctx_spawn`
-≤16 tasks/call, task ≤64 KB, depth-capped at 5. All bookkeeping is fail-open
-(it can never sink a phase) and the per-run blackboard is cleaned up with the
-run. Backward compatible: flows that don't opt in behave exactly as before.
-
-You do **not** need to teach the tools in your `task` text — enabling
-`shareContext` auto-appends usage guidance to the subagent's system prompt
-(read-first discipline, publish reusable findings, report up, delegate on
-fan-out). Mentioning a specific key in the task (e.g. "ctx_write the endpoint
-list under 'endpoints'") just makes the cross-phase contract explicit.
-
-**Producer tip (learned from real runs):** the phase that *publishes* shared
-context should be a **capable** agent (high thinking), and the `ctx_write`
-should be framed as its **primary deliverable** ("if you did not call ctx_write
-you failed the task"). A fast / `thinking: off` agent asked to "survey AND
-ctx_write" will often do the survey and skip the write. Consumers (the agents
-that `ctx_read`) can be lighter — reading is a single reliable step.
-
-## Configuration
-
-For the full set of knobs — per-phase `model`/`thinking`/`tools`/`cwd`, the
-two-level concurrency model, model/thinking/tools resolution precedence,
-`agentScope` & agent discovery, `settings.json` overrides, environment
-variables, and storage paths — read `configuration.md` (next to this file).
-
-Quick reference:
-
-- **Flow:** `name`, `description`, `concurrency` (default 8), `budget` (`maxUSD`/`maxTokens`), `agentScope` (user|project|both), `args`, `strictInterpolation`.
-- **Phase:** `model`, `thinking`, `tools` (whitelist), `cwd`, `output:"json"`, `expect` (output contract), `concurrency` (map/parallel fan-out), `when`, `join` (all|any), `retry`, `timeout` (per-call ms cap), `use`/`with` (flow), `optional` (fail-soft — a failed/blocked phase won't abort the run), `final`.
-- **Cross-run caching:** add `cache: { "scope": "cross-run" }` to a phase to memoize its output across runs (same input → instant reuse, zero tokens), or set `incremental: true` at the flow level (or pass `incremental: true` to `run`) to default every phase to cross-run reuse. See `configuration.md` for `ttl`, `fingerprint` (git/glob/file/env invalidation), scope options, and the `incremental` precedence rules.
-- **Precedence (model/thinking/tools):** phase value → agent frontmatter (resolved via `modelRoles`) → global/default.
-- **Concurrency:** same-layer phases use `flow.concurrency`; a `map`/`parallel` phase uses `phase.concurrency ?? flow.concurrency ?? 8`.
-
-### Per-item map caching (cross-run)
-
-A `map` phase with `cache: { "scope": "cross-run" }` is cached **per item**, not
-just as a whole. When one of N items changes between runs, only that item
-re-executes — the other N−1 are served from the cross-run cache for $0.
-
-```jsonc
-{ "id": "audit-each", "type": "map",
-  "over": "{steps.discover.json.files}",   // array from an upstream phase
-  "task": "audit {item}",
-  "cache": { "scope": "cross-run" },        // ← enables per-item reuse
-  "dependsOn": ["discover"], "final": true }
-```
-
-How it works:
-
-- The **whole-map** entry is still checked first (fast path): an identical
-  re-run is a single $0 hit and never enters the fan-out.
-- On a whole-map miss, each item is looked up individually before it spawns a
-  subagent; a hit returns a 0-token synthesized result. Successful fresh items
-  are recorded so a later run with that item unchanged reuses them.
-- Per-item keys fold the item's resolved task **and agent** (so changing
-  `phase.agent` invalidates every item), plus the phase sub-fingerprint,
-  `thinking`/`tools`, and any `fingerprint` entries — exactly like a standalone
-  cross-run phase.
-
-Automatic fallbacks (per-item disables and the whole-map path is used):
-
-- `shareContext: true` on the phase, or flow-wide `contextSharing: true` — a
-  sharing item can read sibling blackboard writes outside its declared deps, so
-  the per-item key would under-approximate real reads.
-- The map runs **inside a runtime-generated sub-flow** (a `flow { def }` phase
-  or a `ctx_spawn({subflow})`) — untrusted / possibly non-deterministic.
-- `scope: "run-only"` (default) or `"off"` — no persistent store to reuse from.
-
-Notes & limitations:
-
-- Duplicate items (identical task + agent) share a single entry — reuse is
-  content-addressable, not positional.
-- Failed items and **budget-skipped** items are never cached, so they always
-  re-execute on the next run.
-- `{steps.<map>.json.k}` (dot-index) indexes the k-th **successful** item (not
-  the k-th position in `over`); the merged `output` text, however, IS
-  positionally aligned with `over` (labels read `[k/N]`).
-- Within-run resume of a partially-completed map is not supported (only
-  fully-completed maps resume within a run); cross-run per-item reuse covers the
-  common case.
-
-## Actions
-
-- `action: "run"` — run an inline `define` (a one-off DAG) **or** a saved `name` (with optional `args`). Use `define` for an ad-hoc flow; use `name` to invoke something previously saved. Add `detach: true` to run in the background (returns immediately with the runId; poll the store for status).
-- `action: "save"` — persist `define` (scope `project` — default, committed/shared — or `user`); it becomes `/tf:<name>`. On a name collision, project overrides user.
-- `action: "resume"` — continue a paused/failed run by `runId`.
-- `action: "list"` — list saved flows. `action: "verify"` — static-check a `define` (zero tokens). `action: "compile"` — render a saved or inline flow as a Mermaid diagram + verification report (zero tokens, no LLM). `action: "agents"` — list available agents.
+**The incremental loop** (`ir` → `why-stale` → `recompute`) is taskflow's
+cheapest superpower: after a repo change, re-pay for only the affected phases
+of a prior run instead of re-running the whole flow. Full workflow with an
+example in `advanced.md`.
 
 ## Background (detached) runs
 
-Add `detach: true` to `action: "run"` to spawn the flow in a detached child process. The tool returns immediately with the `runId`; the flow continues running even if the host session exits. Status is polled via the store (`/tf runs` or `action: "resume"`).
+Add `detach: true` to `action: "run"` to spawn the flow in a detached child
+process. Returns immediately with the `runId`; the flow survives the host
+session exiting. Poll via `/tf runs` or resume by `runId`. Approval phases
+auto-reject in detached mode; a crashed detached process persists
+`status: "failed"` (resumable).
 
-- **Approval phases auto-reject** in detached mode (no interactive approver). Downstream phases see the rejection; the flow continues (fail-open).
-- **Crash resilience:** if the detached process crashes, the store persists `status: "failed"`; resume with `action: "resume"`.
-- **Same flow, both modes:** a flow can run foreground or background — `detach` is a dispatch-time decision, not a flow property.
+## Operating a run (lifecycle & inspection)
 
-## Operating a run (lifecycle, resume, inspection)
+A run moves through: **running →** `completed` (a `final` phase produced output)
+**/** `blocked` (gate BLOCK, approval rejected, or `budget` hit) **/** `failed`
+(a non-`optional` phase errored) **/** `paused` (aborted).
+`failed` and `paused` are resumable.
 
-A run moves through: **running →** `completed` (a `final` phase produced output) **/** `blocked` (a gate emitted BLOCK, an `approval` was rejected, or the `budget` cap was hit) **/** `failed` (a non-`optional` phase errored) **/** `paused` (the run was aborted). `failed` and `paused` runs are resumable.
-
-- **`blocked` runs:** a blocked status halts the current run — the flow status is set to `blocked` and remaining phases are skipped. Re-running the flow resumes from the last completed state: `done` phases with matching input hashes are skipped; blocked/failed/skipped phases are re-attempted. Fix the gate condition or budget before re-running.
-- **Resume is cache-aware.** `action: "resume"` re-runs only what didn't finish: every phase already `done` is reused from its recorded output (within-run cache), so resuming after a crash or a failed/blocked stop never repeats completed work. A phase that was mid-flight is re-executed cleanly (stale `error`/`endedAt` are cleared first).
-- **When to resume vs. re-run.** Resume when the inputs are unchanged and you just want to continue/retry the tail (fixed a gate, raised the budget, approved a checkpoint). Re-run from scratch when the task or upstream inputs changed — resume would reuse now-stale outputs. (For reuse *across* runs, opt a phase into `cache: {scope:"cross-run"}` — see configuration.md.)
-- **Budget mid-run.** When the run-wide `budget` is exceeded, remaining phases are skipped and an in-flight `map`/`parallel` stops spawning new items; the run ends `blocked` with the partial outputs preserved.
-- **Inspect runs.** `/tf runs` lists recent runs with status; `/tf show <name>` prints a saved flow's definition. Run state lives at `<project .pi>/taskflows/runs/<flowName>/<runId>.json` (gitignored).
-- **Peek at intermediate outputs.** `/tf peek <runId>` lists a run's phases (status + output size); `/tf peek <runId> <phaseId>` prints that phase's stored output — `--json` for the parsed JSON, `--item <n>` for one section of a map/parallel fan-out, `--limit <chars>` to adjust the hard truncation (default 4000, max 32000). Read-only and explicitly human-invoked: the context-isolation contract (only the final output enters the conversation) still holds for the LLM — peek is the debugging escape hatch when one phase of many produced garbage and you don't want to re-run the whole flow.
-
-### Output contracts (`expect`)
-
-Declare the shape a JSON-emitting phase must produce; the runtime enforces it the
-moment the subagent finishes — turning "phase completed but the shape is wrong and
-downstream silently mis-parses" into an immediate, precise failure at the source.
-
-```jsonc
-{ "id": "triage", "type": "agent", "agent": "analyst", "output": "json",
-  "task": "Classify. Output ONLY JSON {\"route\":\"deep\"|\"quick\",\"score\":0-1}.",
-  "expect": { "type": "object", "required": ["route", "score"],
-               "properties": { "route": { "enum": ["deep", "quick"] },
-                                "score": { "type": "number" } } },
-  "retry": { "max": 2, "backoffMs": 0 } }
-```
-
-- Supported keywords: `type` (object|array|string|number|integer|boolean|null),
-  `properties`, `required`, `items`, `enum`. Nested contracts compose.
-- A violation fails the phase with per-path diagnostics; with an explicit
-  `retry` the subagent gets another attempt (the diagnostic is deterministic, so
-  transient auto-retry does NOT apply).
-- Static payoff: `verify` warns when any `{steps.X.json.field}` ref names a field
-  X's contract doesn't declare — catching ref typos before a single token is spent.
+- **Resume is cache-aware.** `action: "resume"` re-runs only what didn't finish;
+  a phase that was mid-flight is re-executed cleanly.
+- **Resume vs. re-run vs. recompute.** Resume when inputs are unchanged and you
+  want to continue the tail (fixed a gate, raised the budget). Re-run from
+  scratch when the task text changed. **Recompute** when the *world* changed
+  (a file, a commit) and you want to re-pay for only the affected phases.
+- **Inspect runs.** `/tf runs` lists recent runs; `/tf show <name>` prints a
+  saved flow's definition. Run state:
+  `<project .pi>/taskflows/runs/<flowName>/<runId>.json` (gitignored).
+- **Peek at intermediate outputs.** `/tf peek <runId>` lists phases (status +
+  output size); `/tf peek <runId> <phaseId>` prints that phase's stored output —
+  `--json` for parsed JSON, `--item <n>` for one section of a fan-out,
+  `--limit <chars>` (default 4000, max 32000). Read-only, human-invoked: the
+  context-isolation contract still holds — peek is the debugging escape hatch
+  when one phase of many produced garbage.
 
 ## User commands
 
-- `/tf list` · `/tf run <name> [args]` · `/tf show <name>` · `/tf compile <name> [lr|td]` · `/tf runs` · `/tf peek <runId> [phaseId] [--json] [--item <n>] [--limit <chars>]` · `/tf resume <runId>`
+- `/tf list` · `/tf run <name> [args]` · `/tf show <name>` · `/tf runs` · `/tf resume <runId>`
+- `/tf verify` · `/tf compile <name> [lr|td]` · `/tf ir <name>`
+- `/tf peek <runId> [phaseId] [--json] [--item <n>] [--limit <chars>]`
+- `/tf provenance <runId>` · `/tf why-stale <runId> [phaseId]` · `/tf recompute <runId> <phaseId> [--apply]` (dry-run by default)
+- `/tf init` — interactive model-roles setup
 - `/tf:<name> [args]` — shortcut for each saved flow

--- a/packages/pi-taskflow/skills/taskflow/advanced.md
+++ b/packages/pi-taskflow/skills/taskflow/advanced.md
@@ -1,0 +1,256 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/advanced.md (npm run build:skills) -->
+
+# Taskflow Advanced — context sharing, dynamic sub-flows, isolation, incremental recompute
+
+Load this when a flow needs: cross-phase knowledge sharing (`shareContext`),
+runtime-generated work (`flow{def}` / `ctx_spawn`), isolated working
+directories, or surgical re-execution after the world changes
+(`ir` / `provenance` / `why-stale` / `recompute`).
+
+---
+
+## Shared Context Tree (blackboard + supervision) — opt-in
+
+By default subagents are fully isolated: they share nothing and only return a
+final output string. Opt a phase in with `shareContext: true` (or
+`contextSharing: true` at the flow level for every phase) to give its subagent
+four extra tools backed by a per-run, file-based blackboard:
+
+| tool | direction | use |
+|------|-----------|-----|
+| `ctx_write(key, value)` | horizontal | publish a finding so siblings/descendants can reuse it (avoid re-reading the same files) |
+| `ctx_read(key?)` | horizontal | read findings visible to this node: its own + ancestors' + **completed** other nodes' (omit `key` to list all) |
+| `ctx_report(summary, structured?)` | vertical ↑ | report a result upward to the parent |
+| `ctx_spawn(assignments[])` | vertical ↓ | delegate child tasks; after this node finishes the runtime runs each child (isolated) and **folds their reports into this phase's output**. Each assignment is either a flat `{task, agent?}` OR a `{subflow, defaultAgent?}` — an inline plan `{phases:[...]}` the runtime validates and runs as a nested sub-flow |
+
+Visibility is eventually-consistent: a sibling's findings become visible once
+that sibling **completes** (a running sibling's half-written blackboard is
+hidden). Own findings beat ancestors' beat completed-others' on key conflicts.
+
+**When to use:** fan-out items share expensive context (one map item maps the
+repo, the rest read its findings), or a task should discover work at runtime
+and delegate it (`ctx_spawn`) rather than the author pre-declaring every branch.
+
+```jsonc
+{ "id": "survey", "type": "agent", "agent": "scout", "shareContext": true,
+  "task": "Map the API surface. ctx_write key 'endpoints' with the JSON list so the auditors don't re-scan." },
+{ "id": "audit", "type": "map", "over": "{steps.survey.json}", "shareContext": true,
+  "dependsOn": ["survey"], "agent": "analyst",
+  "task": "ctx_read 'endpoints' for shared context, then audit {item} for missing auth." }
+```
+
+**Spawning a sub-graph (not just flat tasks).** A `ctx_spawn` assignment can be
+a whole inline plan — use `subflow` when the delegated work has multiple
+coordinated steps with dependencies:
+
+```jsonc
+ctx_spawn({ assignments: [
+  { task: "quick standalone check", agent: "analyst" },          // flat task
+  { subflow: {                                                   // a DAG
+      phases: [
+        { id: "scan",  type: "agent",  agent: "scout",  task: "list endpoints" },
+        { id: "audit", type: "map",    over: "{steps.scan.json}", task: "audit {item}", dependsOn: ["scan"] },
+        { id: "sum",   type: "reduce", from: ["audit"], task: "summarize", dependsOn: ["audit"], final: true }
+      ]
+    },
+    defaultAgent: "analyst"   // inner phases without their own `agent` use this
+  }
+] })
+```
+
+The subflow is validated (cycles / dangling refs / dead-ends) before it runs; a
+bad plan fails **open** (a diagnostic is folded into the report, the run
+continues). `agent` (flat task) = who executes; `defaultAgent` (subflow) =
+fallback for inner phases. Nesting is bounded: spawn-subflows and `flow{def}`
+share one depth counter capped at 5.
+
+**Guards & limits:** ids used with sharing must match `[A-Za-z0-9._-]+`; keys
+are `[A-Za-z0-9._-]` (≤128 chars); values ≤256 KB; ≤256 keys/node; `ctx_spawn`
+≤16 tasks/call, task ≤64 KB, depth ≤5. All bookkeeping is fail-open (it can
+never sink a phase); the per-run blackboard is cleaned up with the run.
+
+You do **not** need to teach the tools in your `task` text — enabling
+`shareContext` auto-appends usage guidance to the subagent's system prompt.
+Mentioning a specific key in the task ("ctx_write the endpoint list under
+'endpoints'") just makes the cross-phase contract explicit.
+
+**Producer tip (learned from real runs):** the phase that *publishes* shared
+context should be a **capable** agent (high thinking), and the `ctx_write`
+should be framed as its **primary deliverable** ("if you did not call ctx_write
+you failed the task"). A fast / `thinking: off` agent asked to "survey AND
+ctx_write" will often do the survey and skip the write. Consumers can be
+lighter — reading is a single reliable step.
+
+**Caching interaction:** `shareContext: true` disables per-item map caching
+(a sharing item can read sibling writes outside its declared deps, so the
+per-item key would under-approximate real reads). The whole-map cache path
+still applies.
+
+---
+
+## Dynamic sub-flows (`flow{def}`) — the full contract
+
+A `flow` phase with `def` resolves a sub-flow **at runtime**, usually from an
+upstream phase's JSON output. The runtime interpolates + JSON-parses the `def`,
+validates it, then runs it nested. This is how a planner decides at runtime
+what work to spawn — with each generated plan checked before it spends a token.
+
+```jsonc
+{ "id": "plan", "type": "agent", "agent": "planner", "output": "json",
+  "task": "Scan the repo. Output ONLY JSON {\"name\":\"audit\",\"phases\":[...]} — one audit phase per file." },
+{ "id": "run", "type": "flow", "def": "{steps.plan.json}", "optional": true,
+  "dependsOn": ["plan"], "final": true }
+```
+
+**LLM output contract for `def`** (put this in the planner's task):
+- A *full* Taskflow `{"name":"...","phases":[...]}`, a bare `phases` array, or
+  `{"phases":[...]}` — pure JSON (a ```json fence is tolerated and stripped).
+- Hyphens in ids, never underscores.
+- Sub-flow phases reference each other in their **own** `{steps.x.output}`
+  namespace (no parent-id prefixing).
+- An **empty** `phases` array is a valid no-op (the planner decided there's
+  nothing to do).
+
+**Security caps on generated flows** (validation rejects; tell the planner not
+to emit these so a retry isn't wasted):
+- **No `script` phases** — shell execution from an LLM-authored plan is an RCE
+  vector; only author-written flows may use `script`.
+- **No workspace `cwd` keywords** (`temp`/`dedicated`/`worktree`) and no `cwd`
+  escaping the run directory.
+- Breadth caps: ≤100 phases, concurrency ≤16 (flow and per-phase).
+- Depth: inline nesting capped at 5 (shared with `ctx_spawn` subflows).
+
+**Fail-open semantics:** if the `def` doesn't parse, has the wrong shape, or
+fails validation, the phase completes with `status: "done"` and a `defError`
+diagnostic field; downstream phases receive empty output and the run continues.
+Design for it:
+- Add `optional: true` on the flow phase so a bad plan never aborts the run.
+- Want a hard stop instead? Add a downstream gate:
+  `{ "type": "gate", "eval": ["{steps.run.output} != "], "task": "…VERDICT: BLOCK if the plan failed." }`
+
+**Iterative replanning** — pair `flow{def}` with a `loop` whose body emits the
+next plan from the previous round's result: the declarative equivalent of
+`for (...) { read result; decide next }`. See `examples/dynamic-plan-execute.json`
+and `examples/iterative-replan.json`.
+
+---
+
+## Workspace isolation (`cwd` keywords)
+
+A phase's `cwd` is normally a literal path (or inherited from the run). Three
+**reserved keywords** ask the runtime to allocate an isolated working directory
+for the phase's subagent and tear it down afterwards — scratch work or file
+mutation without touching the main tree:
+
+| `cwd` value | what the runtime does | lifecycle |
+|-------------|-----------------------|-----------|
+| `"temp"` | ephemeral dir under the OS tmpdir | removed when the phase finishes |
+| `"dedicated"` | persistent dir under the run state (`runs/ws/<runId>/<phaseId>`) | **kept** for inspection; deterministic per phase (resume reuses it) |
+| `"worktree"` | `git worktree add` on a throwaway branch off `HEAD` | `git worktree remove` + branch delete when the phase finishes |
+
+```jsonc
+{ "id": "experiment", "type": "agent", "agent": "executor", "cwd": "worktree",
+  "task": "Try the risky refactor and run the tests. Your edits are isolated in a git worktree." }
+```
+
+- **Fail-open.** If allocation fails (e.g. `worktree` outside a git tree), the
+  phase degrades — `worktree`→`temp`, any other failure → the base cwd — with a
+  `warnings` diagnostic. A phase never fails to run because of isolation.
+- **Security.** Keywords are honoured only in **author-written** flows; a
+  generated plan (`flow{def}` / `ctx_spawn` subflow) requesting one is rejected
+  at validation.
+- A literal path passes through unchanged.
+
+**Pattern — competing experiments in worktrees:** run two `parallel` branches,
+each `cwd: "worktree"`, each attempting a different refactor strategy and
+reporting its test results; a downstream gate/judge picks which diff to apply
+for real. The main tree is never touched by the losers.
+
+---
+
+## Incremental recompute suite (`ir` / `provenance` / `why-stale` / `recompute`)
+
+Taskflow's cheapest superpower: after the world changes, re-pay for **only the
+affected phases** of a stored run instead of re-running the flow.
+
+Two complementary planes:
+
+| Plane | Mechanism | Answers |
+|-------|-----------|---------|
+| **Declared** | `dependsOn` ∪ `{steps.X}` refs in the definition | "what *could* depend on what" |
+| **Observed** | read-sets recorded at runtime (which upstream outputs a phase actually consumed) | "what *did* depend on what" |
+
+`why-stale` and `recompute` use the **union** (observed ∪ declared) so the
+frontier is sound even for runs made before observation existed.
+
+### The workflow
+
+```
+1. taskflow { action: "ir", name: "security-sweep" }
+     → FlowIR: canonical form + a content hash per phase.
+       Diff two versions of a flow; confirm an edit actually changed a
+       phase's fingerprint (identical hash ⇒ cache-hit eligible).
+
+2. taskflow { action: "provenance", runId: "<id>" }
+     → the run's observed read-sets: who actually read what.
+
+3. taskflow { action: "why-stale", runId: "<id>", phaseId: "discover" }
+     → the transitive stale frontier if 'discover' is assumed changed —
+       exactly which phases would re-run and the edge that makes each stale.
+       Omit phaseId to print the whole observed dependency graph.
+
+4. taskflow { action: "recompute", runId: "<id>", phaseId: "discover" }
+     → DRY-RUN by default: reports what would re-execute, zero tokens.
+
+5. taskflow { action: "recompute", runId: "<id>", phaseId: "discover", "dryRun": false }
+     → actually re-runs the seed + stale frontier, reuses every non-stale
+       phase's stored output, persists the updated run.
+       An aborted recompute never overwrites the original run.
+```
+
+CLI equivalents: `/tf ir <name>` · `/tf provenance <runId>` ·
+`/tf why-stale <runId> [phaseId]` · `/tf recompute <runId> <phaseId> [--apply]`.
+
+### When to reach for which reuse mechanism
+
+| Situation | Mechanism |
+|-----------|-----------|
+| Run crashed / gate blocked / budget hit — inputs unchanged | `action: "resume"` (within-run cache) |
+| The flow will be re-run repeatedly as the repo evolves | `incremental: true` + `cache.fingerprint` (cross-run cache — `configuration.md` §8) |
+| One phase of a completed run is now wrong/stale (a file changed, you edited one task) | `why-stale` → `recompute` (surgical, keeps the same run) |
+| The definition changed structurally | fresh `run` (compare `ir` hashes to see what changed) |
+| Cache serving stale results you can't explain | `provenance` to see real reads; `cache-clear` as the last resort |
+
+### Worked example
+
+A 12-phase nightly audit run completed yesterday. Today `src/auth/session.ts`
+changed. Instead of re-running all 12 phases:
+
+```
+/tf why-stale run-xyz discover
+  → Stale frontier (transitive, 4 phases):
+    ■ discover        (changed — seed)
+    ■ audit           ← reads discover
+    ■ screen          ← reads audit
+    ■ report          ← reads screen (declared)
+/tf recompute run-xyz discover --apply
+  → re-runs 4 phases, reuses 8, persists the updated run.
+```
+
+The other 8 phases (dependency summary, license scan, …) are served from the
+stored run at $0.
+
+---
+
+## `init` — model roles setup
+
+`action: "init"` manages the `modelRoles` map (`{{fast}}` / `{{strong}}` / …
+placeholders in agent frontmatter → real model ids):
+
+- `mode: "show"` (default) — read-only report of current roles.
+- `mode: "apply-defaults"` — writes recommended defaults; **requires
+  `force: true`** (destructive: overwrites `modelRoles` in settings.json).
+- `mode: "interactive"` — requires a UI session (`/tf init` is the human path).
+
+If phases fail with `Model metadata for {{fast}} not found`, roles are
+unconfigured — run `/tf init`.

--- a/packages/pi-taskflow/skills/taskflow/patterns.md
+++ b/packages/pi-taskflow/skills/taskflow/patterns.md
@@ -1,0 +1,287 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/patterns.md (npm run build:skills) -->
+
+# Taskflow Patterns — proven archetypes & the production checklist
+
+Read this when designing a flow with ≥ 4 phases, a gate, or any fan-out.
+Each archetype below is a complete, runnable shape distilled from real runs.
+Copy the closest one and adapt — don't design from a blank page.
+
+---
+
+## The production-flow checklist
+
+Before running a flow you designed, check it against this list. Every item is
+cheap to add and each one has prevented a real failure class:
+
+- [ ] **`verify` first.** Run the static verifier (pi: `action: "verify"` /
+      Codex: `taskflow_verify`) — zero tokens,
+      catches cycles / missing deps / ref typos / contract mismatches.
+- [ ] **Every JSON-emitting phase has `expect` + `retry`.** "Output ONLY JSON"
+      in the task text is a request; `expect` is enforcement. Without it, a
+      malformed router output silently skips both branches.
+- [ ] **Machine checks before LLM checks.** `script` phases for build/test
+      ground truth; gate `eval` assertions before the gate's LLM `task`. A
+      token spent verifying what a shell command can verify is a wasted token.
+- [ ] **`budget` on any flow with a fan-out.** A map over a mis-discovered
+      500-item array is unbounded spend without one.
+- [ ] **`optional: true` + a fallback for degradable phases.** An enrichment
+      phase that times out shouldn't sink the run — pair `timeout` +
+      `optional` with a downstream `when`-guarded fallback.
+- [ ] **Exactly one `final: true`** on the result-bearing phase.
+- [ ] **`strictInterpolation: true` on any flow you save.** Saved flows run
+      later with args you're not watching; unresolved placeholders must be
+      errors, not empty strings.
+- [ ] **Discovery phases are cheap and sandboxed.** `agent: "scout"`,
+      `tools: ["read","grep","ls"]`, low thinking. Don't pay executor prices
+      for `ls`.
+- [ ] **The reviewer is not the producer.** A gate reviewing phase X uses a
+      different agent (ideally a different model) than X. Self-review passes
+      ~everything.
+- [ ] **Re-runnable flows are `incremental: true`** with `fingerprint` entries
+      on phases that read the world (`git:HEAD`, `glob!:src/**/*.ts`). See
+      `advanced.md`.
+
+---
+
+## Archetype 1: Audit fan-out (discover → map → gate → reduce)
+
+The workhorse. Use for: audit every endpoint / migrate every file /
+summarize every module.
+
+```jsonc
+{
+  "name": "audit-endpoints",
+  "strictInterpolation": true,
+  "budget": { "maxUSD": 3.00 },
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout",
+      "tools": ["read", "grep", "ls"],
+      "task": "List every HTTP endpoint under src/routes. Output ONLY a JSON array [{\"route\":\"...\",\"file\":\"...\"}]. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object", "required": ["route", "file"] } },
+      "retry": { "max": 2, "backoffMs": 0 } },
+
+    { "id": "audit", "type": "map", "over": "{steps.discover.json}", "as": "item",
+      "agent": "analyst", "concurrency": 4,
+      "task": "Audit {item.route} in {item.file} for missing auth. Report: SEVERITY (high/med/low/none), evidence (file:line), fix.",
+      "dependsOn": ["discover"] },
+
+    { "id": "screen", "type": "gate", "agent": "reviewer",
+      "task": "Cross-check the findings below. Delete false positives (cite why). If ANY confirmed HIGH remains, end with VERDICT: BLOCK and list them; else VERDICT: PASS.\n\n{steps.audit.output}",
+      "dependsOn": ["audit"] },
+
+    { "id": "report", "type": "reduce", "from": ["screen"], "agent": "doc-writer",
+      "task": "Write a prioritized remediation report from:\n{steps.screen.output}",
+      "dependsOn": ["screen"], "final": true }
+  ]
+}
+```
+
+Why each piece: `expect`+`retry` on discover means a chatty scout gets a second
+chance instead of feeding garbage to the map; `concurrency: 4` protects rate
+limits; the gate is a *different* agent than the auditor; `budget` bounds the
+fan-out.
+
+**Variant — per-item caching for repeated audits:** add
+`"cache": { "scope": "cross-run" }` to the map phase. On the next run, only
+items whose task text changed re-execute; the rest are $0 cache hits.
+(Details: `configuration.md` §8.)
+
+---
+
+## Archetype 2: Self-healing implement→verify→rework
+
+Use for: implement against acceptance criteria, fix-until-green.
+The gate re-runs its upstream on BLOCK — a generate→critique→regenerate loop
+without you writing a loop.
+
+```jsonc
+{
+  "name": "implement-verified",
+  "budget": { "maxUSD": 5.00 },
+  "phases": [
+    { "id": "implement", "type": "agent", "agent": "executor-code",
+      "task": "Implement the feature per the spec in docs/spec.md. Run nothing; just edit." },
+
+    { "id": "build-test", "type": "script",
+      "run": "npx tsc --noEmit && npm test 2>&1 | tail -20",
+      "timeout": 180000, "dependsOn": ["implement"] },
+
+    { "id": "spec-gate", "type": "gate", "agent": "reviewer",
+      "onBlock": "retry", "retry": { "max": 3 },
+      "eval": ["{steps.build-test.output} contains pass"],
+      "task": "Build/test output:\n{steps.build-test.output}\n\nDoes the implementation satisfy ALL acceptance criteria in docs/spec.md? VERDICT: PASS, or VERDICT: BLOCK with a precise list of what to fix.",
+      "dependsOn": ["implement", "build-test"] },
+
+    { "id": "summary", "type": "agent", "agent": "doc-writer",
+      "task": "Summarize what was implemented and the verification result:\n{steps.spec-gate.output}",
+      "dependsOn": ["spec-gate"], "final": true }
+  ]
+}
+```
+
+Key mechanics: on BLOCK, `spec-gate` re-runs **both** its `dependsOn` upstreams
+(`implement` gets the blocker's reasons via re-interpolation, `build-test`
+re-verifies), up to 3 rounds. The `eval` line means a green build+test skips
+the LLM review entirely on the happy path.
+
+**Verification phases: force structured output.** LLMs are bad at
+*summarizing* shell output (234 tests read as 230) but good at *copying*
+structured data. If a verification step must go through an agent (not a
+`script`), demand `key=value` lines:
+
+```
+Report EXACTLY in this format (one key=value per line, no prose):
+typecheck=PASS|FAIL
+tests_total=N
+tests_fail=N
+If any field is missing, you failed the task — re-run and re-read.
+```
+
+Prefer a `script` phase whenever the check is a command — exact, free, fast.
+
+---
+
+## Archetype 3: Plan → human approval → execute
+
+Use for: anything expensive or destructive where a human should see the plan
+before the spend. The approval's **Edit** option injects mid-run guidance.
+
+```jsonc
+{
+  "name": "guarded-migration",
+  "phases": [
+    { "id": "plan", "type": "agent", "agent": "planner",
+      "task": "Plan the migration of src/legacy/* to the new API. List each file, the change, and the risk." },
+
+    { "id": "checkpoint", "type": "approval",
+      "task": "Migration plan:\n\n{steps.plan.output}\n\nApprove to execute, reject to abort, or edit to add constraints.",
+      "dependsOn": ["plan"] },
+
+    { "id": "execute", "type": "agent", "agent": "executor-code",
+      "task": "Execute the migration plan:\n{steps.plan.output}\n\nOperator guidance (if any): {steps.checkpoint.output}",
+      "dependsOn": ["checkpoint"] },
+
+    { "id": "verify", "type": "script", "run": "npx tsc --noEmit && npm test 2>&1 | tail -5",
+      "timeout": 180000, "dependsOn": ["execute"], "final": true }
+  ]
+}
+```
+
+Note `{steps.checkpoint.output}` — on Edit it carries the operator's note; on
+Approve it's `(approve)`. Don't use approval in detached/headless runs (it
+auto-rejects there — by design).
+
+---
+
+## Archetype 4: Dynamic plan → execute (`flow{def}`)
+
+Use when the *work itself* must be discovered at runtime — the planner emits a
+whole sub-flow as JSON and the runtime validates + runs it. The declarative
+answer to "loop over whatever we find".
+
+```jsonc
+{
+  "name": "dynamic-audit",
+  "budget": { "maxUSD": 4.00 },
+  "phases": [
+    { "id": "plan", "type": "agent", "agent": "planner", "output": "json",
+      "task": "Scan this repo. Output ONLY a JSON taskflow {\"name\":\"sub\",\"phases\":[...]} with one 'agent' phase per module that needs auditing (agent: \"analyst\"), plus a final 'reduce' phase (agent: \"doc-writer\", from: [all audit ids], final: true). Use hyphens in ids. No script phases, no cwd fields.",
+      "expect": { "type": "object", "required": ["name", "phases"] },
+      "retry": { "max": 2, "backoffMs": 0 } },
+
+    { "id": "run-plan", "type": "flow", "def": "{steps.plan.json}",
+      "optional": true, "dependsOn": ["plan"] },
+
+    { "id": "deliver", "type": "agent", "agent": "doc-writer",
+      "task": "Final result (empty means the plan failed validation — say so):\n{steps.run-plan.output}",
+      "dependsOn": ["run-plan"], "final": true }
+  ]
+}
+```
+
+Critical details (full contract in `advanced.md`): a bad plan **fails open**
+(`defError` diagnostic, empty output downstream) — `optional: true` + the
+`deliver` phase turn that into a graceful report instead of a dead run. The
+planner prompt must forbid what validation will reject anyway (`script`
+phases, workspace `cwd` keywords) so the plan doesn't waste a retry.
+
+**Iterative replanning:** wrap a plan-emitting body in a `loop` so round N's
+plan reacts to round N−1's result — see `examples/iterative-replan.json`.
+
+---
+
+## Archetype 5: Tournament for one-shot-unreliable work
+
+Use when quality varies run-to-run (naming, copywriting, tricky refactor
+strategy, root-cause hypotheses). Branches > variants when you want genuinely
+different *approaches* judged against each other.
+
+```jsonc
+{
+  "id": "strategy", "type": "tournament", "mode": "best",
+  "judgeAgent": "final-arbiter",
+  "judge": "Judge on: correctness under concurrent access, blast radius, migration cost. Quote evidence. End with WINNER: <n>.",
+  "branches": [
+    { "task": "Design the cache-invalidation fix with a conservative approach: minimal diff, no schema change.", "agent": "analyst" },
+    { "task": "Design the fix assuming we can change the schema: optimal correctness.", "agent": "analyst" },
+    { "task": "Design the fix as an adversary: what will break each obvious approach? Then propose the one that survives.", "agent": "critic" }
+  ],
+  "dependsOn": ["context"], "final": true
+}
+```
+
+Give the judge a **rubric with named criteria**, a stronger model
+(`judgeAgent`), and an exact terminator (`WINNER: <n>`). `mode: "aggregate"`
+instead merges all variants — good for research synthesis, bad for decisions.
+
+---
+
+## Archetype 6: Incremental repo-watch audit (cross-run)
+
+Use for flows you'll re-run as the repo evolves. First run pays full price;
+subsequent runs re-pay only for what changed.
+
+```jsonc
+{
+  "name": "security-sweep",
+  "incremental": true,
+  "budget": { "maxUSD": 3.00 },
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "output": "json",
+      "task": "List all files handling user input. Output ONLY a JSON array of paths.",
+      "expect": { "type": "array" },
+      "cache": { "scope": "cross-run", "fingerprint": ["glob!:src/**/*.ts"] } },
+    { "id": "audit", "type": "map", "over": "{steps.discover.json}",
+      "agent": "security-reviewer", "task": "Audit {item} for injection/authz issues.",
+      "cache": { "scope": "cross-run" },
+      "dependsOn": ["discover"] },
+    { "id": "report", "type": "reduce", "from": ["audit"], "agent": "doc-writer",
+      "task": "Prioritized findings report:\n{steps.audit.output}",
+      "dependsOn": ["audit"], "final": true }
+  ]
+}
+```
+
+The `glob!:` fingerprint makes `discover` a cache miss only when file
+*contents* change; the map's per-item cache means one changed file re-audits
+one item.
+For surgically re-running part of an **existing** run after a change,
+use `why-stale` → `recompute` instead of a fresh run — see `advanced.md`.
+
+---
+
+## Anti-patterns (seen in real flows)
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|--------------|-----|
+| One mega-phase doing discover+audit+report | No parallelism, no caching granularity, one failure loses everything | Split along the archetype-1 shape |
+| Gate whose task doesn't demand a `VERDICT:` terminator | Ambiguity fails open → gate silently always passes | End every gate task with the exact verdict instruction |
+| Router phase without `expect` enum | `"Deep"` vs `"deep"` → both `when` branches skip, `join:"any"` reduce gets nothing | `expect: { properties: { route: { enum: [...] } } }` + `retry` |
+| Agent phase that just runs a shell command | Tokens spent, output paraphrased inaccurately | `script` phase |
+| Same agent produces and reviews | Self-review passes everything | Different agent (ideally model) for the gate |
+| Fan-out with no `budget` and no `concurrency` cap | Unbounded spend + rate-limit storms | `budget` + `phase.concurrency` |
+| `dependsOn` declared but output never referenced | The downstream agent doesn't see the upstream's work — dependency ≠ data flow | Interpolate `{steps.X.output}` into the task (or `context`) |
+| Saving a flow without `strictInterpolation` | Later invocations with wrong args silently run on empty strings | `strictInterpolation: true` before saving |
+| `map` over `{steps.X.output}` (text, not json) | `over` must resolve to an array | `output: "json"` upstream + `over: "{steps.X.json}"` |
+| Deep `chain` where steps don't need each other's output | Serialized latency for no reason | `tasks` (parallel) or a DAG with real edges only |

--- a/packages/pi-taskflow/test/skills-build.test.ts
+++ b/packages/pi-taskflow/test/skills-build.test.ts
@@ -1,0 +1,53 @@
+// Guard: the generated skill files (pi + codex) must match what
+// scripts/build-skills.mjs produces from skills-src/taskflow/.
+//
+// The skills are authored ONCE in skills-src/ (single source of truth) and
+// compiled per host. Editing a generated file directly, or editing the source
+// without rebuilding, silently forks the two hosts' documentation — this test
+// makes that a CI failure. Fix with: node scripts/build-skills.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+test("skills: generated skill files are in sync with skills-src (build-skills --check)", () => {
+	try {
+		execFileSync(process.execPath, [path.join(root, "scripts", "build-skills.mjs"), "--check"], {
+			cwd: root,
+			stdio: "pipe",
+		});
+	} catch (e) {
+		const err = e as { stdout?: Buffer; stderr?: Buffer };
+		const out = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+		assert.fail(`generated skill files drifted from skills-src:\n${out}\nRun: node scripts/build-skills.mjs`);
+	}
+});
+
+test("skills: host-conditional filtering removed the other host's content", async () => {
+	const { readFileSync } = await import("node:fs");
+	const piSkill = readFileSync(path.join(root, "packages", "pi-taskflow", "skills", "taskflow", "SKILL.md"), "utf8");
+	const cxSkill = readFileSync(
+		path.join(root, "packages", "codex-taskflow", "plugin", "skills", "taskflow", "SKILL.md"),
+		"utf8",
+	);
+	// No leftover markers in either output.
+	for (const [name, text] of [["pi", piSkill], ["codex", cxSkill]] as const) {
+		assert.ok(!/<!--\s*\/?host:/.test(text), `${name} SKILL.md must not contain host markers`);
+	}
+	// pi teaches its 13 actions; codex must not (they're unreachable via MCP).
+	assert.match(piSkill, /Actions \(all 13\)/);
+	assert.doesNotMatch(cxSkill, /Actions \(all 13\)/);
+	assert.doesNotMatch(cxSkill, /action: "recompute"/);
+	// codex teaches the MCP tools; pi must not.
+	assert.match(cxSkill, /taskflow_verify/);
+	assert.doesNotMatch(piSkill, /taskflow_verify/);
+	// Both share the same core: flow design ladder + common-mistakes section.
+	for (const text of [piSkill, cxSkill]) {
+		assert.match(text, /Flow design ladder/);
+		assert.match(text, /Referencing `\{steps\.X\}` without `dependsOn/);
+	}
+});

--- a/scripts/build-skills.mjs
+++ b/scripts/build-skills.mjs
@@ -1,0 +1,119 @@
+// Single-source skill builder.
+//
+// skills-src/taskflow/ is the ONLY place skill content is authored:
+//   entry.pi.md      — pi frontmatter + host binding preamble
+//   entry.codex.md   — codex frontmatter + MCP tool table preamble
+//   core.md          — the shared body (host-conditional blocks allowed)
+//   patterns.md, advanced.md, configuration.md — shared companions
+//
+// Host-conditional blocks use HTML comment markers on their own lines:
+//   <!-- host:pi -->    …pi-only content…    <!-- /host:pi -->
+//   <!-- host:codex --> …codex-only content… <!-- /host:codex -->
+// A block is kept when its host matches the build target; marker lines are
+// always stripped. Nesting is not supported (build error).
+//
+// Outputs (generated, committed; drift-guarded by skills-build.test.ts):
+//   packages/pi-taskflow/skills/taskflow/{SKILL.md,patterns.md,advanced.md,configuration.md}
+//   packages/codex-taskflow/plugin/skills/taskflow/{SKILL.md,patterns.md,advanced.md,configuration.md}
+//
+// Usage: node scripts/build-skills.mjs [--check]
+//   --check: exit 1 if any generated file differs from what's on disk.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..");
+const srcDir = join(root, "skills-src", "taskflow");
+
+const HOSTS = ["pi", "codex"];
+const COMPANIONS = ["patterns.md", "advanced.md", "configuration.md"];
+const OUT_DIRS = {
+	pi: join(root, "packages", "pi-taskflow", "skills", "taskflow"),
+	codex: join(root, "packages", "codex-taskflow", "plugin", "skills", "taskflow"),
+};
+
+const GENERATED_BANNER = (src) =>
+	`<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/${src} (npm run build:skills) -->\n`;
+
+/** Keep/drop host-conditional blocks for `host`; strip marker lines. */
+function filterForHost(text, host, file) {
+	const out = [];
+	let active = null; // host name of the block we're inside, or null
+	let openLine = 0;
+	const lines = text.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const open = line.match(/^\s*<!--\s*host:(\w+)\s*-->\s*$/);
+		const close = line.match(/^\s*<!--\s*\/host:(\w+)\s*-->\s*$/);
+		if (open) {
+			if (active) throw new Error(`${file}:${i + 1}: nested host block (opened at line ${openLine})`);
+			if (!HOSTS.includes(open[1])) throw new Error(`${file}:${i + 1}: unknown host '${open[1]}'`);
+			active = open[1];
+			openLine = i + 1;
+			continue;
+		}
+		if (close) {
+			if (!active) throw new Error(`${file}:${i + 1}: closing marker without an open block`);
+			if (close[1] !== active) throw new Error(`${file}:${i + 1}: mismatched close (open='${active}')`);
+			active = null;
+			continue;
+		}
+		if (active === null || active === host) out.push(line);
+	}
+	if (active) throw new Error(`${file}: unclosed host block '${active}' opened at line ${openLine}`);
+	// Collapse runs of 3+ blank lines left behind by dropped blocks.
+	return out.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+function read(name) {
+	const p = join(srcDir, name);
+	if (!existsSync(p)) throw new Error(`missing source file: ${p}`);
+	return readFileSync(p, "utf8");
+}
+
+export function buildAll() {
+	const core = read("core.md");
+	const files = []; // { path, content }
+	for (const host of HOSTS) {
+		const entry = read(`entry.${host}.md`);
+		// SKILL.md = frontmatter+preamble (entry) + filtered shared body.
+		const skill =
+			entry.replace(/^(---\n[\s\S]*?\n---\n)/, `$1\n${GENERATED_BANNER(`entry.${host}.md + core.md`)}`).trimEnd() +
+			"\n\n" +
+			filterForHost(core, host, "core.md").trim() +
+			"\n";
+		files.push({ path: join(OUT_DIRS[host], "SKILL.md"), content: skill });
+		for (const c of COMPANIONS) {
+			const body = GENERATED_BANNER(c) + "\n" + filterForHost(read(c), host, c).trim() + "\n";
+			files.push({ path: join(OUT_DIRS[host], c), content: body });
+		}
+	}
+	return files;
+}
+
+const check = process.argv.includes("--check");
+const files = buildAll();
+let drift = 0;
+for (const f of files) {
+	const rel = f.path.slice(root.length + 1);
+	if (check) {
+		const current = existsSync(f.path) ? readFileSync(f.path, "utf8") : "<missing>";
+		if (current !== f.content) {
+			console.error(`[build-skills] DRIFT: ${rel}`);
+			drift++;
+		}
+	} else {
+		mkdirSync(dirname(f.path), { recursive: true });
+		writeFileSync(f.path, f.content);
+		console.log(`[build-skills] wrote ${rel}`);
+	}
+}
+if (check) {
+	if (drift) {
+		console.error(`\n[build-skills] ${drift} file(s) out of date — run: node scripts/build-skills.mjs`);
+		process.exit(1);
+	}
+	console.log("[build-skills] all generated skill files up to date");
+}

--- a/skills-src/taskflow/advanced.md
+++ b/skills-src/taskflow/advanced.md
@@ -1,0 +1,266 @@
+<!-- host:pi -->
+# Taskflow Advanced — context sharing, dynamic sub-flows, isolation, incremental recompute
+
+Load this when a flow needs: cross-phase knowledge sharing (`shareContext`),
+runtime-generated work (`flow{def}` / `ctx_spawn`), isolated working
+directories, or surgical re-execution after the world changes
+(`ir` / `provenance` / `why-stale` / `recompute`).
+<!-- /host:pi -->
+<!-- host:codex -->
+# Taskflow Advanced — dynamic sub-flows & workspace isolation
+
+Load this when a flow needs: runtime-generated work (`flow{def}`) or isolated
+working directories (`cwd: temp/dedicated/worktree`).
+<!-- /host:codex -->
+
+---
+
+<!-- host:pi -->
+## Shared Context Tree (blackboard + supervision) — opt-in
+
+By default subagents are fully isolated: they share nothing and only return a
+final output string. Opt a phase in with `shareContext: true` (or
+`contextSharing: true` at the flow level for every phase) to give its subagent
+four extra tools backed by a per-run, file-based blackboard:
+
+| tool | direction | use |
+|------|-----------|-----|
+| `ctx_write(key, value)` | horizontal | publish a finding so siblings/descendants can reuse it (avoid re-reading the same files) |
+| `ctx_read(key?)` | horizontal | read findings visible to this node: its own + ancestors' + **completed** other nodes' (omit `key` to list all) |
+| `ctx_report(summary, structured?)` | vertical ↑ | report a result upward to the parent |
+| `ctx_spawn(assignments[])` | vertical ↓ | delegate child tasks; after this node finishes the runtime runs each child (isolated) and **folds their reports into this phase's output**. Each assignment is either a flat `{task, agent?}` OR a `{subflow, defaultAgent?}` — an inline plan `{phases:[...]}` the runtime validates and runs as a nested sub-flow |
+
+Visibility is eventually-consistent: a sibling's findings become visible once
+that sibling **completes** (a running sibling's half-written blackboard is
+hidden). Own findings beat ancestors' beat completed-others' on key conflicts.
+
+**When to use:** fan-out items share expensive context (one map item maps the
+repo, the rest read its findings), or a task should discover work at runtime
+and delegate it (`ctx_spawn`) rather than the author pre-declaring every branch.
+
+```jsonc
+{ "id": "survey", "type": "agent", "agent": "scout", "shareContext": true,
+  "task": "Map the API surface. ctx_write key 'endpoints' with the JSON list so the auditors don't re-scan." },
+{ "id": "audit", "type": "map", "over": "{steps.survey.json}", "shareContext": true,
+  "dependsOn": ["survey"], "agent": "analyst",
+  "task": "ctx_read 'endpoints' for shared context, then audit {item} for missing auth." }
+```
+
+**Spawning a sub-graph (not just flat tasks).** A `ctx_spawn` assignment can be
+a whole inline plan — use `subflow` when the delegated work has multiple
+coordinated steps with dependencies:
+
+```jsonc
+ctx_spawn({ assignments: [
+  { task: "quick standalone check", agent: "analyst" },          // flat task
+  { subflow: {                                                   // a DAG
+      phases: [
+        { id: "scan",  type: "agent",  agent: "scout",  task: "list endpoints" },
+        { id: "audit", type: "map",    over: "{steps.scan.json}", task: "audit {item}", dependsOn: ["scan"] },
+        { id: "sum",   type: "reduce", from: ["audit"], task: "summarize", dependsOn: ["audit"], final: true }
+      ]
+    },
+    defaultAgent: "analyst"   // inner phases without their own `agent` use this
+  }
+] })
+```
+
+The subflow is validated (cycles / dangling refs / dead-ends) before it runs; a
+bad plan fails **open** (a diagnostic is folded into the report, the run
+continues). `agent` (flat task) = who executes; `defaultAgent` (subflow) =
+fallback for inner phases. Nesting is bounded: spawn-subflows and `flow{def}`
+share one depth counter capped at 5.
+
+**Guards & limits:** ids used with sharing must match `[A-Za-z0-9._-]+`; keys
+are `[A-Za-z0-9._-]` (≤128 chars); values ≤256 KB; ≤256 keys/node; `ctx_spawn`
+≤16 tasks/call, task ≤64 KB, depth ≤5. All bookkeeping is fail-open (it can
+never sink a phase); the per-run blackboard is cleaned up with the run.
+
+You do **not** need to teach the tools in your `task` text — enabling
+`shareContext` auto-appends usage guidance to the subagent's system prompt.
+Mentioning a specific key in the task ("ctx_write the endpoint list under
+'endpoints'") just makes the cross-phase contract explicit.
+
+**Producer tip (learned from real runs):** the phase that *publishes* shared
+context should be a **capable** agent (high thinking), and the `ctx_write`
+should be framed as its **primary deliverable** ("if you did not call ctx_write
+you failed the task"). A fast / `thinking: off` agent asked to "survey AND
+ctx_write" will often do the survey and skip the write. Consumers can be
+lighter — reading is a single reliable step.
+
+**Caching interaction:** `shareContext: true` disables per-item map caching
+(a sharing item can read sibling writes outside its declared deps, so the
+per-item key would under-approximate real reads). The whole-map cache path
+still applies.
+
+---
+<!-- /host:pi -->
+
+## Dynamic sub-flows (`flow{def}`) — the full contract
+
+A `flow` phase with `def` resolves a sub-flow **at runtime**, usually from an
+upstream phase's JSON output. The runtime interpolates + JSON-parses the `def`,
+validates it, then runs it nested. This is how a planner decides at runtime
+what work to spawn — with each generated plan checked before it spends a token.
+
+```jsonc
+{ "id": "plan", "type": "agent", "agent": "planner", "output": "json",
+  "task": "Scan the repo. Output ONLY JSON {\"name\":\"audit\",\"phases\":[...]} — one audit phase per file." },
+{ "id": "run", "type": "flow", "def": "{steps.plan.json}", "optional": true,
+  "dependsOn": ["plan"], "final": true }
+```
+
+**LLM output contract for `def`** (put this in the planner's task):
+- A *full* Taskflow `{"name":"...","phases":[...]}`, a bare `phases` array, or
+  `{"phases":[...]}` — pure JSON (a ```json fence is tolerated and stripped).
+- Hyphens in ids, never underscores.
+- Sub-flow phases reference each other in their **own** `{steps.x.output}`
+  namespace (no parent-id prefixing).
+- An **empty** `phases` array is a valid no-op (the planner decided there's
+  nothing to do).
+
+**Security caps on generated flows** (validation rejects; tell the planner not
+to emit these so a retry isn't wasted):
+- **No `script` phases** — shell execution from an LLM-authored plan is an RCE
+  vector; only author-written flows may use `script`.
+- **No workspace `cwd` keywords** (`temp`/`dedicated`/`worktree`) and no `cwd`
+  escaping the run directory.
+- Breadth caps: ≤100 phases, concurrency ≤16 (flow and per-phase).
+- Depth: inline nesting capped at 5 (shared with `ctx_spawn` subflows).
+
+**Fail-open semantics:** if the `def` doesn't parse, has the wrong shape, or
+fails validation, the phase completes with `status: "done"` and a `defError`
+diagnostic field; downstream phases receive empty output and the run continues.
+Design for it:
+- Add `optional: true` on the flow phase so a bad plan never aborts the run.
+- Want a hard stop instead? Add a downstream gate:
+  `{ "type": "gate", "eval": ["{steps.run.output} != "], "task": "…VERDICT: BLOCK if the plan failed." }`
+
+**Iterative replanning** — pair `flow{def}` with a `loop` whose body emits the
+next plan from the previous round's result: the declarative equivalent of
+`for (...) { read result; decide next }`. See `examples/dynamic-plan-execute.json`
+and `examples/iterative-replan.json`.
+
+---
+
+## Workspace isolation (`cwd` keywords)
+
+A phase's `cwd` is normally a literal path (or inherited from the run). Three
+**reserved keywords** ask the runtime to allocate an isolated working directory
+for the phase's subagent and tear it down afterwards — scratch work or file
+mutation without touching the main tree:
+
+| `cwd` value | what the runtime does | lifecycle |
+|-------------|-----------------------|-----------|
+| `"temp"` | ephemeral dir under the OS tmpdir | removed when the phase finishes |
+| `"dedicated"` | persistent dir under the run state (`runs/ws/<runId>/<phaseId>`) | **kept** for inspection; deterministic per phase (resume reuses it) |
+| `"worktree"` | `git worktree add` on a throwaway branch off `HEAD` | `git worktree remove` + branch delete when the phase finishes |
+
+```jsonc
+{ "id": "experiment", "type": "agent", "agent": "executor", "cwd": "worktree",
+  "task": "Try the risky refactor and run the tests. Your edits are isolated in a git worktree." }
+```
+
+- **Fail-open.** If allocation fails (e.g. `worktree` outside a git tree), the
+  phase degrades — `worktree`→`temp`, any other failure → the base cwd — with a
+  `warnings` diagnostic. A phase never fails to run because of isolation.
+- **Security.** Keywords are honoured only in **author-written** flows; a
+  generated plan (`flow{def}` / `ctx_spawn` subflow) requesting one is rejected
+  at validation.
+- A literal path passes through unchanged.
+
+**Pattern — competing experiments in worktrees:** run two `parallel` branches,
+each `cwd: "worktree"`, each attempting a different refactor strategy and
+reporting its test results; a downstream gate/judge picks which diff to apply
+for real. The main tree is never touched by the losers.
+
+<!-- host:pi -->
+---
+
+## Incremental recompute suite (`ir` / `provenance` / `why-stale` / `recompute`)
+
+Taskflow's cheapest superpower: after the world changes, re-pay for **only the
+affected phases** of a stored run instead of re-running the flow.
+
+Two complementary planes:
+
+| Plane | Mechanism | Answers |
+|-------|-----------|---------|
+| **Declared** | `dependsOn` ∪ `{steps.X}` refs in the definition | "what *could* depend on what" |
+| **Observed** | read-sets recorded at runtime (which upstream outputs a phase actually consumed) | "what *did* depend on what" |
+
+`why-stale` and `recompute` use the **union** (observed ∪ declared) so the
+frontier is sound even for runs made before observation existed.
+
+### The workflow
+
+```
+1. taskflow { action: "ir", name: "security-sweep" }
+     → FlowIR: canonical form + a content hash per phase.
+       Diff two versions of a flow; confirm an edit actually changed a
+       phase's fingerprint (identical hash ⇒ cache-hit eligible).
+
+2. taskflow { action: "provenance", runId: "<id>" }
+     → the run's observed read-sets: who actually read what.
+
+3. taskflow { action: "why-stale", runId: "<id>", phaseId: "discover" }
+     → the transitive stale frontier if 'discover' is assumed changed —
+       exactly which phases would re-run and the edge that makes each stale.
+       Omit phaseId to print the whole observed dependency graph.
+
+4. taskflow { action: "recompute", runId: "<id>", phaseId: "discover" }
+     → DRY-RUN by default: reports what would re-execute, zero tokens.
+
+5. taskflow { action: "recompute", runId: "<id>", phaseId: "discover", "dryRun": false }
+     → actually re-runs the seed + stale frontier, reuses every non-stale
+       phase's stored output, persists the updated run.
+       An aborted recompute never overwrites the original run.
+```
+
+CLI equivalents: `/tf ir <name>` · `/tf provenance <runId>` ·
+`/tf why-stale <runId> [phaseId]` · `/tf recompute <runId> <phaseId> [--apply]`.
+
+### When to reach for which reuse mechanism
+
+| Situation | Mechanism |
+|-----------|-----------|
+| Run crashed / gate blocked / budget hit — inputs unchanged | `action: "resume"` (within-run cache) |
+| The flow will be re-run repeatedly as the repo evolves | `incremental: true` + `cache.fingerprint` (cross-run cache — `configuration.md` §8) |
+| One phase of a completed run is now wrong/stale (a file changed, you edited one task) | `why-stale` → `recompute` (surgical, keeps the same run) |
+| The definition changed structurally | fresh `run` (compare `ir` hashes to see what changed) |
+| Cache serving stale results you can't explain | `provenance` to see real reads; `cache-clear` as the last resort |
+
+### Worked example
+
+A 12-phase nightly audit run completed yesterday. Today `src/auth/session.ts`
+changed. Instead of re-running all 12 phases:
+
+```
+/tf why-stale run-xyz discover
+  → Stale frontier (transitive, 4 phases):
+    ■ discover        (changed — seed)
+    ■ audit           ← reads discover
+    ■ screen          ← reads audit
+    ■ report          ← reads screen (declared)
+/tf recompute run-xyz discover --apply
+  → re-runs 4 phases, reuses 8, persists the updated run.
+```
+
+The other 8 phases (dependency summary, license scan, …) are served from the
+stored run at $0.
+
+---
+
+## `init` — model roles setup
+
+`action: "init"` manages the `modelRoles` map (`{{fast}}` / `{{strong}}` / …
+placeholders in agent frontmatter → real model ids):
+
+- `mode: "show"` (default) — read-only report of current roles.
+- `mode: "apply-defaults"` — writes recommended defaults; **requires
+  `force: true`** (destructive: overwrites `modelRoles` in settings.json).
+- `mode: "interactive"` — requires a UI session (`/tf init` is the human path).
+
+If phases fail with `Model metadata for {{fast}} not found`, roles are
+unconfigured — run `/tf init`.
+<!-- /host:pi -->

--- a/skills-src/taskflow/configuration.md
+++ b/skills-src/taskflow/configuration.md
@@ -1,5 +1,3 @@
-<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/configuration.md (npm run build:skills) -->
-
 # Taskflow Configuration Reference
 
 Every knob you can set on a taskflow, where it lives, and how the values are
@@ -169,6 +167,7 @@ still reach `{args.X}`).
 
 **Passing args:**
 
+<!-- host:pi -->
 ```
 /tf run audit-endpoints {"dir":"packages/api"}     # JSON
 /tf run audit-endpoints dir=packages/api depth=3   # key=value pairs
@@ -176,6 +175,10 @@ still reach `{args.X}`).
 ```
 
 Via the tool: `{ "action": "run", "name": "audit-endpoints", "args": { "dir": "packages/api" } }`.
+<!-- /host:pi -->
+<!-- host:codex -->
+Via the MCP tool: `taskflow_run` with `{ "name": "audit-endpoints", "args": { "dir": "packages/api" } }`.
+<!-- /host:codex -->
 
 ---
 
@@ -218,8 +221,15 @@ For any phase, the effective value is resolved in this **precedence order**
 
 Notes:
 - `tools` is a **whitelist**. Omit it to allow all.
+<!-- host:pi -->
 - Each phase runs as an isolated process:
   `pi --mode json -p --no-session [--model …] [--thinking …] [--tools …] [--append-system-prompt <agent>] "Task: …"`.
+<!-- /host:pi -->
+<!-- host:codex -->
+- Each phase runs as an isolated `codex exec --json` session. A model id that
+  still looks like a pi-provider path (contains `/`) or an unresolved
+  `{{placeholder}}` is dropped so codex falls back to its configured default.
+<!-- /host:codex -->
 - The agent's markdown body becomes the subagent's appended system prompt.
 
 ---
@@ -370,8 +380,10 @@ Each entry is one of:
 | Run state (resume) | `<project .pi>/taskflows/runs/<flowName>/<runId>.json` | ❌ gitignore |
 
 - `action: "save"` takes `scope: "project"` (default) or `"user"`.
+<!-- host:pi -->
 - Saved flows auto-register as `/tf:<name>` (immediately for the current session,
   and on future `session_start`).
+<!-- /host:pi -->
 - Project flows override user flows on a name collision.
 - Add `.pi/taskflows/runs/` to `.gitignore`.
 

--- a/skills-src/taskflow/core.md
+++ b/skills-src/taskflow/core.md
@@ -1,28 +1,3 @@
----
-name: taskflow
-description: Orchestrate multi-phase subagent workflows with Taskflow. Use whenever a request spans a whole project or many items — deeply exploring / 探索 / auditing / 审计 / analyzing a codebase, reviewing or migrating many files or modules in parallel, cross-checked/adversarial review, codebase-wide research, or any repeatable orchestration you want to save and rerun. Prefer this over ad-hoc parallel work when the task has multiple phases (discover → work → review → report) or dynamic fan-out over a discovered list. Drives the taskflow_* MCP tools.
----
-
-<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/entry.codex.md + core.md (npm run build:skills) -->
-
-# Taskflow (Codex)
-
-**Host binding (Codex):** everything below is driven through the `taskflow_*`
-MCP tools. Where an example shows a host-neutral invocation like `verify`, use
-the Codex form (`taskflow_verify`).
-
-| Tool | What it does |
-|------|--------------|
-| `taskflow_run` | Run a saved flow (`name`) or an inline `define` (full DAG, or shorthand `{task}` / `{tasks}` / `{chain}`). Optional `args`, `incremental`. Returns only the final phase output + a `runId`. |
-| `taskflow_list` | List saved flows discoverable from the current working directory. |
-| `taskflow_show` | Show a saved flow's full definition as JSON. |
-| `taskflow_verify` | Statically verify a flow (cycles, missing deps, undefined refs, contract typos) — no execution, zero tokens. |
-| `taskflow_compile` | Render a flow's DAG as a diagram (inline SVG) + a verification report — no execution. |
-| `taskflow_peek` | Inspect one phase's intermediate output from a stored run (post-hoc debugging). Omit `phaseId` to list phases; `json`/`item`/`limit` refine the slice. Hard-truncated, read-only. |
-
-**Always `taskflow_verify` a non-trivial flow before `taskflow_run`** — it is
-free and catches most authoring mistakes.
-
 Build and run **declarative, multi-phase workflows** of subagents. The runtime
 holds intermediate results and the phase DAG, so your main context only receives
 the final answer — not every step's transcript.
@@ -35,7 +10,12 @@ mistakes that break flows. Load the companion files **only when needed**:
 | File | Load when you need |
 |------|--------------------|
 | `patterns.md` | **Designing a non-trivial flow.** Proven flow archetypes (audit fan-out, self-healing rework, plan→approve→execute, dynamic replanning, tournament synthesis, incremental audit), anti-patterns, and the production-flow quality checklist. |
+<!-- host:pi -->
+| `advanced.md` | Shared Context Tree (`ctx_*` tools, `ctx_spawn` sub-graphs), workspace isolation (`cwd: temp/dedicated/worktree`), dynamic sub-flow (`flow{def}`) contracts & security caps, and the **incremental recompute suite** (`ir` / `provenance` / `why-stale` / `recompute` / `cache-clear`). |
+<!-- /host:pi -->
+<!-- host:codex -->
 | `advanced.md` | Dynamic sub-flow (`flow{def}`) contracts & security caps, and workspace isolation (`cwd: temp/dedicated/worktree`). |
+<!-- /host:codex -->
 | `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
 
 > Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
@@ -55,6 +35,10 @@ mistakes that break flows. Load the companion files **only when needed**:
 - A **single-file, single-step** change you can do directly — just do it.
 - **Interactive debugging** where each step depends on watching live output.
 - Work that is **one bash command** — run it yourself, don't wrap it in a flow.
+<!-- host:pi -->
+- A single quick delegation with no tracking needs — the plain `subagent` tool
+  is fine (though the shorthand below gives you resume + save for free).
+<!-- /host:pi -->
 
 ## Flow design ladder
 
@@ -106,13 +90,26 @@ proper flow, so you still get progress, persistence, and resume.
   `context` on individual steps; a top-level `context` is ignored (with a warning).
 - Add `name` to label the run.
 - Precedence if several are given: `chain` > `tasks` > `task`.
+<!-- host:pi -->
+- You can pass these as top-level tool params **or** inside `define`.
+<!-- /host:pi -->
+<!-- host:codex -->
 - Pass these as the `define` argument to `taskflow_run`.
+<!-- /host:codex -->
 
 ## How to author a taskflow
 
+<!-- host:pi -->
+Call the `taskflow` tool. To run a brand-new flow you write inline, pass
+`action: "run"` with a `define` object. To run a saved flow, pass `name`.
+**Before running a non-trivial flow, `action: "verify"` it — zero tokens,
+catches cycles / missing deps / undefined refs / contract typos.**
+<!-- /host:pi -->
+<!-- host:codex -->
 Call `taskflow_run` with an inline `define` object, or `name` for a saved flow.
 **Before running a non-trivial flow, `taskflow_verify` it — zero tokens,
 catches cycles / missing deps / undefined refs / contract typos.**
+<!-- /host:codex -->
 
 ### DSL shape
 
@@ -244,9 +241,15 @@ The (interpolated) `task` is the prompt shown.
 - **Background (detached)** runs **auto-reject** (no interactive approver);
   downstream sees the rejection; the flow continues (fail-open).
 
+<!-- host:pi -->
+Place one before the expensive part of a flow (a big fan-out, a mutation) —
+see the plan→approve→execute archetype in `patterns.md`.
+<!-- /host:pi -->
+<!-- host:codex -->
 > **Codex caveat:** MCP-driven runs are non-interactive, so an `approval` phase
 > **auto-rejects**. Prefer a `gate` (agent review) in flows you run through the
 > `taskflow_*` tools; use `approval` only in flows a human runs interactively.
+<!-- /host:codex -->
 
 ### Sub-flows (composition) — summary
 
@@ -421,6 +424,10 @@ if you literally want `a → b → c → d`, or write explicit `dependsOn`.
 
 Phase ids and agent names use **hyphens** (`audit-each`, `risk-reviewer`).
 An unknown agent name fails the phase with the list of available agents.
+<!-- host:pi -->
+Check with `action: "agents"` instead of guessing.
+<!-- /host:pi -->
+<!-- host:codex -->
 Built-in agents: `executor`, `executor-code` (complex, multi-file),
 `executor-fast` (trivial), `executor-ui`, `scout` (cheap recon), `planner`,
 `analyst`, `critic`, `reviewer`, `risk-reviewer`, `security-reviewer`,
@@ -428,13 +435,77 @@ Built-in agents: `executor`, `executor-code` (complex, multi-file),
 `recover`, `visual-explorer`. **Do not invent agent names** — omit `agent` to
 use the default. Use cheap agents (`scout`) for discovery and strong agents
 (`critic`, `final-arbiter`) for gates/judging.
+<!-- /host:codex -->
+
+<!-- host:pi -->
+## Actions (all 13)
+
+| action | what it does |
+|--------|--------------|
+| `run` | Run an inline `define` or a saved `name` (+ optional `args`). Add `detach: true` for background (returns runId immediately). Add `incremental: true` to default every phase to cross-run cache reuse. |
+| `save` | Persist `define` (scope `project` default / `user`); becomes `/tf:<name>`. Project overrides user on collision. |
+| `resume` | Continue a paused/failed run by `runId`. Cache-aware: `done` phases are reused, only the unfinished tail re-runs. |
+| `list` | List saved flows. |
+| `agents` | List available agents (never invent names). |
+| `verify` | Static-check a `define` or saved `name` — cycles, missing deps, undefined refs, contract-ref typos. Zero tokens. |
+| `compile` | Render a flow as a Mermaid diagram + verification report. Zero tokens. |
+| `ir` | Compile to **FlowIR** — the canonical intermediate representation with a content hash per phase. Use to diff two versions of a flow or confirm a definition change actually changed a phase's fingerprint. Zero tokens. |
+| `provenance` | Show a completed run's **observed read-sets** — which phases actually read which upstream outputs at runtime (may be narrower than `dependsOn`). Requires `runId`. Zero tokens. |
+| `why-stale` | Given `runId` (+ optional `phaseId` as the assumed-changed seed): with no seed, prints the observed dependency graph; with a seed, computes the **transitive stale frontier** — exactly which phases would need re-running and why (observed ∪ declared edges). Zero tokens. |
+| `recompute` | Re-run **only the stale frontier** of a stored run from a seed `phaseId`. **Defaults to `dryRun: true`** (reports what would re-run, zero tokens). Pass `dryRun: false` to actually re-execute the seed + frontier and persist the updated run. |
+| `cache-clear` | Clear the cross-run memoization store. |
+| `init` | Model-roles configuration. `mode: "show"` is read-only; `apply-defaults` requires `force: true`; `interactive` needs a UI session. |
+
+**The incremental loop** (`ir` → `why-stale` → `recompute`) is taskflow's
+cheapest superpower: after a repo change, re-pay for only the affected phases
+of a prior run instead of re-running the whole flow. Full workflow with an
+example in `advanced.md`.
+
+## Background (detached) runs
+
+Add `detach: true` to `action: "run"` to spawn the flow in a detached child
+process. Returns immediately with the `runId`; the flow survives the host
+session exiting. Poll via `/tf runs` or resume by `runId`. Approval phases
+auto-reject in detached mode; a crashed detached process persists
+`status: "failed"` (resumable).
+<!-- /host:pi -->
 
 ## Operating a run (lifecycle & inspection)
 
 A run moves through: **running →** `completed` (a `final` phase produced output)
 **/** `blocked` (gate BLOCK, approval rejected, or `budget` hit) **/** `failed`
 (a non-`optional` phase errored) **/** `paused` (aborted).
+<!-- host:pi -->
+`failed` and `paused` are resumable.
+<!-- /host:pi -->
 
+<!-- host:pi -->
+- **Resume is cache-aware.** `action: "resume"` re-runs only what didn't finish;
+  a phase that was mid-flight is re-executed cleanly.
+- **Resume vs. re-run vs. recompute.** Resume when inputs are unchanged and you
+  want to continue the tail (fixed a gate, raised the budget). Re-run from
+  scratch when the task text changed. **Recompute** when the *world* changed
+  (a file, a commit) and you want to re-pay for only the affected phases.
+- **Inspect runs.** `/tf runs` lists recent runs; `/tf show <name>` prints a
+  saved flow's definition. Run state:
+  `<project .pi>/taskflows/runs/<flowName>/<runId>.json` (gitignored).
+- **Peek at intermediate outputs.** `/tf peek <runId>` lists phases (status +
+  output size); `/tf peek <runId> <phaseId>` prints that phase's stored output —
+  `--json` for parsed JSON, `--item <n>` for one section of a fan-out,
+  `--limit <chars>` (default 4000, max 32000). Read-only, human-invoked: the
+  context-isolation contract still holds — peek is the debugging escape hatch
+  when one phase of many produced garbage.
+
+## User commands
+
+- `/tf list` · `/tf run <name> [args]` · `/tf show <name>` · `/tf runs` · `/tf resume <runId>`
+- `/tf verify` · `/tf compile <name> [lr|td]` · `/tf ir <name>`
+- `/tf peek <runId> [phaseId] [--json] [--item <n>] [--limit <chars>]`
+- `/tf provenance <runId>` · `/tf why-stale <runId> [phaseId]` · `/tf recompute <runId> <phaseId> [--apply]` (dry-run by default)
+- `/tf init` — interactive model-roles setup
+- `/tf:<name> [args]` — shortcut for each saved flow
+<!-- /host:pi -->
+<!-- host:codex -->
 `taskflow_run` reports a `runId`. If the final output looks wrong, don't
 re-run blind — `taskflow_peek` the run: omit `phaseId` to list phase statuses
 and output sizes, then peek the suspicious phase (`json: true` for parsed
@@ -446,3 +517,4 @@ For flows re-run as the repo evolves, pass `incremental: true` to
 input → $0 instant hit. Per-phase `cache.fingerprint` entries
 (`git:HEAD`, `glob!:src/**/*.ts`, `file:package.json`) invalidate on world
 changes; a cached `map` re-executes only changed items. See `configuration.md` §8.
+<!-- /host:codex -->

--- a/skills-src/taskflow/entry.codex.md
+++ b/skills-src/taskflow/entry.codex.md
@@ -1,0 +1,22 @@
+---
+name: taskflow
+description: Orchestrate multi-phase subagent workflows with Taskflow. Use whenever a request spans a whole project or many items — deeply exploring / 探索 / auditing / 审计 / analyzing a codebase, reviewing or migrating many files or modules in parallel, cross-checked/adversarial review, codebase-wide research, or any repeatable orchestration you want to save and rerun. Prefer this over ad-hoc parallel work when the task has multiple phases (discover → work → review → report) or dynamic fan-out over a discovered list. Drives the taskflow_* MCP tools.
+---
+
+# Taskflow (Codex)
+
+**Host binding (Codex):** everything below is driven through the `taskflow_*`
+MCP tools. Where an example shows a host-neutral invocation like `verify`, use
+the Codex form (`taskflow_verify`).
+
+| Tool | What it does |
+|------|--------------|
+| `taskflow_run` | Run a saved flow (`name`) or an inline `define` (full DAG, or shorthand `{task}` / `{tasks}` / `{chain}`). Optional `args`, `incremental`. Returns only the final phase output + a `runId`. |
+| `taskflow_list` | List saved flows discoverable from the current working directory. |
+| `taskflow_show` | Show a saved flow's full definition as JSON. |
+| `taskflow_verify` | Statically verify a flow (cycles, missing deps, undefined refs, contract typos) — no execution, zero tokens. |
+| `taskflow_compile` | Render a flow's DAG as a diagram (inline SVG) + a verification report — no execution. |
+| `taskflow_peek` | Inspect one phase's intermediate output from a stored run (post-hoc debugging). Omit `phaseId` to list phases; `json`/`item`/`limit` refine the slice. Hard-truncated, read-only. |
+
+**Always `taskflow_verify` a non-trivial flow before `taskflow_run`** — it is
+free and catches most authoring mistakes.

--- a/skills-src/taskflow/entry.pi.md
+++ b/skills-src/taskflow/entry.pi.md
@@ -1,0 +1,11 @@
+---
+name: taskflow
+description: Orchestrate multi-phase subagent workflows with pi-taskflow. Use whenever a request spans a whole project or many items — deeply exploring / 探索 / auditing / 审计 / analyzing a codebase, reviewing or migrating many files or modules in parallel, cross-checked/adversarial review, codebase-wide research, or any repeatable orchestration you want to save and rerun. Prefer this over ad-hoc parallel subagents when the work has multiple phases or dynamic fan-out over a discovered list. Also supports subagent-style shorthand (single / parallel / chain) for simple non-DAG delegations you want tracked, resumable, or saveable.
+---
+
+# Taskflow
+
+**Host binding (pi):** everything below is driven through the `taskflow` tool
+(`action: "run" | "verify" | …`) and the `/tf` slash commands. Where an example
+shows a host-neutral invocation like `verify`, use the pi form
+(`action: "verify"` or `/tf verify`).

--- a/skills-src/taskflow/patterns.md
+++ b/skills-src/taskflow/patterns.md
@@ -1,0 +1,293 @@
+# Taskflow Patterns — proven archetypes & the production checklist
+
+Read this when designing a flow with ≥ 4 phases, a gate, or any fan-out.
+Each archetype below is a complete, runnable shape distilled from real runs.
+Copy the closest one and adapt — don't design from a blank page.
+
+---
+
+## The production-flow checklist
+
+Before running a flow you designed, check it against this list. Every item is
+cheap to add and each one has prevented a real failure class:
+
+- [ ] **`verify` first.** Run the static verifier (pi: `action: "verify"` /
+      Codex: `taskflow_verify`) — zero tokens,
+      catches cycles / missing deps / ref typos / contract mismatches.
+- [ ] **Every JSON-emitting phase has `expect` + `retry`.** "Output ONLY JSON"
+      in the task text is a request; `expect` is enforcement. Without it, a
+      malformed router output silently skips both branches.
+- [ ] **Machine checks before LLM checks.** `script` phases for build/test
+      ground truth; gate `eval` assertions before the gate's LLM `task`. A
+      token spent verifying what a shell command can verify is a wasted token.
+- [ ] **`budget` on any flow with a fan-out.** A map over a mis-discovered
+      500-item array is unbounded spend without one.
+- [ ] **`optional: true` + a fallback for degradable phases.** An enrichment
+      phase that times out shouldn't sink the run — pair `timeout` +
+      `optional` with a downstream `when`-guarded fallback.
+- [ ] **Exactly one `final: true`** on the result-bearing phase.
+- [ ] **`strictInterpolation: true` on any flow you save.** Saved flows run
+      later with args you're not watching; unresolved placeholders must be
+      errors, not empty strings.
+- [ ] **Discovery phases are cheap and sandboxed.** `agent: "scout"`,
+      `tools: ["read","grep","ls"]`, low thinking. Don't pay executor prices
+      for `ls`.
+- [ ] **The reviewer is not the producer.** A gate reviewing phase X uses a
+      different agent (ideally a different model) than X. Self-review passes
+      ~everything.
+- [ ] **Re-runnable flows are `incremental: true`** with `fingerprint` entries
+      on phases that read the world (`git:HEAD`, `glob!:src/**/*.ts`). See
+      `advanced.md`.
+
+---
+
+## Archetype 1: Audit fan-out (discover → map → gate → reduce)
+
+The workhorse. Use for: audit every endpoint / migrate every file /
+summarize every module.
+
+```jsonc
+{
+  "name": "audit-endpoints",
+  "strictInterpolation": true,
+  "budget": { "maxUSD": 3.00 },
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout",
+      "tools": ["read", "grep", "ls"],
+      "task": "List every HTTP endpoint under src/routes. Output ONLY a JSON array [{\"route\":\"...\",\"file\":\"...\"}]. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object", "required": ["route", "file"] } },
+      "retry": { "max": 2, "backoffMs": 0 } },
+
+    { "id": "audit", "type": "map", "over": "{steps.discover.json}", "as": "item",
+      "agent": "analyst", "concurrency": 4,
+      "task": "Audit {item.route} in {item.file} for missing auth. Report: SEVERITY (high/med/low/none), evidence (file:line), fix.",
+      "dependsOn": ["discover"] },
+
+    { "id": "screen", "type": "gate", "agent": "reviewer",
+      "task": "Cross-check the findings below. Delete false positives (cite why). If ANY confirmed HIGH remains, end with VERDICT: BLOCK and list them; else VERDICT: PASS.\n\n{steps.audit.output}",
+      "dependsOn": ["audit"] },
+
+    { "id": "report", "type": "reduce", "from": ["screen"], "agent": "doc-writer",
+      "task": "Write a prioritized remediation report from:\n{steps.screen.output}",
+      "dependsOn": ["screen"], "final": true }
+  ]
+}
+```
+
+Why each piece: `expect`+`retry` on discover means a chatty scout gets a second
+chance instead of feeding garbage to the map; `concurrency: 4` protects rate
+limits; the gate is a *different* agent than the auditor; `budget` bounds the
+fan-out.
+
+**Variant — per-item caching for repeated audits:** add
+`"cache": { "scope": "cross-run" }` to the map phase. On the next run, only
+items whose task text changed re-execute; the rest are $0 cache hits.
+(Details: `configuration.md` §8.)
+
+---
+
+## Archetype 2: Self-healing implement→verify→rework
+
+Use for: implement against acceptance criteria, fix-until-green.
+The gate re-runs its upstream on BLOCK — a generate→critique→regenerate loop
+without you writing a loop.
+
+```jsonc
+{
+  "name": "implement-verified",
+  "budget": { "maxUSD": 5.00 },
+  "phases": [
+    { "id": "implement", "type": "agent", "agent": "executor-code",
+      "task": "Implement the feature per the spec in docs/spec.md. Run nothing; just edit." },
+
+    { "id": "build-test", "type": "script",
+      "run": "npx tsc --noEmit && npm test 2>&1 | tail -20",
+      "timeout": 180000, "dependsOn": ["implement"] },
+
+    { "id": "spec-gate", "type": "gate", "agent": "reviewer",
+      "onBlock": "retry", "retry": { "max": 3 },
+      "eval": ["{steps.build-test.output} contains pass"],
+      "task": "Build/test output:\n{steps.build-test.output}\n\nDoes the implementation satisfy ALL acceptance criteria in docs/spec.md? VERDICT: PASS, or VERDICT: BLOCK with a precise list of what to fix.",
+      "dependsOn": ["implement", "build-test"] },
+
+    { "id": "summary", "type": "agent", "agent": "doc-writer",
+      "task": "Summarize what was implemented and the verification result:\n{steps.spec-gate.output}",
+      "dependsOn": ["spec-gate"], "final": true }
+  ]
+}
+```
+
+Key mechanics: on BLOCK, `spec-gate` re-runs **both** its `dependsOn` upstreams
+(`implement` gets the blocker's reasons via re-interpolation, `build-test`
+re-verifies), up to 3 rounds. The `eval` line means a green build+test skips
+the LLM review entirely on the happy path.
+
+**Verification phases: force structured output.** LLMs are bad at
+*summarizing* shell output (234 tests read as 230) but good at *copying*
+structured data. If a verification step must go through an agent (not a
+`script`), demand `key=value` lines:
+
+```
+Report EXACTLY in this format (one key=value per line, no prose):
+typecheck=PASS|FAIL
+tests_total=N
+tests_fail=N
+If any field is missing, you failed the task — re-run and re-read.
+```
+
+Prefer a `script` phase whenever the check is a command — exact, free, fast.
+
+---
+
+## Archetype 3: Plan → human approval → execute
+
+Use for: anything expensive or destructive where a human should see the plan
+before the spend. The approval's **Edit** option injects mid-run guidance.
+
+<!-- host:codex -->
+> **Codex caveat:** approval phases auto-reject in MCP-driven (non-interactive)
+> runs. This archetype only works when a human runs the flow interactively;
+> for tool-driven runs, replace the approval with a strict `gate`.
+<!-- /host:codex -->
+
+```jsonc
+{
+  "name": "guarded-migration",
+  "phases": [
+    { "id": "plan", "type": "agent", "agent": "planner",
+      "task": "Plan the migration of src/legacy/* to the new API. List each file, the change, and the risk." },
+
+    { "id": "checkpoint", "type": "approval",
+      "task": "Migration plan:\n\n{steps.plan.output}\n\nApprove to execute, reject to abort, or edit to add constraints.",
+      "dependsOn": ["plan"] },
+
+    { "id": "execute", "type": "agent", "agent": "executor-code",
+      "task": "Execute the migration plan:\n{steps.plan.output}\n\nOperator guidance (if any): {steps.checkpoint.output}",
+      "dependsOn": ["checkpoint"] },
+
+    { "id": "verify", "type": "script", "run": "npx tsc --noEmit && npm test 2>&1 | tail -5",
+      "timeout": 180000, "dependsOn": ["execute"], "final": true }
+  ]
+}
+```
+
+Note `{steps.checkpoint.output}` — on Edit it carries the operator's note; on
+Approve it's `(approve)`. Don't use approval in detached/headless runs (it
+auto-rejects there — by design).
+
+---
+
+## Archetype 4: Dynamic plan → execute (`flow{def}`)
+
+Use when the *work itself* must be discovered at runtime — the planner emits a
+whole sub-flow as JSON and the runtime validates + runs it. The declarative
+answer to "loop over whatever we find".
+
+```jsonc
+{
+  "name": "dynamic-audit",
+  "budget": { "maxUSD": 4.00 },
+  "phases": [
+    { "id": "plan", "type": "agent", "agent": "planner", "output": "json",
+      "task": "Scan this repo. Output ONLY a JSON taskflow {\"name\":\"sub\",\"phases\":[...]} with one 'agent' phase per module that needs auditing (agent: \"analyst\"), plus a final 'reduce' phase (agent: \"doc-writer\", from: [all audit ids], final: true). Use hyphens in ids. No script phases, no cwd fields.",
+      "expect": { "type": "object", "required": ["name", "phases"] },
+      "retry": { "max": 2, "backoffMs": 0 } },
+
+    { "id": "run-plan", "type": "flow", "def": "{steps.plan.json}",
+      "optional": true, "dependsOn": ["plan"] },
+
+    { "id": "deliver", "type": "agent", "agent": "doc-writer",
+      "task": "Final result (empty means the plan failed validation — say so):\n{steps.run-plan.output}",
+      "dependsOn": ["run-plan"], "final": true }
+  ]
+}
+```
+
+Critical details (full contract in `advanced.md`): a bad plan **fails open**
+(`defError` diagnostic, empty output downstream) — `optional: true` + the
+`deliver` phase turn that into a graceful report instead of a dead run. The
+planner prompt must forbid what validation will reject anyway (`script`
+phases, workspace `cwd` keywords) so the plan doesn't waste a retry.
+
+**Iterative replanning:** wrap a plan-emitting body in a `loop` so round N's
+plan reacts to round N−1's result — see `examples/iterative-replan.json`.
+
+---
+
+## Archetype 5: Tournament for one-shot-unreliable work
+
+Use when quality varies run-to-run (naming, copywriting, tricky refactor
+strategy, root-cause hypotheses). Branches > variants when you want genuinely
+different *approaches* judged against each other.
+
+```jsonc
+{
+  "id": "strategy", "type": "tournament", "mode": "best",
+  "judgeAgent": "final-arbiter",
+  "judge": "Judge on: correctness under concurrent access, blast radius, migration cost. Quote evidence. End with WINNER: <n>.",
+  "branches": [
+    { "task": "Design the cache-invalidation fix with a conservative approach: minimal diff, no schema change.", "agent": "analyst" },
+    { "task": "Design the fix assuming we can change the schema: optimal correctness.", "agent": "analyst" },
+    { "task": "Design the fix as an adversary: what will break each obvious approach? Then propose the one that survives.", "agent": "critic" }
+  ],
+  "dependsOn": ["context"], "final": true
+}
+```
+
+Give the judge a **rubric with named criteria**, a stronger model
+(`judgeAgent`), and an exact terminator (`WINNER: <n>`). `mode: "aggregate"`
+instead merges all variants — good for research synthesis, bad for decisions.
+
+---
+
+## Archetype 6: Incremental repo-watch audit (cross-run)
+
+Use for flows you'll re-run as the repo evolves. First run pays full price;
+subsequent runs re-pay only for what changed.
+
+```jsonc
+{
+  "name": "security-sweep",
+  "incremental": true,
+  "budget": { "maxUSD": 3.00 },
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "output": "json",
+      "task": "List all files handling user input. Output ONLY a JSON array of paths.",
+      "expect": { "type": "array" },
+      "cache": { "scope": "cross-run", "fingerprint": ["glob!:src/**/*.ts"] } },
+    { "id": "audit", "type": "map", "over": "{steps.discover.json}",
+      "agent": "security-reviewer", "task": "Audit {item} for injection/authz issues.",
+      "cache": { "scope": "cross-run" },
+      "dependsOn": ["discover"] },
+    { "id": "report", "type": "reduce", "from": ["audit"], "agent": "doc-writer",
+      "task": "Prioritized findings report:\n{steps.audit.output}",
+      "dependsOn": ["audit"], "final": true }
+  ]
+}
+```
+
+The `glob!:` fingerprint makes `discover` a cache miss only when file
+*contents* change; the map's per-item cache means one changed file re-audits
+one item.
+<!-- host:pi -->
+For surgically re-running part of an **existing** run after a change,
+use `why-stale` → `recompute` instead of a fresh run — see `advanced.md`.
+<!-- /host:pi -->
+
+---
+
+## Anti-patterns (seen in real flows)
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|--------------|-----|
+| One mega-phase doing discover+audit+report | No parallelism, no caching granularity, one failure loses everything | Split along the archetype-1 shape |
+| Gate whose task doesn't demand a `VERDICT:` terminator | Ambiguity fails open → gate silently always passes | End every gate task with the exact verdict instruction |
+| Router phase without `expect` enum | `"Deep"` vs `"deep"` → both `when` branches skip, `join:"any"` reduce gets nothing | `expect: { properties: { route: { enum: [...] } } }` + `retry` |
+| Agent phase that just runs a shell command | Tokens spent, output paraphrased inaccurately | `script` phase |
+| Same agent produces and reviews | Self-review passes everything | Different agent (ideally model) for the gate |
+| Fan-out with no `budget` and no `concurrency` cap | Unbounded spend + rate-limit storms | `budget` + `phase.concurrency` |
+| `dependsOn` declared but output never referenced | The downstream agent doesn't see the upstream's work — dependency ≠ data flow | Interpolate `{steps.X.output}` into the task (or `context`) |
+| Saving a flow without `strictInterpolation` | Later invocations with wrong args silently run on empty strings | `strictInterpolation: true` before saving |
+| `map` over `{steps.X.output}` (text, not json) | `over` must resolve to an array | `output: "json"` upstream + `over: "{steps.X.json}"` |
+| Deep `chain` where steps don't need each other's output | Serialized latency for no reason | `tasks` (parallel) or a DAG with real edges only |


### PR DESCRIPTION
## Summary

Skills are now authored **once** in `skills-src/taskflow/` and compiled per host by `scripts/build-skills.mjs`, replacing the two hand-maintained skill copies that had drifted (the Codex skill was a 103-line stub while the pi skill was 683 lines, and neither documented the incremental-recompute action suite).

## Authoring model

```
skills-src/taskflow/
├─ entry.pi.md       — pi frontmatter + host binding (taskflow tool + /tf commands)
├─ entry.codex.md    — codex frontmatter + taskflow_* MCP tool table
├─ core.md           — shared body (phase types, control flow, common mistakes)
└─ patterns.md / advanced.md / configuration.md — shared companions
```

Host-only capabilities are wrapped in `<!-- host:pi -->` / `<!-- host:codex -->` blocks, so a host is **never taught a tool it cannot reach** (e.g. `recompute`/`save`/`detach` are pi-only; the approval-auto-reject caveat is codex-only). ~85% of the content is shared verbatim.

## Content upgrades (both hosts)

- **Progressive loading**: `SKILL.md` (core) → `patterns.md` (6 production archetypes, anti-pattern table, quality checklist, flow design ladder L0–L5) → `advanced.md` (`flow{def}` contract, workspace isolation; pi additionally gets Shared Context Tree + `ir`/`provenance`/`why-stale`/`recompute`) → `configuration.md` (knobs, caching, fingerprints)
- pi `SKILL.md` now documents **all 13 actions** (`ir`/`provenance`/`why-stale`/`recompute`/`cache-clear` were previously invisible to the LLM)
- Codex skill grows from a 103-line stub to the full capability surface minus MCP-unreachable features
- "When NOT to use" sections, `strictInterpolation` guidance, and `expect`+`retry` baked into every example so agents copy best practice by default

## Guardrails

- `npm run build:skills` wired into `npm run build`
- `skills-build.test.ts`: `--check` drift guard (CI fails if generated files diverge from `skills-src/`) + host-filtering semantic assertions
- `mcp-server.test.ts`: flow-example verification extended from `SKILL.md` to **all bundled skill files** (≥5 complete flows must pass `taskflow_verify`)
- `RELEASE.md` pre-flight gains a skill-coverage checklist; `AGENTS.md` updated to point at `skills-src/`

## Test plan

- [x] 954/954 unit tests pass (`npm test`)
- [x] `node scripts/build-skills.mjs --check` green (no drift)
- [x] All complete flow examples in both hosts' skill files validate against the live schema (zero errors/warnings)
