### PR TITLE
feat(website): add robots.txt pointing to sitemap

### DIFF
--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://heggria.github.io/taskflow/sitemap.xml


### PR DESCRIPTION
Adds a robots.txt file to the static site that allows all crawlers and points them to the sitemap URL.