### PR TITLE
feat(website): prepare Google Search Console verification

### DIFF
--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -20,6 +20,10 @@ const site = {
   },
 } as const;
 
+// Replace this with the actual content from Google Search Console HTML tag verification.
+// Example: 'abc123...'
+const GOOGLE_SITE_VERIFICATION = process.env.GOOGLE_SITE_VERIFICATION || '';
+
 export async function generateMetadata({
   params,
 }: {
@@ -45,6 +49,9 @@ export async function generateMetadata({
     icons: {
       icon: [{ url: '/favicon.svg', type: 'image/svg+xml' }],
     },
+    verification: GOOGLE_SITE_VERIFICATION
+      ? { google: GOOGLE_SITE_VERIFICATION }
+      : undefined,
   };
 }
 

--- a/website/public/google-site-verification.html
+++ b/website/public/google-site-verification.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Google Search Console Verification Placeholder</title>
+  </head>
+  <body>
+    <p>
+      This file is a placeholder for Google Search Console HTML file verification.
+    </p>
+    <p>
+      To verify, go to
+      <a href="https://search.google.com/search-console">Google Search Console</a>,
+      add the property <code>https://heggria.github.io/taskflow/</code>, choose
+      <strong>HTML tag</strong> verification, and copy the <code>content</code>
+      value from the meta tag. Then replace the placeholder verification value in
+      <code>website/app/[lang]/layout.tsx</code> (or provide the content so it can
+      be updated and redeployed).
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Prepares the site for Google Search Console verification by reading GOOGLE_SITE_VERIFICATION from the environment and adding a placeholder HTML file with instructions.