### PR TITLE
feat(website): generate sitemap.xml for search engines

### DIFF
--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next';
+import { source } from '@/lib/source';
+
+export const dynamic = 'force-static';
+
+const baseUrl = 'https://heggria.github.io/taskflow';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const pages = source.getPages();
+
+  const docsUrls = pages.map((page) => ({
+    url: `${baseUrl}${page.url}/`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: page.url === '/docs' || page.url === '/en/docs' || page.url === '/zh-cn/docs' ? 0.9 : 0.7,
+  }));
+
+  return [
+    { url: `${baseUrl}/`, lastModified: new Date(), changeFrequency: 'weekly', priority: 1 },
+    { url: `${baseUrl}/en/`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${baseUrl}/zh-cn/`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.9 },
+    ...docsUrls,
+  ];
+}


### PR DESCRIPTION
Adds  to generate a static  during Next.js export.\n\nThe sitemap includes:\n- Home, , and \n- All docs pages from the Fumadocs source for both locales\n- Trailing slashes to match the site's  config\n\nOnce deployed, the sitemap will be available at  and can be submitted to Google Search Console and Bing Webmaster Tools.\n\nBuild verified: 
> taskflow-website@0.1.0 build
> next build

▲ Next.js 16.2.10 (Turbopack)

[MDX] generated files in 10.15141699999981ms
  Creating an optimized production build ...
✓ Compiled successfully in 4.8s
  Running TypeScript ...
  Finished TypeScript in 2.0s ...
  Collecting page data using 8 workers ...
  Generating static pages using 8 workers (0/62) ...
  Generating static pages using 8 workers (15/62) 
  Generating static pages using 8 workers (30/62) 
  Generating static pages using 8 workers (46/62) 
✓ Generating static pages using 8 workers (62/62) in 929ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ● /[lang]
│ ├ /en
│ └ /zh-cn
├ ● /[lang]/docs/[[...slug]]
│ ├ /en/docs/getting-started
│ ├ /en/docs
│ ├ /en/docs/what-is-taskflow
│ └ [+51 more paths]
├ ● /-/opengraph-image
│ ├ /en/opengraph-image
│ └ /zh-cn/opengraph-image
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams) produces .