### PR TITLE
assets: align badges, plugin icons, and brand color with the light visual system

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 <img src="./assets/hero.png" alt="taskflow — a declarative, verifiable graph of task nodes for coding-agent subagents: stateful, resumable, context-isolated" width="900">
 
 <p>
-  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/v/pi-taskflow?style=flat-square&color=B692FF&label=npm" alt="npm version"></a>
-  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/dm/pi-taskflow?style=flat-square&color=6E8BFF&label=downloads" alt="npm downloads"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-43D9AD?style=flat-square" alt="MIT license"></a>
-  <a href="#whats-inside"><img src="https://img.shields.io/badge/runtime%20deps-0-43D9AD?style=flat-square" alt="zero runtime dependencies"></a>
+  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/v/pi-taskflow?style=flat-square&color=4B4ACF&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/dm/pi-taskflow?style=flat-square&color=5A5D63&label=downloads" alt="npm downloads"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-0E8A66?style=flat-square" alt="MIT license"></a>
+  <a href="#whats-inside"><img src="https://img.shields.io/badge/runtime%20deps-0-0E8A66?style=flat-square" alt="zero runtime dependencies"></a>
   <a href="https://github.com/heggria/taskflow/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/heggria/taskflow/ci.yml?branch=main&style=flat-square&label=CI" alt="CI status"></a>
-  <a href="#whats-inside"><img src="https://img.shields.io/badge/tests-918-6E8BFF?style=flat-square" alt="918 tests"></a>
-  <a href="#whats-inside"><img src="https://img.shields.io/badge/dogfooded-%E2%9C%93-43D9AD?style=flat-square" alt="dogfooded"></a>
-  <a href="#run-it-on-your-agent"><img src="https://img.shields.io/badge/runs%20on-Pi%20%2B%20Codex-B692FF?style=flat-square" alt="runs on Pi and Codex"></a>
+  <a href="#whats-inside"><img src="https://img.shields.io/badge/tests-918-4B4ACF?style=flat-square" alt="918 tests"></a>
+  <a href="#whats-inside"><img src="https://img.shields.io/badge/dogfooded-%E2%9C%93-0E8A66?style=flat-square" alt="dogfooded"></a>
+  <a href="#run-it-on-your-agent"><img src="https://img.shields.io/badge/runs%20on-Pi%20%2B%20Codex-4B4ACF?style=flat-square" alt="runs on Pi and Codex"></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,14 +3,14 @@
 <img src="./assets/hero.png" alt="taskflow — 面向编码智能体子代理的声明式、可验证的任务节点图：有状态、可恢复、上下文隔离" width="900">
 
 <p>
-  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/v/pi-taskflow?style=flat-square&color=B692FF&label=npm" alt="npm version"></a>
-  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/dm/pi-taskflow?style=flat-square&color=6E8BFF&label=downloads" alt="npm downloads"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-43D9AD?style=flat-square" alt="MIT license"></a>
-  <a href="#whats-inside"><img src="https://img.shields.io/badge/runtime%20deps-0-43D9AD?style=flat-square" alt="zero runtime dependencies"></a>
+  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/v/pi-taskflow?style=flat-square&color=4B4ACF&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/pi-taskflow"><img src="https://img.shields.io/npm/dm/pi-taskflow?style=flat-square&color=5A5D63&label=downloads" alt="npm downloads"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-0E8A66?style=flat-square" alt="MIT license"></a>
+  <a href="#whats-inside"><img src="https://img.shields.io/badge/runtime%20deps-0-0E8A66?style=flat-square" alt="zero runtime dependencies"></a>
   <a href="https://github.com/heggria/taskflow/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/heggria/taskflow/ci.yml?branch=main&style=flat-square&label=CI" alt="CI status"></a>
-  <a href="#whats-inside"><img src="https://img.shields.io/badge/tests-918-6E8BFF?style=flat-square" alt="918 tests"></a>
-  <a href="#whats-inside"><img src="https://img.shields.io/badge/dogfooded-%E2%9C%93-43D9AD?style=flat-square" alt="dogfooded"></a>
-  <a href="#run-it-on-your-agent"><img src="https://img.shields.io/badge/runs%20on-Pi%20%2B%20Codex-B692FF?style=flat-square" alt="runs on Pi and Codex"></a>
+  <a href="#whats-inside"><img src="https://img.shields.io/badge/tests-918-4B4ACF?style=flat-square" alt="918 tests"></a>
+  <a href="#whats-inside"><img src="https://img.shields.io/badge/dogfooded-%E2%9C%93-0E8A66?style=flat-square" alt="dogfooded"></a>
+  <a href="#run-it-on-your-agent"><img src="https://img.shields.io/badge/runs%20on-Pi%20%2B%20Codex-4B4ACF?style=flat-square" alt="runs on Pi and Codex"></a>
 </p>
 
 <p align="center">

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -36,6 +36,6 @@
     ],
     "composerIcon": "./assets/taskflow-small.svg",
     "logo": "./assets/taskflow.svg",
-    "brandColor": "#B692FF"
+    "brandColor": "#4B4ACF"
   }
 }

--- a/packages/codex-taskflow/plugin/assets/taskflow-small.svg
+++ b/packages/codex-taskflow/plugin/assets/taskflow-small.svg
@@ -1,14 +1,14 @@
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Taskflow">
-  <g stroke="#9FB6F0" stroke-width="2.4" stroke-linecap="round" fill="none">
+  <g stroke="#8B8AE3" stroke-width="2.4" stroke-linecap="round" fill="none">
     <path d="M12 24 C18 24, 18 12, 24 12"/>
     <path d="M12 24 H24"/>
     <path d="M12 24 C18 24, 18 36, 24 36"/>
     <path d="M24 12 C30 12, 30 24, 36 24"/>
     <path d="M24 36 C30 36, 30 24, 36 24"/>
   </g>
-  <circle cx="12" cy="24" r="5" fill="#A78BFA"/>
-  <circle cx="24" cy="12" r="3.6" fill="#6E8BFF"/>
-  <circle cx="24" cy="24" r="3.6" fill="#6E8BFF"/>
-  <circle cx="24" cy="36" r="3.6" fill="#6E8BFF"/>
-  <circle cx="36" cy="24" r="5" fill="#43D9AD"/>
+  <circle cx="12" cy="24" r="5" fill="#6B6AD9"/>
+  <circle cx="24" cy="12" r="3.6" fill="#8B8AE3"/>
+  <circle cx="24" cy="24" r="3.6" fill="#8B8AE3"/>
+  <circle cx="24" cy="36" r="3.6" fill="#8B8AE3"/>
+  <circle cx="36" cy="24" r="5" fill="#1FA57E"/>
 </svg>

--- a/packages/codex-taskflow/plugin/assets/taskflow.svg
+++ b/packages/codex-taskflow/plugin/assets/taskflow.svg
@@ -1,16 +1,7 @@
 <svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Taskflow — a declarative DAG of subagent tasks">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#131A2E"/>
-      <stop offset="1" stop-color="#0A0E18"/>
-    </linearGradient>
-    <linearGradient id="edge" x1="0" y1="0" x2="512" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#6E8BFF"/>
-      <stop offset="1" stop-color="#B692FF"/>
-    </linearGradient>
-  </defs>
-  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
-  <g stroke="url(#edge)" stroke-width="10" stroke-linecap="round" fill="none" opacity="0.9">
+  <rect width="512" height="512" rx="112" fill="#F7F6F3"/>
+  <rect x="4" y="4" width="504" height="504" rx="108" stroke="#E5E3DD" stroke-width="8"/>
+  <g stroke="#4B4ACF" stroke-width="12" stroke-linecap="round" fill="none">
     <path d="M150 256 C205 256, 205 150, 256 150"/>
     <path d="M150 256 C205 256, 205 256, 256 256"/>
     <path d="M150 256 C205 256, 205 362, 256 362"/>
@@ -18,9 +9,9 @@
     <path d="M256 256 C312 256, 312 256, 362 256"/>
     <path d="M256 362 C312 362, 312 256, 362 256"/>
   </g>
-  <circle cx="150" cy="256" r="34" fill="#A78BFA"/>
-  <circle cx="256" cy="150" r="26" fill="#6E8BFF"/>
-  <circle cx="256" cy="256" r="26" fill="#6E8BFF"/>
-  <circle cx="256" cy="362" r="26" fill="#6E8BFF"/>
-  <circle cx="362" cy="256" r="34" fill="#43D9AD"/>
+  <circle cx="150" cy="256" r="34" fill="#4B4ACF"/>
+  <circle cx="256" cy="150" r="26" fill="#8B8AE3"/>
+  <circle cx="256" cy="256" r="26" fill="#8B8AE3"/>
+  <circle cx="256" cy="362" r="26" fill="#8B8AE3"/>
+  <circle cx="362" cy="256" r="34" fill="#0E8A66"/>
 </svg>


### PR DESCRIPTION
## Summary
Follow-up to #22 — sweeps the remaining brand material to the new light visual system:

- **README badges** (en + zh): neon `B692FF/6E8BFF/43D9AD` → indigo `#4B4ACF`, green `#0E8A66`, neutral gray
- **Codex plugin icons** `taskflow.svg` / `taskflow-small.svg`: dark neon tile → light tile with the same indigo DAG mark as the README hero logo
- **plugin.json** `brandColor`: `#B692FF` → `#4B4ACF`

`packages/*/README.md` are git-ignored build-time copies of the root README, so they inherit the badge changes automatically.

## Test plan
- [x] Both icons re-rendered and visually verified
- [x] No remaining old-palette hex codes outside assets/ SVG history and run logs