### PR TITLE
fix(website): correct per-page hreflang URLs in docs metadata

### DIFF
--- a/website/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/app/[lang]/docs/[[...slug]]/page.tsx
@@ -137,8 +137,33 @@ export async function generateMetadata({
   const page = source.getPage(slug, lang);
   if (!page) return {};
 
+  const canonicalUrl = `${SITE_URL}${page.url}/`;
+  // page.url already includes the locale prefix, e.g. /en/docs/getting-started
+  // Derive the locale-agnostic path by stripping the leading locale segment.
+  const pathWithoutLocale = page.url.replace(/^\/(en|zh-cn)/, '');
+
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: canonicalUrl,
+      languages: {
+        en: `${SITE_URL}/en${pathWithoutLocale}/`,
+        'zh-CN': `${SITE_URL}/zh-cn${pathWithoutLocale}/`,
+        'x-default': `${SITE_URL}/en${pathWithoutLocale}/`,
+      },
+    },
+    openGraph: {
+      title: page.data.title,
+      description: page.data.description,
+      url: canonicalUrl,
+      images: '/opengraph-image',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.data.title,
+      description: page.data.description,
+      images: '/opengraph-image',
+    },
   };
 }


### PR DESCRIPTION
Fixes the hreflang alternate URLs on docs pages. The page.url from Fumadocs already includes the locale prefix, so the previous code was duplicating it (/en/en/docs/...). This change derives the locale-agnostic path and rebuilds the en/zh-CN/x-default URLs correctly.