### PR TITLE
chore(release): 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,88 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+## [0.1.5] — 2026-07-03
+
+### Added
+- **Scoring gates (`score` on `gate` phases).** Deterministic, composable,
+  auditable quality checks: six pure scorers (`exact-match`, `contains`,
+  `regex`, `json-schema`, `length-range`, `code-compiles`) run against a target
+  string at **zero tokens** and combine via `all` / `any` / `weighted`
+  (+ `threshold`). When the deterministic combination passes and the judge
+  cannot veto it, the gate auto-passes with **no LLM call** (mirrors the `eval`
+  fast-path). When it fails, an optional `judge` (LLM-as-judge) decides, or the
+  gate `task` runs with the scorer report appended, or — with no fallback — the
+  gate blocks explicitly. The structured result is the gate's `.json`
+  (`{steps.<gate>.json.combined}`, `.json.results`), so downstream phases can
+  route on quality, not just pass/fail.
+- **Reflexion memory in loops (`reflexion: true`).** Each iteration after the
+  first receives a structured failure summary of the prior one via the
+  `{reflexion}` placeholder (auto-appended when absent, capped at 2000 chars):
+  `expect`-contract diagnostics, the (sanitized) error, or the unmet `until`,
+  plus a truncated output snippet. Body failures become **feedback instead of
+  termination** — timeout/abort/over-budget still hard-stop, and exhausting
+  `maxIterations` on a failure still fails the phase. `PhaseState.loop.failures`
+  records every failed iteration for audit. Default off = byte-for-byte the
+  historical behavior.
+- **Side-effect classification (`idempotent: false`).** Marks a phase with
+  irreversible side effects (webhook POSTs, deploys, DB writes): transient
+  provider errors are **not** auto-retried (explicit `retry{}` is still
+  honored) and the result is **never cached** in any scope (within-run resume,
+  cross-run, `incremental`). The phase state records `sideEffect: true`
+  (rendered as ⚡), and a re-execution on resume surfaces a warning.
+- **Single-source skills.** The pi and codex skill docs are now authored once
+  in `skills-src/taskflow/` and compiled per host by `scripts/build-skills.mjs`
+  (`npm run build:skills`); a drift guard (`skills-build.test.ts`) fails CI if a
+  generated file is edited directly. Codex reaches feature parity with pi
+  automatically.
+
+### Security
+- **Scoring-gate hardening for LLM-generated dynamic sub-flows.**
+  `validateTaskflow` rejects `code-compiles` scorers (compiler execution — the
+  `npx tsc` path could resolve a repo-planted `node_modules/.bin/tsc`) and
+  `regex` scorers (catastrophic-backtracking ReDoS) inside `flow{def}`
+  definitions produced at runtime — the same hardening class as the existing
+  `script`-phase block. Author-written flows keep both (a human reviewed them).
+- **`code-compiles` runs in an isolated temp directory.** `mkdtempSync` closes
+  the predictable-temp-name symlink/TOCTOU race, and running the compiler with
+  that dir as its cwd stops `npx` resolving a repo-planted `tsc` even in
+  author-written flows (defense-in-depth).
+- **Judge-prompt injection guard.** A scoring gate's judge embeds the
+  model-produced target in a fenced evidence block; fences in the target are
+  now neutralized so crafted output cannot close the block and inject
+  instructions at prompt level.
+- **Reflexion prompt-injection surface reduced.** Provider error noise is run
+  through `sanitizeErrorMessage` before it is injected into the next
+  iteration's prompt (HTML gateway pages no longer leak in verbatim).
+- **ReDoS fixes in `safeParse`.** The fenced-block extractor and the stray-key
+  diagnostic regexes are now linear-time (removed ambiguous adjacent whitespace
+  quantifiers) — closes two `js/polynomial-redos` code-scanning alerts.
+
+### Fixed
+- **Detached (background) runs load the host runner correctly.** The host now
+  self-reports its runner module path via `import.meta.url` instead of
+  resolving a relative `.ts` specifier that `rewriteRelativeImportExtensions`
+  left pointing at a non-existent `dist/runner.ts` — every detached phase
+  previously failed with "No subagent runner injected" in the published build
+  while dev checkouts worked. The detached runner now also fails fast (exits
+  non-zero, persisting the real import error on a `__detach__` phase) instead
+  of burying the cause under N no-runner stubs.
+- **Loop `until` self-references no longer error.** `{steps.<thisId>.json.done}`
+  in a loop's `until` (the documented stop-condition pattern) was flagged as a
+  self-reference bug; loop phases are now exempt.
+- **Per-scorer field validation.** Fields not applicable to a scorer's type
+  (e.g. `negate` on `contains`) are rejected instead of silently ignored.
+- **Loop-only fields on non-loop phases warn.** `until` / `maxIterations` /
+  `convergence` on a non-loop phase now surface a warning instead of being
+  silently dropped.
+
+### Docs
+- The interpolation reference now documents `{reflexion}`, `{loop.iteration}`,
+  `{loop.lastOutput}`, `{loop.maxIterations}`, and the `score.target` /
+  `score.judge.task` interpolation sites.
+- `examples/quality-pipeline.json` composes all three new features (scoring
+  gate → reflexion loop → non-idempotent notify).
+
 ## [0.1.4] — 2026-07-02
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-taskflow-monorepo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-taskflow-monorepo",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "workspaces": [
         "packages/taskflow-core",
         "packages/pi-taskflow",
@@ -3071,10 +3071,10 @@
       }
     },
     "packages/codex-taskflow": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "taskflow-core": "0.1.4"
+        "taskflow-core": "0.1.5"
       },
       "bin": {
         "codex-taskflow-mcp": "dist/mcp/bin.js"
@@ -3084,10 +3084,10 @@
       }
     },
     "packages/pi-taskflow": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "taskflow-core": "0.1.4"
+        "taskflow-core": "0.1.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3101,7 +3101,7 @@
       }
     },
     "packages/taskflow-core": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow-monorepo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Monorepo for taskflow-core, pi-taskflow, and codex-taskflow.",
   "type": "module",

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskflow",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Run taskflow on OpenAI Codex: a Codex subagent runner plus an MCP server (and a plug-and-play Codex plugin) that exposes the taskflow_* tools to Codex users.",
   "keywords": [
     "codex",
@@ -42,6 +42,6 @@
     "access": "public"
   },
   "dependencies": {
-    "taskflow-core": "0.1.4"
+    "taskflow-core": "0.1.5"
   }
 }

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.1.4", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.1.5", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
   "keywords": [
     "pi-package",
@@ -53,7 +53,7 @@
     "image": "https://raw.githubusercontent.com/heggria/taskflow/main/assets/social-preview.png"
   },
   "dependencies": {
-    "taskflow-core": "0.1.4"
+    "taskflow-core": "0.1.5"
   },
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow and codex-taskflow.",
   "keywords": [
     "taskflow",


### PR DESCRIPTION
## Release 0.1.5

Bumps all three packages + root + the Codex plugin manifest/.mcp.json to **0.1.5** in lockstep (the `taskflow-core` dep pin is bumped in both adapters), stamps `CHANGELOG.md`, and regenerates `package-lock.json` (0 vulnerabilities).

Everything merged since 0.1.4 (#14, #15, #16):

### Added
- **Scoring gates** (`score` on `gate`) — 6 deterministic scorers + LLM-judge fallback, `all`/`any`/`weighted`, zero-token auto-pass when the judge can't veto, structured `.json` result for downstream routing.
- **Reflexion loops** (`reflexion: true`) — prior-iteration failure summary injected via `{reflexion}`; body failures become feedback instead of termination; `loop.failures` audit trail.
- **Side-effect classification** (`idempotent: false`) — suppresses transient auto-retry (explicit `retry{}` honored), disables all caching, ⚡ marker + resume warning.
- **Single-source skills** — authored once in `skills-src/`, compiled per host, drift-guarded in CI.

### Security (from the adversarial review of #16)
- Dynamic (LLM-generated) sub-flows may not use `code-compiles` (compiler-exec RCE) or `regex` (ReDoS) scorers.
- `code-compiles` runs in an isolated `mkdtemp` dir (TOCTOU + `node_modules/.bin` planting defense-in-depth).
- Judge-prompt fence-escape guard; reflexion error-message sanitization.
- Two `js/polynomial-redos` alerts in `safeParse` fixed (linear regexes).

### Fixed
- Detached runs load the host runner correctly in the published build (self-reported `import.meta.url` path; fail-fast on load error).
- Loop `until` self-references no longer error; per-scorer field validation; loop-only-field warnings on non-loop phases.

### Pre-flight
- [x] `npm run typecheck` clean
- [x] `node scripts/build-skills.mjs --check` — no drift
- [x] `npm test` — **1015/1015**
- [x] `npm run build` — dist emits
- [x] version gate simulated: root + 3 packages + plugin.json + .mcp.json pin all == `v0.1.5`

After merge: push tag `v0.1.5` → `publish.yml` verifies versions, publishes `taskflow-core` → `pi-taskflow` → `codex-taskflow` to npm (provenance), and cuts the GitHub Release from this CHANGELOG section.
