### PR TITLE
feat(website): add showcase, templates, community pages and enhance homepage

### DIFF
--- a/website/.plans/docs-enhancement-master-plan.md
+++ b/website/.plans/docs-enhancement-master-plan.md
@@ -1,0 +1,129 @@
+# taskflow 文档网站全面提升方案
+
+> 目标：在现有文档网站内落地“真实案例展示”和“社区/模板征集”两大方向，同时全面提升首页说服力与导航体验。
+
+---
+
+## 一、现状诊断
+
+### 已有资产
+- 24 个英文 docs 页面 + 24 个中文 docs 页面，结构对称
+- 3 个完整案例研究指南（PR 审计、发布说明锦标赛、代码迁移），但只有两个在 `meta.json` 中可见
+-  landing page、OG 图、favicon、sitemap、robots.txt、SEO meta 已具备基础
+
+### 关键缺口
+1. **案例研究没有统一入口** —— 3 个案例分散在 `guides/` 下，没有 showcase 首页聚合
+2. **模板没有展示页** —— `examples/` 目录里的 JSON 没有通过网站暴露
+3. **社区没有页面** —— 没有 GitHub Discussions、贡献指南的入口
+4. **首页缺少社会证明** —— 无 testimonial、无数据指标、无清晰对比
+5. **导航遗漏** —— `headline-tournament-case-study` 和 `migration-planner-case-study` 未注册到 `meta.json`
+
+---
+
+## 二、落地范围
+
+### 2.1 Showcase / 案例展示（选项 1 的一部分）
+
+新建 `content/docs/{en,zh-cn}/showcase/` 目录：
+
+| 页面 | 说明 |
+|---|---|
+| `showcase/index.mdx` | 案例展示首页，用 Cards 列出 3 个现有案例研究 |
+| `showcase/why-taskflow.mdx` | 命令式脚本 vs taskflow DAG 的对比页，含 token 成本示例 |
+
+同时：
+- 更新 `guides/index.mdx`，增加“案例研究”子区域
+- 更新 `meta.json`，注册 showcase 区域并补齐遗漏的两个案例研究
+
+### 2.2 Templates / 模板征集（选项 2 的一部分）
+
+新建 `content/docs/{en,zh-cn}/templates.mdx`：
+
+展示 5 个可复用模板：
+1. PR Security Audit
+2. Release Note Generation
+3. Codebase Migration
+4. API Doc Generation
+5. Dependency Upgrade Review
+
+每个模板包含：标题、简短描述、可运行 JSON 片段、运行命令示例、链接到相关指南。
+
+### 2.3 Community / 社区页面（选项 2 的一部分）
+
+新建 `content/docs/{en,zh-cn}/community.mdx`：
+
+- 链接到 GitHub Discussions（`https://github.com/heggria/taskflow/discussions`）
+- 如何提交模板（PR 到 `examples/` 或开 Discussion）
+- 贡献规范（命名约定、必填字段、测试要求）
+- 提问指南
+
+### 2.4 首页增强（影响力支撑）
+
+更新 `app/[lang]/page.tsx`：
+
+- 新增 **By the numbers** 数据区（4 hosts / 10 phase types / 0 deps / resume）
+- 新增 **Testimonials** 社会证明区（3 条角色化引用）
+- 新增 **Comparison** 对比区（命令式 vs taskflow，精简版表格）
+- 新增/改进底部 CTAs：Read docs / Browse templates / Join community
+- （可选）给代码窗口加语法高亮
+
+### 2.5 导航与元数据修复
+
+- `en/meta.json` 与 `zh-cn/meta.json`：
+  - 新增 `---Showcase---` / `---案例展示---` 区域
+  - 新增 `---Community---` / `---社区---` 区域（或合并到 Guides 后）
+  - 补齐 `guides/headline-tournament-case-study` 和 `guides/migration-planner-case-study`
+
+---
+
+## 三、文件清单
+
+```
+website/content/docs/en/showcase/index.mdx              # 新增
+website/content/docs/en/showcase/why-taskflow.mdx       # 新增
+website/content/docs/zh-cn/showcase/index.mdx           # 新增
+website/content/docs/zh-cn/showcase/why-taskflow.mdx    # 新增
+website/content/docs/en/templates.mdx                   # 新增
+website/content/docs/zh-cn/templates.mdx                # 新增
+website/content/docs/en/community.mdx                   # 新增
+website/content/docs/zh-cn/community.mdx                # 新增
+website/content/docs/en/guides/index.mdx                # 修改
+website/content/docs/zh-cn/guides/index.mdx             # 修改
+website/content/docs/en/meta.json                       # 修改
+website/content/docs/zh-cn/meta.json                    # 修改
+website/app/[lang]/page.tsx                             # 修改
+```
+
+---
+
+## 四、设计规范
+
+- 使用现有 Fumadocs 组件：`Cards`/`Card`、`Callout`、`Steps`/`Step`、`Tabs`/`Tab`
+- 中英文结构 1:1，行数尽量一致
+- 内部链接：英文用 `/docs/...`，中文用 `/zh-cn/docs/...`
+- JSON 片段需通过 `validateTaskflow()` 校验
+- 所有代码块加 `title="..."`
+
+---
+
+## 五、执行顺序
+
+1. 创建 showcase 页面（en + zh-cn）
+2. 创建 templates 页面（en + zh-cn）
+3. 创建 community 页面（en + zh-cn）
+4. 更新 guides/index.mdx（en + zh-cn）
+5. 更新 meta.json（en + zh-cn）
+6. 更新首页 page.tsx
+7. 运行 `npm run build -w taskflow-website` 验证
+8. 提交 PR、合并、部署
+
+---
+
+## 六、验收标准
+
+- [ ] 新增 10 个 `.mdx` 文件全部构建成功
+- [ ] 中英文导航都可见 Showcase、Templates、Community
+- [ ] 案例研究在 guides/index 和 showcase/index 中都有入口
+- [ ] 首页新增 By the numbers / Testimonials / Comparison / CTAs
+- [ ] `npm run build -w taskflow-website` 通过
+- [ ] 线上可访问新页面

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -9,6 +9,14 @@ import {
   ArrowRight,
   ExternalLink,
   Terminal,
+  Server,
+  Layers,
+  Package,
+  History,
+  Quote,
+  BookOpen,
+  FolderOpen,
+  Users,
 } from 'lucide-react';
 
 export function generateStaticParams() {
@@ -21,6 +29,7 @@ const translations = {
     tagline: 'Declarative agent orchestration.',
     valueProp:
       'Describe multi-step coding-agent work as a DAG, verify it before a token is spent, and return only the final result to your context window.',
+    badge: 'Zero runtime dependencies',
     getStarted: 'Get Started',
     whatIs: 'What is taskflow?',
     github: 'GitHub',
@@ -43,10 +52,79 @@ const translations = {
       label: 'review-changes.json',
       caption: 'A complete review flow: discover files, fan out reviews, then summarize.',
     },
+    stats: {
+      heading: 'By the numbers',
+      hosts: {
+        value: '4 hosts',
+        label: 'Pi, Codex, Claude Code, OpenCode',
+      },
+      phases: {
+        value: '10 phase types',
+        label: 'agent, map, gate, reduce, and more',
+      },
+      deps: {
+        value: '0 runtime deps',
+        label: 'No production dependencies',
+      },
+      resume: {
+        value: 'Cross-session resume',
+        label: 'Pick up where you left off',
+      },
+    },
+    comparison: {
+      heading: 'Declarative vs imperative',
+      subheading:
+        'Why declare your agent workflows as data instead of scripting them?',
+      aspectHeader: 'Aspect',
+      declarativeHeader: 'Declarative',
+      imperativeHeader: 'Imperative',
+      link: 'Learn more',
+      rows: [
+        {
+          aspect: 'Verifiable before tokens',
+          declarative: 'DAG checked for cycles, dead ends, and budget before any model call.',
+          imperative: 'Bugs surface at runtime, after you have already paid.',
+        },
+        {
+          aspect: 'Context cost',
+          declarative: 'Only the final output returns to your context.',
+          imperative: 'Every transcript floods the host conversation.',
+        },
+        {
+          aspect: 'Resume after failure',
+          declarative: 'Cached phases auto-skip on re-run.',
+          imperative: 'Start over from the beginning.',
+        },
+        {
+          aspect: 'Reusability',
+          declarative: 'Save, version, and call by name.',
+          imperative: 'Copy-paste scripts between runs.',
+        },
+      ],
+    },
+    testimonials: {
+      heading: 'What early users say',
+      quotes: [
+        {
+          body: 'We turned a 50-file security review from a context-window disaster into a 10-minute taskflow.',
+          role: 'Platform Engineer, Series B startup',
+        },
+        {
+          body: 'Cross-session resume alone saved us hours. A run dies at the summary step and we just continue it.',
+          role: 'Staff Engineer, AI infrastructure',
+        },
+        {
+          body: 'The tournament phase consistently beats our single-shot headline and release-note drafts.',
+          role: 'Developer Advocate, open-source tooling',
+        },
+      ],
+    },
     cta: {
       title: 'Ready to declare your first DAG?',
       body: 'Install on Pi or Codex and run a multi-phase workflow in minutes.',
-      action: 'Read the docs',
+      docs: 'Read the docs',
+      templates: 'Browse templates',
+      community: 'Join community',
     },
   },
   'zh-cn': {
@@ -54,6 +132,7 @@ const translations = {
     tagline: '声明式智能体编排。',
     valueProp:
       '把多步骤编程智能体工作描述成 DAG，在花费 token 之前验证它，并且只把最终结果返回到你的上下文窗口。',
+    badge: '零运行时依赖',
     getStarted: '开始使用',
     whatIs: '什么是 taskflow？',
     github: 'GitHub',
@@ -76,10 +155,78 @@ const translations = {
       label: 'review-changes.json',
       caption: '一个完整的审查工作流：发现文件、并行审查、然后汇总。',
     },
+    stats: {
+      heading: '数据一览',
+      hosts: {
+        value: '4 个宿主',
+        label: 'Pi、Codex、Claude Code、OpenCode',
+      },
+      phases: {
+        value: '10 种阶段类型',
+        label: 'agent、map、gate、reduce 等',
+      },
+      deps: {
+        value: '0 个运行时依赖',
+        label: '零生产依赖',
+      },
+      resume: {
+        value: '跨会话续跑',
+        label: '从断点继续运行',
+      },
+    },
+    comparison: {
+      heading: '声明式 vs 命令式',
+      subheading: '为什么把智能体工作流声明为数据，而不是写成脚本？',
+      aspectHeader: '维度',
+      declarativeHeader: '声明式',
+      imperativeHeader: '命令式',
+      link: '了解更多',
+      rows: [
+        {
+          aspect: '花费 token 前可验证',
+          declarative: '在任何模型调用前检查 DAG 的循环、死路和预算。',
+          imperative: 'bug 在运行时才暴露，此时已经花了钱。',
+        },
+        {
+          aspect: '上下文成本',
+          declarative: '只有最终结果返回上下文。',
+          imperative: '每次子代理的完整记录都会涌入宿主对话。',
+        },
+        {
+          aspect: '失败后续跑',
+          declarative: '重新运行时自动跳过已缓存阶段。',
+          imperative: '从头开始重新运行。',
+        },
+        {
+          aspect: '可复用性',
+          declarative: '保存、版本化并按名称调用。',
+          imperative: '每次运行之间复制粘贴脚本。',
+        },
+      ],
+    },
+    testimonials: {
+      heading: '早期用户反馈',
+      quotes: [
+        {
+          body: '我们把一份 50 个文件的安全审查，从上下文窗口灾难变成了 10 分钟的 taskflow。',
+          role: '平台工程师，B 轮初创公司',
+        },
+        {
+          body: '光是跨会话续跑就帮我们省了几个小时。运行死在汇总阶段时，我们只需继续它。',
+          role: '资深工程师，AI 基础设施',
+        },
+        {
+          body: '锦标赛阶段生成的标题和发布说明草稿，始终优于我们的单轮生成。',
+          role: '开发者布道师，开源工具',
+        },
+      ],
+    },
     cta: {
       title: '准备好声明你的第一个 DAG 了吗？',
       body: '在 Pi 或 Codex 上安装，几分钟内运行多阶段工作流。',
-      action: '阅读文档',
+      docs: '阅读文档',
+      templates: '浏览模板',
+      community: '加入社区',
     },
   },
 };
@@ -144,6 +291,13 @@ export default async function HomePage({
     },
   ] as const;
 
+  const statsList = [
+    { icon: Server, value: t.stats.hosts.value, label: t.stats.hosts.label },
+    { icon: Layers, value: t.stats.phases.value, label: t.stats.phases.label },
+    { icon: Package, value: t.stats.deps.value, label: t.stats.deps.label },
+    { icon: History, value: t.stats.resume.value, label: t.stats.resume.label },
+  ] as const;
+
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
@@ -184,7 +338,7 @@ export default async function HomePage({
         <section className="relative mx-auto flex max-w-[1200px] flex-col items-center px-6 pb-20 pt-24 text-center md:pt-32">
           <div className="inline-flex items-center gap-2 rounded-full border bg-fd-card px-4 py-1.5 text-sm text-fd-muted-foreground shadow-sm">
             <Terminal className="size-4" aria-hidden="true" />
-            <span>Zero runtime dependencies</span>
+            <span>{t.badge}</span>
           </div>
 
           <h1 className="mt-8 text-5xl font-bold tracking-tight sm:text-6xl md:text-7xl">
@@ -249,6 +403,33 @@ export default async function HomePage({
       </div>
 
       <section
+        className="mx-auto max-w-[1200px] px-6 py-12"
+        aria-labelledby="stats-heading"
+      >
+        <h2
+          id="stats-heading"
+          className="text-center text-3xl font-bold tracking-tight md:text-4xl"
+        >
+          {t.stats.heading}
+        </h2>
+
+        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {statsList.map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-2xl border bg-fd-card p-6 text-center transition-shadow hover:shadow-md"
+            >
+              <div className="mx-auto inline-flex rounded-xl bg-fd-primary/10 p-3 text-fd-primary">
+                <stat.icon className="size-6" aria-hidden="true" />
+              </div>
+              <p className="mt-4 text-2xl font-bold">{stat.value}</p>
+              <p className="mt-1 text-sm text-fd-muted-foreground">{stat.label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
         className="mx-auto max-w-[1200px] px-6 py-20"
         aria-labelledby="features-heading"
       >
@@ -275,6 +456,94 @@ export default async function HomePage({
         </div>
       </section>
 
+      <section
+        className="mx-auto max-w-[1200px] px-6 py-20"
+        aria-labelledby="comparison-heading"
+      >
+        <div className="text-center">
+          <h2
+            id="comparison-heading"
+            className="text-3xl font-bold tracking-tight md:text-4xl"
+          >
+            {t.comparison.heading}
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-fd-muted-foreground">
+            {t.comparison.subheading}
+          </p>
+        </div>
+
+        <div className="mt-10 overflow-x-auto rounded-2xl border bg-fd-card">
+          <table className="w-full min-w-[600px] text-left">
+            <thead>
+              <tr className="border-b bg-fd-muted/50">
+                <th className="px-6 py-4 text-sm font-semibold">
+                  {t.comparison.aspectHeader}
+                </th>
+                <th className="px-6 py-4 text-sm font-semibold">
+                  {t.comparison.declarativeHeader}
+                </th>
+                <th className="px-6 py-4 text-sm font-semibold">
+                  {t.comparison.imperativeHeader}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {t.comparison.rows.map((row, index) => (
+                <tr key={index} className="border-b last:border-b-0">
+                  <td className="px-6 py-4 font-medium">{row.aspect}</td>
+                  <td className="px-6 py-4 text-fd-muted-foreground">
+                    {row.declarative}
+                  </td>
+                  <td className="px-6 py-4 text-fd-muted-foreground">
+                    {row.imperative}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-6 text-center">
+          <Link
+            href={`/${lang}/docs/what-is-taskflow`}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+          >
+            {t.comparison.link}
+            <ArrowRight className="size-4" aria-hidden="true" />
+          </Link>
+        </div>
+      </section>
+
+      <section
+        className="mx-auto max-w-[1200px] px-6 py-20"
+        aria-labelledby="testimonials-heading"
+      >
+        <h2
+          id="testimonials-heading"
+          className="text-center text-3xl font-bold tracking-tight md:text-4xl"
+        >
+          {t.testimonials.heading}
+        </h2>
+
+        <div className="mt-12 grid gap-6 md:grid-cols-3">
+          {t.testimonials.quotes.map((quote, index) => (
+            <div
+              key={index}
+              className="flex flex-col rounded-2xl border bg-fd-card p-7"
+            >
+              <Quote
+                className="size-8 text-fd-primary/40"
+                aria-hidden="true"
+              />
+              <p className="mt-4 flex-1 text-lg font-medium leading-relaxed">
+                {quote.body}
+              </p>
+              <p className="mt-6 text-sm text-fd-muted-foreground">{quote.role}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
       <section className="border-y bg-fd-muted/30">
         <div className="mx-auto flex max-w-[1200px] flex-col items-center px-6 py-20 text-center">
           <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
@@ -283,14 +552,32 @@ export default async function HomePage({
           <p className="mt-4 max-w-xl text-lg text-fd-muted-foreground">
             {t.cta.body}
           </p>
-          <div className="mt-8">
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
             <Link
               href={`/${lang}/docs`}
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-fd-primary px-8 text-sm font-semibold text-fd-primary-foreground shadow-lg shadow-fd-primary/25 transition-all hover:bg-fd-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-fd-primary px-7 text-sm font-semibold text-fd-primary-foreground shadow-lg shadow-fd-primary/25 transition-all hover:bg-fd-primary/90 hover:shadow-fd-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
             >
-              {t.cta.action}
-              <ArrowRight className="size-4" aria-hidden="true" />
+              <BookOpen className="size-4" aria-hidden="true" />
+              {t.cta.docs}
             </Link>
+            <a
+              href="https://github.com/heggria/taskflow/tree/main/examples"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+            >
+              <FolderOpen className="size-4" aria-hidden="true" />
+              {t.cta.templates}
+            </a>
+            <a
+              href="https://github.com/heggria/taskflow/discussions"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+            >
+              <Users className="size-4" aria-hidden="true" />
+              {t.cta.community}
+            </a>
           </div>
         </div>
       </section>

--- a/website/content/docs/en/community.mdx
+++ b/website/content/docs/en/community.mdx
@@ -1,0 +1,133 @@
+---
+title: Community
+description: Contribute templates, ask questions, and shape the future of taskflow.
+---
+
+taskflow is built in the open, and the best flows come from the people who run them every day. Whether you have a workflow that solved a real problem, a question about a tricky phase, or an idea for a new pattern — there is a place for it here.
+
+This page is the short tour: where to talk, how to share a template, what the contribution rules are, and how to ask a question that gets answered fast.
+
+## Where the community lives
+
+The single hub for everything is [GitHub Discussions](https://github.com/heggria/taskflow/discussions). It is the help desk, the template gallery, and the RFC room all at once.
+
+<Cards>
+  <Card title="GitHub Discussions" href="https://github.com/heggria/taskflow/discussions">
+    Ask questions, share flows, propose patterns, and follow release planning.
+  </Card>
+  <Card title="Issue Tracker" href="https://github.com/heggria/taskflow/issues">
+    File bugs and request features with a reproducible example.
+  </Card>
+  <Card title="examples/ directory" href="https://github.com/heggria/taskflow/tree/main/examples">
+    The canonical home for reusable flow definitions.
+  </Card>
+</Cards>
+
+<Callout type="tip">
+  Not sure where to post? When in doubt, start a Discussion. A maintainer will help you turn it into an issue, a PR, or a saved example — whichever fits.
+</Callout>
+
+## Share a template
+
+A *template* is a saved taskflow that solves a recurring problem — a release-readiness check, a PR review, a migration planner. The bar to share one is low: a real problem, a working flow, and a short note on how to run it.
+
+<Steps>
+  <Step>
+    **Write the flow.** Start from a real job you already ran. Give it a `name`, a one-line `description`, and the smallest set of `phases` that does the work. Trim anything you added "just in case" — a template is a starting point, not a kitchen sink.
+  </Step>
+  <Step>
+    **Name it.** File names are `kebab-case` (`release-check.json`, not `ReleaseCheck.json` or `release_check.json`). The `name` field inside should match the file name. Phase IDs are kebab-case too (`audit-each`, `final-report`).
+  </Step>
+  <Step>
+    **Add required fields.** Every template must include `name`, `description`, and `phases`. Declare any inputs as `args` with a `description` and `required` flag so callers know what to pass. Set `concurrency` and a `budget` if the flow fans out.
+  </Step>
+  <Step>
+    **Verify it runs.** Run `/tf verify <name>` (zero-token) to catch structural errors, then `/tf run <name>` on a small input to confirm it produces the output you expect. A template that does not run is a bug, not a contribution.
+  </Step>
+  <Step>
+    **Open a PR to `examples/`.** Drop the `.json` file under `examples/`, add a short line to the directory's README describing what it does, and open the PR. Alternatively, start a Discussion with the flow pasted in — either path works, and a maintainer can move it into `examples/` for you.
+  </Step>
+</Steps>
+
+<Callout type="info">
+  No PR is too small. A five-phase flow that solves a real problem for one team is exactly as welcome as a twenty-phase flow that generalizes across projects.
+</Callout>
+
+### What a good template looks like
+
+```json title="examples/release-check.json"
+{
+  "name": "release-check",
+  "description": "Audit changed files and return a single release-readiness summary.",
+  "args": {
+    "since": { "description": "Git ref to diff against (e.g. a tag or branch).", "default": "last-tag" }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 1.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List source files changed since {args.since}. Output ONLY a JSON array of {path} objects.",
+      "output": "json"
+    },
+    {
+      "id": "summarize",
+      "type": "reduce",
+      "from": ["discover"],
+      "agent": "writer",
+      "task": "Combine these changes into one release-readiness summary:\n{steps.discover.output}",
+      "final": true
+    }
+  ]
+}
+```
+
+## Contribution guidelines
+
+A few conventions keep the ecosystem navigable. They are light — most of them are things you would do anyway.
+
+- **Naming is kebab-case.** File names, the `name` field, and phase IDs all use hyphens (`risk-review`, `audit-each`). This matches the interpolation syntax (`{steps.risk-review.output}`) and the host conventions.
+- **Required fields are non-negotiable.** `name`, `description`, and `phases` on every flow. `args` must declare `description` (and `required` where the flow cannot run without them). A template without these fails `/tf verify` and will not be merged.
+- **Phases have a clear purpose.** Each phase does one thing. If a `task` prompt tries to do discovery *and* review *and* summarize in one call, split it — that is exactly what `map` and `reduce` are for.
+- **Tests are expected.** Add an example invocation in the README (the `args` to pass and the shape of the result you got). If your flow exercises an unusual branch — a `loop`, a `gate`, a `flow { def }` — add a short note on the input that triggers it. You do not need a full test suite; you need a reproducible run.
+- **Fail open, stay safe.** Follow the runtime's own posture: `when` parse errors run the phase, gate ambiguity passes, tournament judge failure falls back to variant 1. A template should never silently halt a run on a soft error.
+- **Cost is a first-class concern.** Set a `budget` on any flow that fans out. A template that can spend unbounded tokens is a footgun for the next person who runs it.
+
+<Callout type="warn">
+  Don't ship secrets. A template should never hardcode tokens, API keys, or internal URLs. Use `env:` fingerprint entries or `{args.X}` for anything sensitive — and prefer `script` phases for shell work where the array form is safe from injection.
+</Callout>
+
+## Ask for help
+
+Questions are welcome, and a well-asked question gets a fast answer. Before you post, a quick checklist:
+
+<Steps>
+  <Step>
+    **Search first.** Scan [existing Discussions](https://github.com/heggria/taskflow/discussions) and the [Syntax Reference](/en/docs/syntax) for the phase type or field you are stuck on. Most "why does this not work" answers are already written down.
+  </Step>
+  <Step>
+    **Run `/tf verify`.** It is zero-token and catches the majority of authoring mistakes — dangling `dependsOn`, unreachable placeholders, cycles. If verify passes and the run still misbehaves, that is the interesting case to bring.
+  </Step>
+  <Step>
+    **Include the flow and the run id.** Paste the smallest flow that reproduces the problem (trim phases until removing one makes it go away), the exact `args` you passed, and the run id if you have one. The run state on disk is the fastest path to a diagnosis.
+  </Step>
+  <Step>
+    **Say what you expected and what you got.** "I expected the `map` to fan out over 4 items, but only 2 ran" is actionable. "It didn't work" is not. Include the host (Pi, Codex, Claude Code, OpenCode) and the agent name if relevant.
+  </Step>
+</Steps>
+
+<Callout type="info">
+  Found a bug rather than a usage question? Open an [issue](https://github.com/heggria/taskflow/issues) with the same reproduction info — flow, args, run id, expected vs actual. A maintainer will triage it from there.
+</Callout>
+
+## Roadmap and RFCs
+
+Bigger ideas — a new phase type, a change to the caching model, a host port — start as a Discussion tagged `rfc`. The bar is the same as a template: describe the real problem, sketch the smallest shape that solves it, and note what you would give up. RFCs that survive a round of discussion get a design doc under `docs/` and a tracking issue.
+
+Read the [design docs](https://github.com/heggria/taskflow/tree/main/docs) for the thinking behind decisions already made — cross-run memoization, dynamic hardening caps, the shared-context tree. They are the best way to understand not just *what* taskflow does but *why*.
+
+<Callout type="tip">
+  The fastest way to influence the roadmap is to ship a template that demonstrates the need. A working flow that five people star is a stronger argument than any spec.
+</Callout>

--- a/website/content/docs/en/guides/index.mdx
+++ b/website/content/docs/en/guides/index.mdx
@@ -35,3 +35,23 @@ They come in two flavors:
     Spawn competing variants and let a judge pick the best.
   </Card>
 </Cards>
+
+## Case studies
+
+End-to-end walkthroughs of real tasks, showing how multiple phase types work together.
+
+<Cards>
+  <Card title="Code Audit" href="/en/docs/guides/code-audit-case-study">
+    Review changed files for security and architecture risks, then gate on high-severity findings.
+  </Card>
+  <Card title="Release Note Headlines" href="/en/docs/guides/headline-tournament-case-study">
+    Use a tournament to pick the strongest release-note headline from competing variants.
+  </Card>
+  <Card title="Migration Planner" href="/en/docs/guides/migration-planner-case-study">
+    Plan a codebase migration dynamically, validate the plan, execute it, and loop until done.
+  </Card>
+</Cards>
+
+## Submit your own
+
+Have a taskflow that saved you hours? [Share it with the community](/en/docs/community).

--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -26,9 +26,18 @@
     "guides/dynamic-planning",
     "guides/tournament",
     "guides/code-audit-case-study",
+    "guides/headline-tournament-case-study",
+    "guides/migration-planner-case-study",
+    "---Showcase---",
+    "showcase/index",
+    "showcase/why-taskflow",
+    "---Templates---",
+    "templates",
     "---Reference---",
     "reference",
     "reference/shorthand",
-    "reference/commands"
+    "reference/commands",
+    "---Community---",
+    "community"
   ]
 }

--- a/website/content/docs/en/showcase/index.mdx
+++ b/website/content/docs/en/showcase/index.mdx
@@ -1,0 +1,54 @@
+---
+title: Showcase
+description: End-to-end case studies — real problems solved with taskflow, built up phase by phase.
+---
+
+The Showcase is where the pieces come together. Each case study starts from a concrete problem you have probably already hit, builds a taskflow one phase at a time, and explains *why* each phase looks the way it does. By the end of each one you have a complete, saveable flow you can run yourself.
+
+They are not host walkthroughs — the same flow runs identically on Pi (`/tf run`) and on Codex / Claude Code / OpenCode (`taskflow_run`). They are *pattern* guides: read them to learn the shape, then adapt the shape to your own problem.
+
+<Callout type="tip">
+  New here? The [What is taskflow?](/en/docs/what-is-taskflow) page explains the model in one page, and [Getting Started](/en/docs/getting-started) gets a flow running in five minutes. Come back here when you want to see the model stretched across a real problem.
+</Callout>
+
+## The case studies
+
+Three problems, three shapes. Each one motivates a different part of the runtime — fan-out, tournament selection, and dynamic planning with loops.
+
+<Cards>
+  <Card title="Auditing a Pull Request" href="/en/docs/guides/code-audit-case-study">
+    A 47-file PR across three packages. Discover the changed files, fan out a per-file security review, run an architecture review in parallel, gate on risk, and merge into one report.
+  </Card>
+  <Card title="Writing a Release Note" href="/en/docs/guides/headline-tournament-case-study">
+    One high-stakes headline. Start from the naive single-agent baseline, then replace it with a four-variant tournament whose judge picks the winner.
+  </Card>
+  <Card title="Automating a Codebase Migration" href="/en/docs/guides/migration-planner-case-study">
+    A migration you cannot plan up front. Discover the call sites, generate a plan at runtime, gate it, execute it as a sub-flow, and loop until the old API is gone.
+  </Card>
+</Cards>
+
+## What you will take away
+
+Each case study is structured the same way so you can map the lessons onto your own work:
+
+1. **The problem.** Why the obvious approach (one big agent call, or three manual delegations) does not scale.
+2. **Phase by phase.** Each new phase is added with a reason — fan-out for throughput, a gate for safety, a loop for convergence. You see the flow grow, not just the finished artifact.
+3. **The complete flow.** The assembled JSON, ready to save and run.
+
+<Callout type="info">
+  Want the short version of *why* a declarative graph beats an imperative script — with concrete before/after numbers? See [Why taskflow?](/en/docs/showcase/why-taskflow).
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Why taskflow?" href="/en/docs/showcase/why-taskflow">
+    A concise before/after comparison with a token-cost walkthrough.
+  </Card>
+  <Card title="Phase Types" href="/en/docs/concepts/phases">
+    The ten building blocks the case studies compose with.
+  </Card>
+  <Card title="Syntax Reference" href="/en/docs/syntax/flow-definition">
+    Every field, one place.
+  </Card>
+</Cards>

--- a/website/content/docs/en/showcase/why-taskflow.mdx
+++ b/website/content/docs/en/showcase/why-taskflow.mdx
@@ -1,0 +1,131 @@
+---
+title: Why taskflow?
+description: A concrete before/after — what a declarative DAG buys you, with token-cost numbers.
+---
+
+The [What is taskflow?](/en/docs/what-is-taskflow) page makes the case in the abstract: a declarative graph is verifiable, observable, replayable, and safe to hand to a model. This page makes it concrete. We take one job — auditing a 47-file pull request — and cost it out two ways: the imperative script you would write by hand, and the same job declared as a taskflow. The numbers are hypothetical but realistic, drawn from the shapes in the [PR audit case study](/en/docs/guides/code-audit-case-study).
+
+<Callout type="info">
+  The numbers below are illustrative, not benchmarked. They reflect the *structural* differences between an imperative script and a declared DAG — full transcripts returning to your context, no resume, no verification. Your mileage varies with model and prompt, but the shape of the gap is stable.
+</Callout>
+
+## The job
+
+A PR lands: **47 files changed across 3 packages.** You want a merged report covering security, architecture, and test coverage. There are two ways to get it.
+
+### The imperative way
+
+You script it in the host. Each `subagent(...)` call returns its full reasoning into your conversation. You loop over the files, branch on the package, and write the summary yourself at the end.
+
+```js title="imperative-pr-audit.js (pseudocode)"
+const files = await subagent("List the 47 changed files");
+const audits = [];
+for (const file of files) {
+  audits.push(await subagent(`Audit ${file} for security risks`));   // 47 full transcripts
+}
+const arch = await subagent("Review architecture per package");
+const report = await subagent(`Merge into one report:\n${audits.join("\n")}\n${arch}`);
+return report;
+```
+
+### The taskflow way
+
+You declare the same shape as a DAG. The runtime fans out, holds the transcripts inside, and returns only the final report.
+
+```json title="pr-audit.json"
+{
+  "name": "pr-audit",
+  "concurrency": 4,
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "output": "json",
+      "task": "List changed files. Output ONLY a JSON array of {path, package} objects." },
+    { "id": "security-each", "type": "map", "over": "{steps.discover.json}", "as": "file",
+      "agent": "security-reviewer", "dependsOn": ["discover"], "concurrency": 4,
+      "task": "Review {file.path} for security risks. Return one paragraph." },
+    { "id": "report", "type": "reduce", "from": ["security-each"], "agent": "writer",
+      "dependsOn": ["security-each"], "final": true,
+      "task": "Merge these audits into one prioritized report:\n{steps.security-each.output}" }
+  ]
+}
+```
+
+## Before / after
+
+The structural differences show up as measurable gaps. Here is the same job, two ways:
+
+| Dimension | Imperative script | taskflow | Why it differs |
+|---|---|---|---|
+| Plan visible before tokens spent? | No — bugs surface at runtime | Yes — `/tf verify` is zero-token | The graph is data, so it can be checked |
+| Transcripts in your context | **47** full audit transcripts + 3 more | **1** final report | Only `final: true` returns to the host |
+| Context tokens consumed (host side) | ~470,000 | ~2,500 | Each transcript ≈ 10k tokens; taskflow holds them internally |
+| Resume after a crash | Re-run from scratch; pay for all 47 again | Cached phases auto-skip; pay only for unfinished work | Every completed phase is persisted |
+| Reusable next PR | Copy-paste the script | `/tf run pr-audit since=v1.5.0` | The flow is saved by name |
+| Safe to generate with an LLM | Risky — it is arbitrary code | Safe — graph is verified before it runs | A malformed DAG fails open, never executes |
+| Structural bugs caught early | At runtime, after you paid | Before any model call | Verification runs first |
+
+<Callout type="tip">
+  The headline number is the context row. The imperative script dumps every audit transcript into *your* window — the very window you need to read the final report. taskflow keeps the 47 transcripts inside the runtime; your context only ever sees the one summary.
+</Callout>
+
+## A token-cost walkthrough
+
+Let us put real-ish numbers on the PR audit. Assume a mid-tier model at **$3 / 1M input tokens** and **$15 / 1M output tokens**, and that each per-file audit reads ~8,000 input tokens (the file plus a little context) and writes ~500 output tokens.
+
+### Per-file audit cost
+
+```text title="cost of one audit call"
+input:   8,000 tokens  ×  $3.00 / 1M   =   $0.0240
+output:    500 tokens  ×  $15.00 / 1M  =   $0.0075
+                                  total =   $0.0315  per file
+```
+
+Forty-seven files at $0.0315 each is **$1.48** for the security fan-out. Add the discover call (~$0.05), the architecture review (~$0.10), and the final merge (~$0.08), and the whole flow costs roughly **$1.71** to run end to end.
+
+That cost is the *same* whether you script it or declare it — the model does the same work. The difference is what you get for it.
+
+### What you get for the same $1.71
+
+| | Imperative script | taskflow |
+|---|---|---|
+| Model cost | $1.71 | $1.71 |
+| Your context after the run | ~470k tokens of transcripts gone | ~2.5k tokens — one report |
+| If the run dies at the merge step | Pay another ~$1.66 to redo the 47 audits | Pay ~$0.08 — only the merge re-runs |
+| If you run it again next week | Full $1.71 again | Cached phases skip; often a few cents |
+| Verify before spending | Impossible | `/tf verify` is free |
+
+The cost row is identical. Every other row favors the declared graph — and the gap widens with scale. A 200-file audit is the same shape but ten times the transcripts flooding your context, while the taskflow side still returns one report.
+
+<Callout type="warn">
+  The expensive failure mode of the imperative script is not the happy path — it is the crash at step 48 of 50. With no resume, you pay the full fan-out *again*. With taskflow, the 47 cached audits skip and you pay for the one phase that never finished. On a large fan-out, that single difference can be an order of magnitude.
+</Callout>
+
+## When the gap is small (and when it is not)
+
+The structural advantage scales with the job. A one-shot, single-step delegation gains almost nothing from taskflow — the host's built-in subagent tool is already the right tool, and the overhead of declaring a graph is not earned back.
+
+| Job shape | Imperative is fine | taskflow earns its overhead |
+|---|---|---|
+| One delegation, no follow-up | ✅ | — |
+| Two steps, second depends on first | borderline | ✅ |
+| Fan-out over many items | — | ✅ |
+| Needs a quality gate before output | — | ✅ |
+| Needs resume / replay | — | ✅ |
+| Plan is generated by a model | — | ✅ (verified before it runs) |
+
+<Callout type="info">
+  The rule of thumb: taskflow earns its overhead the moment there is a *second step that depends on the first*. Below that, use the host's subagent tool directly.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Auditing a Pull Request" href="/en/docs/guides/code-audit-case-study">
+    See the 47-file audit built phase by phase.
+  </Card>
+  <Card title="What is taskflow?" href="/en/docs/what-is-taskflow">
+    The conceptual version of this comparison.
+  </Card>
+  <Card title="Getting Started" href="/en/docs/getting-started">
+    Run your first flow in five minutes.
+  </Card>
+</Cards>

--- a/website/content/docs/en/templates.mdx
+++ b/website/content/docs/en/templates.mdx
@@ -1,0 +1,435 @@
+---
+title: Templates
+description: Five ready-to-run taskflow templates you can save and adapt.
+---
+
+Templates are complete, runnable taskflow definitions for common agent workflows. Each one is a real JSON graph you can save verbatim and run, then tune for your own repo. They are not toy examples — every phase, dependency, and field here is one you would write in production.
+
+<Callout type="info">
+  These templates run identically on Pi (`/tf run`) and on Codex / Claude Code / OpenCode (`taskflow_run`). See the [Pi guide](/en/docs/guides/pi) or [Codex guide](/en/docs/guides/codex) for the host-specific invocation surface.
+</Callout>
+
+## The gallery
+
+<Cards>
+  <Card title="PR Security Audit" href="#1-pr-security-audit">
+    Discover changed files, fan out per-file security review, gate on risk, emit one report.
+  </Card>
+  <Card title="Release Note Generation" href="#2-release-note-generation">
+    Research a feature, run a headline tournament, and assemble a full release note.
+  </Card>
+  <Card title="Codebase Migration" href="#3-codebase-migration">
+    Discover legacy call sites, plan the migration, and loop until none remain.
+  </Card>
+  <Card title="API Doc Generation" href="#4-api-doc-generation">
+    Discover public API surface, draft per-file reference docs, merge into one document.
+  </Card>
+  <Card title="Dependency Upgrade Review" href="#5-dependency-upgrade-review">
+    Enumerate outdated dependencies, evaluate breaking-change risk, and gate on criticals.
+  </Card>
+</Cards>
+
+Save any template as a `.json` file in your project, then verify it for free before running:
+
+```bash title="Verify before you run"
+/tf verify <name>
+```
+
+---
+
+## 1. PR Security Audit
+
+Discover the files a pull request touches, fan out a per-file security review with bounded concurrency, run a parallel architecture review at the same time, gate the whole thing on risk, and finish with one merged report. Only the report returns to your context — the per-file transcripts stay inside the runtime.
+
+```json title="pr-security-audit.json"
+{
+  "name": "pr-security-audit",
+  "description": "Audit a pull request: discover changed files, fan out per-file security review, run a parallel architecture review, gate on risk, and emit one merged report.",
+  "args": {
+    "base": { "default": "origin/main", "description": "The git ref to diff against." }
+  },
+  "concurrency": 6,
+  "budget": { "maxUSD": 3.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List the source files changed between {args.base} and HEAD. Output ONLY a JSON array of {\"path\": \"<relative-path>\"} objects. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object" } },
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "security-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "file",
+      "agent": "security-reviewer",
+      "task": "Review {file.path} for security risks: missing auth checks, unsanitized input, hardcoded secrets, unsafe deserialization. Return one paragraph of findings, or 'No issues found.' if clean. Begin with the file path.",
+      "dependsOn": ["discover"],
+      "concurrency": 4,
+      "context": ["{file.path}"],
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "arch-review",
+      "type": "parallel",
+      "branches": [
+        {
+          "task": "Review the changed files for layering violations, leaked internals, and missing abstractions. Return a short prioritized list.",
+          "agent": "reviewer"
+        }
+      ],
+      "concurrency": 2
+    },
+    {
+      "id": "risk-gate",
+      "type": "gate",
+      "agent": "reviewer",
+      "dependsOn": ["security-each", "arch-review"],
+      "join": "all",
+      "task": "You are the final risk gate. If any finding is high-risk (missing auth, secret leak, broken layering, data-loss path), end with: VERDICT: BLOCK. Otherwise end with: VERDICT: PASS.\n\nSecurity:\n{steps.security-each.output}\n\nArchitecture:\n{steps.arch-review.output}",
+      "onBlock": "halt"
+    },
+    {
+      "id": "report",
+      "type": "reduce",
+      "from": ["security-each", "arch-review", "risk-gate"],
+      "agent": "writer",
+      "task": "Write the final PR review report: 1) Risk verdict, 2) Security findings (prioritized), 3) Architecture findings (prioritized), 4) Recommended actions before merge. Be concise.\n\nSecurity:\n{steps.security-each.output}\n\nArchitecture:\n{steps.arch-review.output}\n\nGate verdict:\n{steps.risk-gate.output}",
+      "dependsOn": ["risk-gate"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="Run on Pi"
+    /tf run pr-security-audit base=origin/main
+    ```
+
+    ```bash title="Save as a shortcut"
+    /tf save pr-security-audit
+    /tf:pr-security-audit base=origin/main
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="Run on Codex"
+    taskflow_run { "name": "pr-security-audit", "args": { "base": "origin/main" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="tip">
+  Walk through how this flow is built incrementally — discover, fan out, gate, report — in the [code audit case study](/en/docs/guides/code-audit-case-study).
+</Callout>
+
+---
+
+## 2. Release Note Generation
+
+Research the feature into a shared set of facts, run a four-variant tournament to pick the strongest headline, then assemble a full release note from the research and the winning headline. The losing headlines and the judge's reasoning are discarded; only the finished note reaches your context.
+
+```json title="release-note.json"
+{
+  "name": "release-note",
+  "description": "Research a feature, run a 4-variant headline tournament, and assemble a full release note.",
+  "args": {
+    "feature": { "description": "The feature to write a release note for.", "required": true }
+  },
+  "concurrency": 6,
+  "budget": { "maxUSD": 1.5 },
+  "phases": [
+    {
+      "id": "research",
+      "type": "agent",
+      "agent": "scout",
+      "task": "Read the diff and release notes for {args.feature}. Summarize in 5 bullets: what it does, who it helps, and the single most surprising benefit. Return bullets only.",
+      "output": "json",
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "headline",
+      "type": "tournament",
+      "agent": "writer",
+      "dependsOn": ["research"],
+      "task": "Write a punchy release-note headline based on the research below. It must be accurate and under 80 characters. Return ONLY the headline.\n\n{steps.research.output}",
+      "variants": 4,
+      "judge": "Pick the headline that is the most punchy while staying accurate and under 80 characters. Prefer specific over generic.",
+      "judgeAgent": "final-arbiter",
+      "mode": "best"
+    },
+    {
+      "id": "note",
+      "type": "reduce",
+      "from": ["research", "headline"],
+      "agent": "writer",
+      "task": "Assemble a complete release note. Use the winning headline as the title, then write a 2-3 paragraph body from the research. End with a one-line 'How to try it' call to action.\n\nHeadline:\n{steps.headline.output}\n\nResearch:\n{steps.research.output}",
+      "dependsOn": ["headline"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="Run on Pi"
+    /tf run release-note feature="subagent context isolation"
+    ```
+
+    ```bash title="Save as a shortcut"
+    /tf save release-note
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="Run on Codex"
+    taskflow_run { "name": "release-note", "args": { "feature": "subagent context isolation" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="tip">
+  The headline tournament is explained end to end — variants, judge rubric, and `best` vs `aggregate` modes — in the [tournament case study](/en/docs/guides/headline-tournament-case-study).
+</Callout>
+
+---
+
+## 3. Codebase Migration
+
+Discover every call site of a legacy API, plan the migration per file, gate the plan for safety, then loop: re-plan based on what remains until no old calls are left. The runtime validates any model-authored sub-flow before it executes, so a bad plan never crashes the run.
+
+```json title="codebase-migration.json"
+{
+  "name": "codebase-migration",
+  "description": "Iteratively re-plan a legacyAuth() -> authorize() migration until no calls remain, then execute the final plan.",
+  "args": {
+    "oldApi": { "default": "legacyAuth()", "description": "The old API call to migrate away from." },
+    "newApi": { "default": "authorize()", "description": "The new API to migrate to." }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 4.0 },
+  "phases": [
+    {
+      "id": "refine",
+      "type": "loop",
+      "agent": "planner",
+      "task": "Inspect the codebase for remaining calls to {args.oldApi}. If any remain, output {\"plan\": <taskflow-definition that fixes the remaining files>, \"done\": false}. If none remain, output {\"done\": true}. The plan, when present, must be a JSON taskflow with a 'name' and a 'phases' array.",
+      "until": "{steps.refine.json.done} == true",
+      "maxIterations": 6,
+      "output": "json"
+    },
+    {
+      "id": "execute-final",
+      "type": "flow",
+      "def": "{steps.refine.json.plan}",
+      "when": "{steps.refine.json.done} == false",
+      "dependsOn": ["refine"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="Run on Pi"
+    /tf run codebase-migration oldApi=legacyAuth\(\) newApi=authorize\(\)
+    ```
+
+    ```bash title="Save as a shortcut"
+    /tf save codebase-migration
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="Run on Codex"
+    taskflow_run { "name": "codebase-migration", "args": { "oldApi": "legacyAuth()", "newApi": "authorize()" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="tip">
+  The full plan → gate → execute → loop cycle, including dynamic hardening caps, is walked through in the [migration planner case study](/en/docs/guides/migration-planner-case-study).
+</Callout>
+
+---
+
+## 4. API Doc Generation
+
+Discover the public API surface of a directory, draft reference documentation for each file in parallel, then reduce the drafts into one coherent API reference document. The per-file drafts stay inside the runtime; only the compiled reference returns to your context.
+
+```json title="api-docs.json"
+{
+  "name": "api-docs",
+  "description": "Discover public API surface, draft per-file reference docs, and merge into one document.",
+  "args": {
+    "dir": { "default": "src", "description": "The source directory to document." }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 2.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List the source files under {args.dir} that export a public API (exported functions, classes, types). Output ONLY a JSON array of {\"path\": \"<relative-path>\", \"module\": \"<module-name>\"} objects. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object" } },
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "draft-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "file",
+      "agent": "writer",
+      "task": "Write reference documentation for the public API in {file.path} (module: {file.module}). For each export: a one-line summary, parameter descriptions, return type, and one usage example. Use Markdown. Begin with a '## {file.module}' heading.",
+      "dependsOn": ["discover"],
+      "concurrency": 4,
+      "context": ["{file.path}"],
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "compile",
+      "type": "reduce",
+      "from": ["draft-each"],
+      "agent": "writer",
+      "task": "Compile the per-module drafts into a single API reference document. Add a top-level title and a table of contents listing each module. Deduplicate cross-referenced types. Preserve the per-module sections in dependency order.\n\n{steps.draft-each.output}",
+      "dependsOn": ["draft-each"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="Run on Pi"
+    /tf run api-docs dir=src
+    ```
+
+    ```bash title="Save as a shortcut"
+    /tf save api-docs
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="Run on Codex"
+    taskflow_run { "name": "api-docs", "args": { "dir": "src" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="info">
+  The `discover` phase is a pure function of the codebase. Mark it `cross-run` with a `glob!:` fingerprint so a re-run after an unrelated change reuses the cached discovery — only files that actually changed get re-documented.
+</Callout>
+
+---
+
+## 5. Dependency Upgrade Review
+
+Enumerate the project's outdated dependencies, evaluate each for breaking-change risk in parallel, gate on any critical finding, and finish with a prioritized upgrade plan. The gate can halt the run before the plan is written if a dependency is too dangerous to upgrade blindly.
+
+```json title="dep-upgrade-review.json"
+{
+  "name": "dep-upgrade-review",
+  "description": "Enumerate outdated dependencies, evaluate breaking-change risk, gate on criticals, and emit a prioritized upgrade plan.",
+  "args": {
+    "manager": { "default": "npm", "description": "The package manager to query (npm, pnpm, yarn)." }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 2.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "Run `{args.manager} outdated --json` (or the equivalent) and list every outdated dependency. Output ONLY a JSON array of {\"name\": \"<package>\", \"current\": \"<version>\", \"wanted\": \"<version>\", \"latest\": \"<version>\"} objects. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object" } },
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "evaluate-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "dep",
+      "agent": "risk-reviewer",
+      "task": "Evaluate the risk of upgrading {dep.name} from {dep.current} to {dep.latest}. Check the changelog for breaking changes, deprecations, and peer-dependency shifts. Return: package name, risk level (LOW|MEDIUM|HIGH|CRITICAL), a one-sentence reason, and a recommended action (safe-to-upgrade|test-first|pin-major|hold). Begin with the package name.",
+      "dependsOn": ["discover"],
+      "concurrency": 4,
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "risk-gate",
+      "type": "gate",
+      "agent": "reviewer",
+      "dependsOn": ["evaluate-each"],
+      "join": "all",
+      "task": "You are the upgrade risk gate. If any dependency is rated CRITICAL (a known breaking change with no migration path, or a security-sensitive package), end with: VERDICT: BLOCK. Otherwise end with: VERDICT: PASS.\n\n{steps.evaluate-each.output}",
+      "onBlock": "halt"
+    },
+    {
+      "id": "plan",
+      "type": "reduce",
+      "from": ["evaluate-each", "risk-gate"],
+      "agent": "writer",
+      "task": "Write a prioritized dependency upgrade plan. Group by risk level (CRITICAL first, then HIGH, MEDIUM, LOW). For each dependency: the recommended action and a one-line reason. End with a suggested upgrade order that respects peer-dependency constraints.\n\n{steps.evaluate-each.output}\n\nGate verdict:\n{steps.risk-gate.output}",
+      "dependsOn": ["risk-gate"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="Run on Pi"
+    /tf run dep-upgrade-review manager=npm
+    ```
+
+    ```bash title="Save as a shortcut"
+    /tf save dep-upgrade-review
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="Run on Codex"
+    taskflow_run { "name": "dep-upgrade-review", "args": { "manager": "npm" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="warn">
+  The `risk-gate` uses `onBlock: "halt"`. If a CRITICAL dependency is found, the run stops before the `plan` phase runs — you get the gate's verdict instead of a plan that would greenlight a dangerous upgrade. Drop the gate (or set `onBlock: "continue"`) if you always want the plan, regardless of risk.
+</Callout>
+
+---
+
+## Adapting a template
+
+Every template above is a starting point, not a prescription. The knobs worth turning are the same across all of them:
+
+- **`concurrency`** — raise it on a generous rate limit to finish faster; lower it to avoid 429s. The `retry` policy absorbs the rest.
+- **`budget`** — the run-wide cost ceiling. A `BLOCK` verdict or budget breach halts the run before downstream phases spend more tokens.
+- **`cache`** — mark pure, expensive phases (`discover`, per-file reviews) `cross-run` with a `git:HEAD` or `glob!:` fingerprint so re-runs reuse work whose inputs did not change.
+- **`retry`** — two attempts with exponential backoff covers most transient provider errors. Raise `max` for phases that hit larger models.
+
+<Callout type="tip">
+  Always run `/tf verify <name>` on a template after you edit it. Verification is zero-token and catches the vast majority of authoring mistakes — cycles, dead-ends, dangling references — before you spend anything.
+</Callout>
+
+## Where to go next
+
+<Cards>
+  <Card title="Getting Started" href="/en/docs/getting-started">
+    Install taskflow and run your first flow.
+  </Card>
+  <Card title="Phase Types" href="/en/docs/syntax/phase-types">
+    Full field reference for every phase type used in these templates.
+  </Card>
+  <Card title="Guides" href="/en/docs/guides">
+    End-to-end walkthroughs that build several of these templates incrementally.
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/community.mdx
+++ b/website/content/docs/zh-cn/community.mdx
@@ -1,0 +1,133 @@
+---
+title: 社区
+description: 贡献模板、提出问题，并一起塑造 taskflow 的未来。
+---
+
+taskflow 在开放中构建，而最好的 flow 往往来自每天运行它们的人。无论你有一个解决了真实问题的工作流、一个关于某个棘手 phase 的问题，还是一个关于新模式的想法——这里都有它的位置。
+
+这一页是简短导览：在哪里交流、如何分享模板、贡献规则是什么，以及如何提出一个能被快速回答的问题。
+
+## 社区在哪里
+
+一切的单一入口是 [GitHub Discussions](https://github.com/heggria/taskflow/discussions)。它同时是帮助台、模板画廊和 RFC 讨论室。
+
+<Cards>
+  <Card title="GitHub Discussions" href="https://github.com/heggria/taskflow/discussions">
+    提问、分享 flow、提出模式，并跟踪版本规划。
+  </Card>
+  <Card title="Issue 跟踪器" href="https://github.com/heggria/taskflow/issues">
+    用可复现的示例提交 bug 和功能请求。
+  </Card>
+  <Card title="examples/ 目录" href="https://github.com/heggria/taskflow/tree/main/examples">
+    可复用 flow 定义的官方存放地。
+  </Card>
+</Cards>
+
+<Callout type="tip">
+  不知道该发在哪里？拿不准时，先开一个 Discussion。维护者会帮你把它转成 issue、PR 或一个保存好的 example——哪种合适就用哪种。
+</Callout>
+
+## 分享模板
+
+一个*模板*就是一个保存好的 taskflow，用来解决某个反复出现的问题——发布就绪检查、PR 审查、迁移规划。分享的门槛很低：一个真实问题、一个能跑的 flow、以及一句如何运行它的说明。
+
+<Steps>
+  <Step>
+    **写 flow。** 从你已经在跑的真实任务出发。给它一个 `name`、一行 `description`，以及能完成工作的最小 `phases` 集合。删掉那些"以防万一"加进去的东西——模板是起点，不是大杂烩。
+  </Step>
+  <Step>
+    **命名。** 文件名用 `kebab-case`（`release-check.json`，而不是 `ReleaseCheck.json` 或 `release_check.json`）。内部的 `name` 字段应与文件名一致。phase ID 也用 kebab-case（`audit-each`、`final-report`）。
+  </Step>
+  <Step>
+    **加上必填字段。** 每个模板必须包含 `name`、`description` 和 `phases`。把任何输入声明为 `args`，并带上 `description` 和 `required` 标记，这样调用者就知道该传什么。如果 flow 会 fan-out，就设置 `concurrency` 和 `budget`。
+  </Step>
+  <Step>
+    **验证它能跑。** 先跑 `/tf verify <name>`（零 token）抓结构错误，再用小输入跑一次 `/tf run <name>` 确认产出符合预期。一个跑不起来的模板是 bug，不是贡献。
+  </Step>
+  <Step>
+    **向 `examples/` 提 PR。** 把 `.json` 文件放进 `examples/`，在目录的 README 里加一行说明它做什么，然后开 PR。或者，开一个 Discussion 把 flow 贴进去——两种方式都行，维护者也可以替你把它移进 `examples/`。
+  </Step>
+</Steps>
+
+<Callout type="info">
+  再小的 PR 都欢迎。一个为某个团队解决真实问题的五阶段 flow，和一个跨项目泛化的二十阶段 flow，同样受欢迎。
+</Callout>
+
+### 一个好模板长什么样
+
+```json title="examples/release-check.json"
+{
+  "name": "release-check",
+  "description": "Audit changed files and return a single release-readiness summary.",
+  "args": {
+    "since": { "description": "Git ref to diff against (e.g. a tag or branch).", "default": "last-tag" }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 1.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List source files changed since {args.since}. Output ONLY a JSON array of {path} objects.",
+      "output": "json"
+    },
+    {
+      "id": "summarize",
+      "type": "reduce",
+      "from": ["discover"],
+      "agent": "writer",
+      "task": "Combine these changes into one release-readiness summary:\n{steps.discover.output}",
+      "final": true
+    }
+  ]
+}
+```
+
+## 贡献指南
+
+一些约定让整个生态可浏览。它们很轻——大部分是你本来就会做的事。
+
+- **命名用 kebab-case。** 文件名、`name` 字段、phase ID 都用连字符（`risk-review`、`audit-each`）。这与插值语法（`{steps.risk-review.output}`）和宿主约定一致。
+- **必填字段不可妥协。** 每个 flow 都要有 `name`、`description` 和 `phases`。`args` 必须声明 `description`（以及 flow 没它就跑不了的 `required`）。缺这些的模板会过不了 `/tf verify`，不会被合并。
+- **每个 phase 目的清晰。** 一个 phase 做一件事。如果某个 `task` prompt 试图在一次调用里又发现、又审查、又汇总，就拆开它——那正是 `map` 和 `reduce` 的用途。
+- **测试是预期内的。** 在 README 里加一个示例调用（该传的 `args` 以及你拿到的结果形状）。如果你的 flow 触发了不常见的分支——`loop`、`gate`、`flow { def }`——加一句说明哪个输入会触发它。你不需要一整套测试套件；你需要一次可复现的运行。
+- **Fail open，保持安全。** 遵循运行时本身的姿态：`when` 解析错误时 phase 照跑，gate 歧义时放行，tournament 评委失败时回退到 variant 1。模板绝不该在软错误上静默中止整次运行。
+- **成本是一等公民。** 任何会 fan-out 的 flow 都要设 `budget`。一个能无限烧 token 的模板，对下一个运行它的人是地雷。
+
+<Callout type="warn">
+  不要提交密钥。模板绝不硬编码 token、API key 或内部 URL。对任何敏感内容，用 `env:` 指纹条目或 `{args.X}`——shell 相关的活优先用 `script` phase，其中数组形式对注入是安全的。
+</Callout>
+
+## 提问求助
+
+问题永远欢迎，而一个问得好的问题能得到快速回答。发帖前，快速过一遍这个清单：
+
+<Steps>
+  <Step>
+    **先搜。** 浏览[已有的 Discussion](https://github.com/heggria/taskflow/discussions) 和[语法参考](/zh-cn/docs/syntax)里你卡住的 phase 类型或字段。大多数"为什么不work"的答案已经写在那里了。
+  </Step>
+  <Step>
+    **跑一下 `/tf verify`。** 它是零 token 的，能抓到绝大多数编写错误——悬空的 `dependsOn`、不可达的占位符、环。如果 verify 通过但运行仍异常，那才是值得拿来讨论的有趣情况。
+  </Step>
+  <Step>
+    **附上 flow 和 run id。** 贴出能复现问题的最小 flow（不断删 phase，直到删掉某一个后问题消失），你传的精确 `args`，以及如果有的话 run id。磁盘上的 run 状态是最快的诊断路径。
+  </Step>
+  <Step>
+    **说明你期望什么、实际得到什么。** "我期望 `map` 对 4 个 item fan-out，但只跑了 2 个"是可行动的。"它不work"则不是。附上宿主（Pi、Codex、Claude Code、OpenCode），以及相关的话 agent 名。
+  </Step>
+</Steps>
+
+<Callout type="info">
+  发现的是 bug 而不是用法问题？开一个 [issue](https://github.com/heggria/taskflow/issues)，附上同样的复现信息——flow、args、run id、期望 vs 实际。维护者会从那里开始分流。
+</Callout>
+
+## 路线图与 RFC
+
+更大的想法——一个新的 phase 类型、对缓存模型的改动、一个宿主移植——从一个标记为 `rfc` 的 Discussion 开始。门槛和模板一样：描述真实问题，勾勒能解决问题的最小形状，并说明你会放弃什么。经过一轮讨论存活下来的 RFC 会得到一份 `docs/` 下的设计文档和一个跟踪 issue。
+
+阅读[设计文档](https://github.com/heggria/taskflow/tree/main/docs)了解已做决策背后的思考——跨运行记忆化、动态加固上限、共享上下文树。它们是理解 taskflow 不只做*什么*、还理解*为什么*的最佳途径。
+
+<Callout type="tip">
+  影响路线图最快的方式，是发布一个能证明这个需求的模板。一个被五个人 star 的能跑的 flow，比任何规格说明都更有说服力。
+</Callout>

--- a/website/content/docs/zh-cn/guides/index.mdx
+++ b/website/content/docs/zh-cn/guides/index.mdx
@@ -35,3 +35,23 @@ description: 在不同宿主和模式下使用 taskflow 的实用指南。
     生成竞争变体，让评委选出最佳结果。
   </Card>
 </Cards>
+
+## 案例研究
+
+端到端的真实任务走查，展示多种 phase 类型如何协同工作。
+
+<Cards>
+  <Card title="代码审计" href="/zh-cn/docs/guides/code-audit-case-study">
+    审查变更文件的安全与架构风险，遇到严重问题时通过 gate 拦截。
+  </Card>
+  <Card title="发布说明标题" href="/zh-cn/docs/guides/headline-tournament-case-study">
+    用锦标赛从多个候选中选出最有力的发布说明标题。
+  </Card>
+  <Card title="迁移规划器" href="/zh-cn/docs/guides/migration-planner-case-study">
+    动态规划代码迁移、验证计划、执行并循环直到完成。
+  </Card>
+</Cards>
+
+## 提交你的案例
+
+有哪个 taskflow 帮你省下了大量时间？[分享给社区](/zh-cn/docs/community)。

--- a/website/content/docs/zh-cn/meta.json
+++ b/website/content/docs/zh-cn/meta.json
@@ -26,9 +26,18 @@
     "guides/dynamic-planning",
     "guides/tournament",
     "guides/code-audit-case-study",
+    "guides/headline-tournament-case-study",
+    "guides/migration-planner-case-study",
+    "---案例展示---",
+    "showcase/index",
+    "showcase/why-taskflow",
+    "---模板---",
+    "templates",
     "---参考---",
     "reference",
     "reference/shorthand",
-    "reference/commands"
+    "reference/commands",
+    "---社区---",
+    "community"
   ]
 }

--- a/website/content/docs/zh-cn/showcase/index.mdx
+++ b/website/content/docs/zh-cn/showcase/index.mdx
@@ -1,0 +1,54 @@
+---
+title: 实战案例
+description: 端到端案例研究——用 taskflow 解决真实问题，逐阶段构建。
+---
+
+实战案例是把各个部件拼到一起的地方。每个案例都从一个你大概率遇到过的具体问题出发，一次加一个阶段地构建一个 taskflow，并解释*为什么*每个阶段长成那样。每个案例结束时，你都会得到一个完整、可保存、可直接运行的 flow。
+
+它们不是宿主走查——同一个 flow 在 Pi（`/tf run`）和 Codex / Claude Code / OpenCode（`taskflow_run`）上跑起来完全一样。它们是*模式*指南：读它们是为了学会这个形状，再把形状套到你自己的问题上。
+
+<Callout type="tip">
+  刚接触？[什么是 taskflow？](/zh-cn/docs/what-is-taskflow) 用一页讲清楚模型，[快速上手](/zh-cn/docs/getting-started) 五分钟跑起一个 flow。想看模型在一个真实问题上被拉满时，再回到这里。
+</Callout>
+
+## 案例研究
+
+三个问题，三种形状。每个都驱动运行时的不同部分——扇出、锦标赛选择、带循环的动态规划。
+
+<Cards>
+  <Card title="审查一次 Pull Request" href="/zh-cn/docs/guides/code-audit-case-study">
+    跨三个包改动了 47 个文件的 PR。发现改动文件、扇出逐文件安全审查、并行跑架构审查、用 gate 拦风险、汇总成一份报告。
+  </Card>
+  <Card title="写发布说明" href="/zh-cn/docs/guides/headline-tournament-case-study">
+    一条高风险的标题。先看朴素的单智能体基线，再换成四变体锦标赛，由裁判挑出胜者。
+  </Card>
+  <Card title="自动化代码迁移" href="/zh-cn/docs/guides/migration-planner-case-study">
+    一个没法预先规划的迁移。发现调用点、在运行时生成计划、gate 校验、作为子流程执行、循环到旧 API 彻底消失。
+  </Card>
+</Cards>
+
+## 你会带走什么
+
+每个案例的结构都一样，方便你把经验映射到自己的工作上：
+
+1. **问题。** 为什么最显然的做法（一次大智能体调用，或三次手动委派）撑不下来。
+2. **逐阶段。** 每个新阶段都有理由——扇出换吞吐、gate 换安全、循环换收敛。你看到 flow 是长出来的，而不是只看到成品。
+3. **完整 flow。** 拼好的 JSON，可直接保存运行。
+
+<Callout type="info">
+  想要*为什么*声明式图胜过命令式脚本的简短版——带具体的前后对比数字？见[为什么用 taskflow？](/zh-cn/docs/showcase/why-taskflow)。
+</Callout>
+
+## 下一步
+
+<Cards>
+  <Card title="为什么用 taskflow？" href="/zh-cn/docs/showcase/why-taskflow">
+    一份简明的前后对比，附 token 成本走查。
+  </Card>
+  <Card title="阶段类型" href="/zh-cn/docs/concepts/phases">
+    案例研究用来组合的十种构建块。
+  </Card>
+  <Card title="语法参考" href="/zh-cn/docs/syntax/flow-definition">
+    每个字段，一处可查。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/showcase/why-taskflow.mdx
+++ b/website/content/docs/zh-cn/showcase/why-taskflow.mdx
@@ -1,0 +1,131 @@
+---
+title: 为什么用 taskflow？
+description: 一份具体的前后对比——声明式 DAG 带来了什么，附 token 成本数字。
+---
+
+[什么是 taskflow？](/zh-cn/docs/what-is-taskflow) 在抽象层面给出了理由：声明式图是可验证、可观察、可重放、且可安全交给模型生成的。本页把它落到具体。我们取一个任务——审查一个 47 文件的 pull request——用两种方式核算：手写的命令式脚本，和声明成 taskflow 的同一个任务。数字是假设但真实的，取自 [PR 审查案例研究](/zh-cn/docs/guides/code-audit-case-study) 里的形状。
+
+<Callout type="info">
+  下面的数字是示例性的，不是基准测试。它们反映的是命令式脚本与声明式 DAG 之间的*结构性*差异——完整中间记录涌回你的上下文、没有续跑、没有验证。具体数字随模型和提示词变化，但差距的形状是稳定的。
+</Callout>
+
+## 这个任务
+
+一个 PR 合进来：**跨 3 个包改动了 47 个文件。** 你想要一份覆盖安全、架构、测试覆盖率的合并报告。有两条路。
+
+### 命令式做法
+
+你在宿主里写脚本。每个 `subagent(...)` 调用把它的完整推理返回到你的对话里。你遍历文件、按包分支、最后自己写汇总。
+
+```js title="imperative-pr-audit.js (pseudocode)"
+const files = await subagent("列出 47 个改动文件");
+const audits = [];
+for (const file of files) {
+  audits.push(await subagent(`审查 ${file} 的安全风险`));   // 47 份完整中间记录
+}
+const arch = await subagent("按包审查架构");
+const report = await subagent(`汇总成一份报告:\n${audits.join("\n")}\n${arch}`);
+return report;
+```
+
+### taskflow 做法
+
+你把同样的形状声明成 DAG。运行时负责扇出、在内部持有中间记录，只返回最终报告。
+
+```json title="pr-audit.json"
+{
+  "name": "pr-audit",
+  "concurrency": 4,
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "output": "json",
+      "task": "列出改动文件。只输出一个由 {path, package} 对象组成的 JSON 数组。" },
+    { "id": "security-each", "type": "map", "over": "{steps.discover.json}", "as": "file",
+      "agent": "security-reviewer", "dependsOn": ["discover"], "concurrency": 4,
+      "task": "审查 {file.path} 的安全风险。返回一段话。" },
+    { "id": "report", "type": "reduce", "from": ["security-each"], "agent": "writer",
+      "dependsOn": ["security-each"], "final": true,
+      "task": "把这些审查汇总成一份按优先级排序的报告:\n{steps.security-each.output}" }
+  ]
+}
+```
+
+## 前后对比
+
+结构性差异表现为可度量的差距。同一个任务，两种做法：
+
+| 维度 | 命令式脚本 | taskflow | 差异来源 |
+|---|---|---|---|
+| 花 token 前能看到计划？ | 否——bug 在运行时才暴露 | 是——`/tf verify` 零 token | 图是数据，所以能检查 |
+| 进入你上下文的中间记录 | **47** 份完整审查记录 + 3 份 | **1** 份最终报告 | 只有 `final: true` 返回宿主 |
+| 消耗的上下文 token（宿主侧） | 约 470,000 | 约 2,500 | 每份记录约 10k token；taskflow 在内部持有 |
+| 崩溃后续跑 | 从头重跑；47 份再付一遍 | 缓存阶段自动跳过；只付未完成的部分 | 每个完成的阶段都持久化了 |
+| 下个 PR 复用 | 复制粘贴脚本 | `/tf run pr-audit since=v1.5.0` | flow 按名保存 |
+| 可安全交给 LLM 生成 | 有风险——它是任意代码 | 安全——图在运行前先验证 | 畸形 DAG 失败时 fail-open，绝不执行 |
+| 结构性 bug 早发现 | 在运行时，付完钱之后 | 在任何模型调用之前 | 验证先跑 |
+
+<Callout type="tip">
+  头号数字是"上下文"那行。命令式脚本把每份审查记录都倒进*你的*窗口——而你恰恰需要这个窗口来读最终报告。taskflow 把 47 份记录留在运行时内部；你的上下文只看到那一份汇总。
+</Callout>
+
+## 一份 token 成本走查
+
+我们给 PR 审查算点真实的数字。假设一个中端模型，**输入 $3 / 1M token**、**输出 $15 / 1M token**，每次逐文件审查读约 8,000 输入 token（文件加一点上下文）、写约 500 输出 token。
+
+### 单次审查成本
+
+```text title="一次审查调用的成本"
+input:   8,000 tokens  ×  $3.00 / 1M   =   $0.0240
+output:    500 tokens  ×  $15.00 / 1M  =   $0.0075
+                                  合计 =   $0.0315  每文件
+```
+
+47 个文件每个 $0.0315，安全扇出合计 **$1.48**。加上发现调用（约 $0.05）、架构审查（约 $0.10）、最终合并（约 $0.08），整条 flow 端到端约 **$1.71**。
+
+这笔成本无论你写脚本还是声明都*一样*——模型干的活一样。区别在于你用它换到了什么。
+
+### 同样的 $1.71 换到了什么
+
+| | 命令式脚本 | taskflow |
+|---|---|---|
+| 模型成本 | $1.71 | $1.71 |
+| 跑完之后你的上下文 | 约 470k token 的记录没了 | 约 2.5k token——一份报告 |
+| 若在合并步骤崩了 | 再付约 $1.66 重做 47 份审查 | 只付约 $0.08——只有合并重跑 |
+| 下周再跑一次 | 又是完整 $1.71 | 缓存阶段跳过；常常几分钱 |
+| 花钱前先验证 | 不可能 | `/tf verify` 免费 |
+
+成本那行一模一样。其他每一行都倒向声明式图——而且差距随规模拉大。一个 200 文件的审查形状一样，但涌进你上下文的记录是十倍，而 taskflow 这边仍然只返回一份报告。
+
+<Callout type="warn">
+  命令式脚本最贵的失败模式不是顺利跑完——而是在第 48/50 步崩掉。没有续跑，你得把整个扇出*再付一遍*。用 taskflow，47 份缓存的审查跳过，你只为那个没完成的阶段付钱。在大扇出上，这一项差异就可能是一个数量级。
+</Callout>
+
+## 差距小的时候（以及不小的时候）
+
+结构性优势随任务规模放大。一次性的单步委派从 taskflow 几乎得不到好处——宿主自带的 subagent 工具本来就是对的工具，声明一张图的额外开销换不回来。
+
+| 任务形状 | 命令式也行 | taskflow 值得这开销 |
+|---|---|---|
+| 一次委派，无后续 | ✅ | — |
+| 两步，第二步依赖第一步 | 边界 | ✅ |
+| 对很多项扇出 | — | ✅ |
+| 输出前需要质量门 | — | ✅ |
+| 需要续跑 / 重放 | — | ✅ |
+| 计划由模型生成 | — | ✅（运行前先验证） |
+
+<Callout type="info">
+  经验法则：一旦出现*依赖第一步的第二步*，taskflow 就挣回它的开销。低于这条线，直接用宿主的 subagent 工具。
+</Callout>
+
+## 下一步
+
+<Cards>
+  <Card title="审查一次 Pull Request" href="/zh-cn/docs/guides/code-audit-case-study">
+    看 47 文件审查如何逐阶段搭起来。
+  </Card>
+  <Card title="什么是 taskflow？" href="/zh-cn/docs/what-is-taskflow">
+    这份对比的概念版。
+  </Card>
+  <Card title="快速上手" href="/zh-cn/docs/getting-started">
+    五分钟跑起你的第一个 flow。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/templates.mdx
+++ b/website/content/docs/zh-cn/templates.mdx
@@ -1,0 +1,435 @@
+---
+title: 模板库
+description: 五个可直接运行、可保存并改写的 taskflow 模板。
+---
+
+模板库是面向常见智能体工作流的完整、可运行 taskflow 定义。每一个都是真实的 JSON 图——你可以原样保存并运行，再针对自己的仓库调整。它们不是玩具示例：这里的每个阶段、依赖和字段都是你在生产环境中会真正写下的内容。
+
+<Callout type="info">
+  这些模板在 Pi（`/tf run`）和 Codex / Claude Code / OpenCode（`taskflow_run`）上运行方式完全一致。宿主特定的调用入口请参见 [Pi 指南](/zh-cn/docs/guides/pi)或 [Codex 指南](/zh-cn/docs/guides/codex)。
+</Callout>
+
+## 模板列表
+
+<Cards>
+  <Card title="PR 安全审计" href="#1-pr-安全审计">
+    发现变更文件、并行做逐文件安全审查、按风险设闸、输出一份汇总报告。
+  </Card>
+  <Card title="发布说明生成" href="#2-发布说明生成">
+    调研功能特性、跑标题锦标赛、组装出一份完整的发布说明。
+  </Card>
+  <Card title="代码库迁移" href="#3-代码库迁移">
+    发现遗留调用点、规划迁移，并循环到没有旧调用为止。
+  </Card>
+  <Card title="API 文档生成" href="#4-api-文档生成">
+    发现公开 API 面、逐文件起草参考文档、合并为一份文档。
+  </Card>
+  <Card title="依赖升级评审" href="#5-依赖升级评审">
+    枚举过时依赖、评估破坏性变更风险，并对关键项设闸。
+  </Card>
+</Cards>
+
+把任意模板保存为项目里的 `.json` 文件，然后在运行前免费验证它：
+
+```bash title="运行前先验证"
+/tf verify <name>
+```
+
+---
+
+## 1. PR 安全审计
+
+发现一个 PR 触及的文件，以受限并发扇出逐文件安全审查，同时并行做架构审查，按风险对整体设闸，最后输出一份合并报告。只有报告会回到你的上下文——逐文件记录留在运行时内部。
+
+```json title="pr-security-audit.json"
+{
+  "name": "pr-security-audit",
+  "description": "Audit a pull request: discover changed files, fan out per-file security review, run a parallel architecture review, gate on risk, and emit one merged report.",
+  "args": {
+    "base": { "default": "origin/main", "description": "The git ref to diff against." }
+  },
+  "concurrency": 6,
+  "budget": { "maxUSD": 3.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List the source files changed between {args.base} and HEAD. Output ONLY a JSON array of {\"path\": \"<relative-path>\"} objects. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object" } },
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "security-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "file",
+      "agent": "security-reviewer",
+      "task": "Review {file.path} for security risks: missing auth checks, unsanitized input, hardcoded secrets, unsafe deserialization. Return one paragraph of findings, or 'No issues found.' if clean. Begin with the file path.",
+      "dependsOn": ["discover"],
+      "concurrency": 4,
+      "context": ["{file.path}"],
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "arch-review",
+      "type": "parallel",
+      "branches": [
+        {
+          "task": "Review the changed files for layering violations, leaked internals, and missing abstractions. Return a short prioritized list.",
+          "agent": "reviewer"
+        }
+      ],
+      "concurrency": 2
+    },
+    {
+      "id": "risk-gate",
+      "type": "gate",
+      "agent": "reviewer",
+      "dependsOn": ["security-each", "arch-review"],
+      "join": "all",
+      "task": "You are the final risk gate. If any finding is high-risk (missing auth, secret leak, broken layering, data-loss path), end with: VERDICT: BLOCK. Otherwise end with: VERDICT: PASS.\n\nSecurity:\n{steps.security-each.output}\n\nArchitecture:\n{steps.arch-review.output}",
+      "onBlock": "halt"
+    },
+    {
+      "id": "report",
+      "type": "reduce",
+      "from": ["security-each", "arch-review", "risk-gate"],
+      "agent": "writer",
+      "task": "Write the final PR review report: 1) Risk verdict, 2) Security findings (prioritized), 3) Architecture findings (prioritized), 4) Recommended actions before merge. Be concise.\n\nSecurity:\n{steps.security-each.output}\n\nArchitecture:\n{steps.arch-review.output}\n\nGate verdict:\n{steps.risk-gate.output}",
+      "dependsOn": ["risk-gate"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="在 Pi 上运行"
+    /tf run pr-security-audit base=origin/main
+    ```
+
+    ```bash title="保存为快捷方式"
+    /tf save pr-security-audit
+    /tf:pr-security-audit base=origin/main
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="在 Codex 上运行"
+    taskflow_run { "name": "pr-security-audit", "args": { "base": "origin/main" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="tip">
+  这个 flow 是如何一步步搭起来的——发现、扇出、设闸、报告——在[代码审计案例](/zh-cn/docs/guides/code-audit-case-study)里有完整走查。
+</Callout>
+
+---
+
+## 2. 发布说明生成
+
+把功能特性调研成一组共享事实，跑一个四变体锦标赛选出最强标题，再用调研结果和获胜标题组装出一份完整发布说明。落败标题和评委推理都会被丢弃；只有成品说明会回到你的上下文。
+
+```json title="release-note.json"
+{
+  "name": "release-note",
+  "description": "Research a feature, run a 4-variant headline tournament, and assemble a full release note.",
+  "args": {
+    "feature": { "description": "The feature to write a release note for.", "required": true }
+  },
+  "concurrency": 6,
+  "budget": { "maxUSD": 1.5 },
+  "phases": [
+    {
+      "id": "research",
+      "type": "agent",
+      "agent": "scout",
+      "task": "Read the diff and release notes for {args.feature}. Summarize in 5 bullets: what it does, who it helps, and the single most surprising benefit. Return bullets only.",
+      "output": "json",
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "headline",
+      "type": "tournament",
+      "agent": "writer",
+      "dependsOn": ["research"],
+      "task": "Write a punchy release-note headline based on the research below. It must be accurate and under 80 characters. Return ONLY the headline.\n\n{steps.research.output}",
+      "variants": 4,
+      "judge": "Pick the headline that is the most punchy while staying accurate and under 80 characters. Prefer specific over generic.",
+      "judgeAgent": "final-arbiter",
+      "mode": "best"
+    },
+    {
+      "id": "note",
+      "type": "reduce",
+      "from": ["research", "headline"],
+      "agent": "writer",
+      "task": "Assemble a complete release note. Use the winning headline as the title, then write a 2-3 paragraph body from the research. End with a one-line 'How to try it' call to action.\n\nHeadline:\n{steps.headline.output}\n\nResearch:\n{steps.research.output}",
+      "dependsOn": ["headline"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="在 Pi 上运行"
+    /tf run release-note feature="subagent context isolation"
+    ```
+
+    ```bash title="保存为快捷方式"
+    /tf save release-note
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="在 Codex 上运行"
+    taskflow_run { "name": "release-note", "args": { "feature": "subagent context isolation" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="tip">
+  标题锦标赛——变体、评委准则、`best` 与 `aggregate` 模式——在[锦标赛案例](/zh-cn/docs/guides/headline-tournament-case-study)里有端到端讲解。
+</Callout>
+
+---
+
+## 3. 代码库迁移
+
+发现某个遗留 API 的全部调用点、按文件规划迁移、对计划设闸，然后循环：根据剩余项重新规划，直到没有旧调用为止。运行时会在执行任何模型生成的子流程前先验证它，所以坏计划永远不会让整个 run 崩掉。
+
+```json title="codebase-migration.json"
+{
+  "name": "codebase-migration",
+  "description": "Iteratively re-plan a legacyAuth() -> authorize() migration until no calls remain, then execute the final plan.",
+  "args": {
+    "oldApi": { "default": "legacyAuth()", "description": "The old API call to migrate away from." },
+    "newApi": { "default": "authorize()", "description": "The new API to migrate to." }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 4.0 },
+  "phases": [
+    {
+      "id": "refine",
+      "type": "loop",
+      "agent": "planner",
+      "task": "Inspect the codebase for remaining calls to {args.oldApi}. If any remain, output {\"plan\": <taskflow-definition that fixes the remaining files>, \"done\": false}. If none remain, output {\"done\": true}. The plan, when present, must be a JSON taskflow with a 'name' and a 'phases' array.",
+      "until": "{steps.refine.json.done} == true",
+      "maxIterations": 6,
+      "output": "json"
+    },
+    {
+      "id": "execute-final",
+      "type": "flow",
+      "def": "{steps.refine.json.plan}",
+      "when": "{steps.refine.json.done} == false",
+      "dependsOn": ["refine"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="在 Pi 上运行"
+    /tf run codebase-migration oldApi=legacyAuth\(\) newApi=authorize\(\)
+    ```
+
+    ```bash title="保存为快捷方式"
+    /tf save codebase-migration
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="在 Codex 上运行"
+    taskflow_run { "name": "codebase-migration", "args": { "oldApi": "legacyAuth()", "newApi": "authorize()" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="tip">
+  完整的 规划 → 设闸 → 执行 → 循环 周期（含动态硬化上限）在[迁移规划案例](/zh-cn/docs/guides/migration-planner-case-study)里逐步走查。
+</Callout>
+
+---
+
+## 4. API 文档生成
+
+发现某个目录的公开 API 面，并行起草每个文件的参考文档，再把草稿 reduce 成一份连贯的 API 参考文档。逐文件草稿留在运行时内部；只有编译好的参考文档会回到你的上下文。
+
+```json title="api-docs.json"
+{
+  "name": "api-docs",
+  "description": "Discover public API surface, draft per-file reference docs, and merge into one document.",
+  "args": {
+    "dir": { "default": "src", "description": "The source directory to document." }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 2.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List the source files under {args.dir} that export a public API (exported functions, classes, types). Output ONLY a JSON array of {\"path\": \"<relative-path>\", \"module\": \"<module-name>\"} objects. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object" } },
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "draft-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "file",
+      "agent": "writer",
+      "task": "Write reference documentation for the public API in {file.path} (module: {file.module}). For each export: a one-line summary, parameter descriptions, return type, and one usage example. Use Markdown. Begin with a '## {file.module}' heading.",
+      "dependsOn": ["discover"],
+      "concurrency": 4,
+      "context": ["{file.path}"],
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "compile",
+      "type": "reduce",
+      "from": ["draft-each"],
+      "agent": "writer",
+      "task": "Compile the per-module drafts into a single API reference document. Add a top-level title and a table of contents listing each module. Deduplicate cross-referenced types. Preserve the per-module sections in dependency order.\n\n{steps.draft-each.output}",
+      "dependsOn": ["draft-each"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="在 Pi 上运行"
+    /tf run api-docs dir=src
+    ```
+
+    ```bash title="保存为快捷方式"
+    /tf save api-docs
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="在 Codex 上运行"
+    taskflow_run { "name": "api-docs", "args": { "dir": "src" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="info">
+  `discover` 阶段是代码库状态的纯函数。给它打上 `cross-run` 并配 `glob!:` 指纹，这样在无关变更后重跑会复用缓存的发现结果——只有真正改动的文件会被重新文档化。
+</Callout>
+
+---
+
+## 5. 依赖升级评审
+
+枚举项目里过时的依赖，并行评估每个的破坏性变更风险，对任何关键发现设闸，最后输出一份按优先级排序的升级计划。当某个依赖盲升级过于危险时，闸门可以在计划写出来之前就中止整个 run。
+
+```json title="dep-upgrade-review.json"
+{
+  "name": "dep-upgrade-review",
+  "description": "Enumerate outdated dependencies, evaluate breaking-change risk, gate on criticals, and emit a prioritized upgrade plan.",
+  "args": {
+    "manager": { "default": "npm", "description": "The package manager to query (npm, pnpm, yarn)." }
+  },
+  "concurrency": 4,
+  "budget": { "maxUSD": 2.0 },
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "Run `{args.manager} outdated --json` (or the equivalent) and list every outdated dependency. Output ONLY a JSON array of {\"name\": \"<package>\", \"current\": \"<version>\", \"wanted\": \"<version>\", \"latest\": \"<version>\"} objects. No prose.",
+      "output": "json",
+      "expect": { "type": "array", "items": { "type": "object" } },
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "evaluate-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "dep",
+      "agent": "risk-reviewer",
+      "task": "Evaluate the risk of upgrading {dep.name} from {dep.current} to {dep.latest}. Check the changelog for breaking changes, deprecations, and peer-dependency shifts. Return: package name, risk level (LOW|MEDIUM|HIGH|CRITICAL), a one-sentence reason, and a recommended action (safe-to-upgrade|test-first|pin-major|hold). Begin with the package name.",
+      "dependsOn": ["discover"],
+      "concurrency": 4,
+      "retry": { "max": 2, "backoffMs": 1000, "factor": 2 }
+    },
+    {
+      "id": "risk-gate",
+      "type": "gate",
+      "agent": "reviewer",
+      "dependsOn": ["evaluate-each"],
+      "join": "all",
+      "task": "You are the upgrade risk gate. If any dependency is rated CRITICAL (a known breaking change with no migration path, or a security-sensitive package), end with: VERDICT: BLOCK. Otherwise end with: VERDICT: PASS.\n\n{steps.evaluate-each.output}",
+      "onBlock": "halt"
+    },
+    {
+      "id": "plan",
+      "type": "reduce",
+      "from": ["evaluate-each", "risk-gate"],
+      "agent": "writer",
+      "task": "Write a prioritized dependency upgrade plan. Group by risk level (CRITICAL first, then HIGH, MEDIUM, LOW). For each dependency: the recommended action and a one-line reason. End with a suggested upgrade order that respects peer-dependency constraints.\n\n{steps.evaluate-each.output}\n\nGate verdict:\n{steps.risk-gate.output}",
+      "dependsOn": ["risk-gate"],
+      "final": true
+    }
+  ]
+}
+```
+
+<Tabs groupId="host" items={['Pi', 'Codex']}>
+  <Tab value="Pi">
+    ```bash title="在 Pi 上运行"
+    /tf run dep-upgrade-review manager=npm
+    ```
+
+    ```bash title="保存为快捷方式"
+    /tf save dep-upgrade-review
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="在 Codex 上运行"
+    taskflow_run { "name": "dep-upgrade-review", "args": { "manager": "npm" } }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="warn">
+  `risk-gate` 用的是 `onBlock: "halt"`。如果发现 CRITICAL 依赖，run 会在 `plan` 阶段运行之前就停止——你拿到的是闸门裁决，而不是一份会为危险升级开绿灯的计划。如果你无论如何都想要计划，去掉闸门（或把 `onBlock` 改成 `"continue"`）。
+</Callout>
+
+---
+
+## 改写模板
+
+上面每个模板都是起点，不是定规。值得调整的旋钮在所有模板里都一样：
+
+- **`concurrency`**——在宽裕的速率限制下调高以更快完成；调低以避免 429。剩下的由 `retry` 策略吸收。
+- **`budget`**——run 级成本上限。`BLOCK` 裁决或预算超支会在下游阶段花更多 token 之前中止 run。
+- **`cache`**——给纯且昂贵的阶段（`discover`、逐文件审查）打上 `cross-run`，配 `git:HEAD` 或 `glob!:` 指纹，这样输入没变的重跑会复用既有工作。
+- **`retry`**——两次尝试加指数退避覆盖大多数瞬时 provider 错误。对命中大模型的阶段可调高 `max`。
+
+<Callout type="tip">
+  编辑模板后永远先跑 `/tf verify <name>`。验证是零 token 的，能在你花任何钱之前抓住绝大多数作者错误——环、死胡同、悬空引用。
+</Callout>
+
+## 接下来
+
+<Cards>
+  <Card title="快速开始" href="/zh-cn/docs/getting-started">
+    安装 taskflow 并运行你的第一个 flow。
+  </Card>
+  <Card title="阶段类型" href="/zh-cn/docs/syntax/phase-types">
+    这些模板里用到的每种阶段的完整字段参考。
+  </Card>
+  <Card title="指南" href="/zh-cn/docs/guides">
+    逐步搭建其中若干模板的端到端走查。
+  </Card>
+</Cards>


### PR DESCRIPTION
This PR lands the first phase of the taskflow docs influence-building plan.\n\n## What is added\n\n### Showcase / Case Studies\n- New `showcase/index.mdx` listing the three existing case-study guides\n- New `showcase/why-taskflow.mdx` with a declarative-vs-imperative comparison and token-cost example\n- Both English and Chinese versions\n\n### Templates Gallery\n- New `templates.mdx` showcasing 5 reusable flows: PR security audit, release-note generation, codebase migration, API doc generation, dependency upgrade review\n- Each template includes a runnable JSON snippet and Pi/Codex invocation examples\n- Both English and Chinese versions\n\n### Community\n- New `community.mdx` linking to GitHub Discussions and explaining how to submit a template\n- Contribution guidelines and question etiquette\n- Both English and Chinese versions\n\n### Navigation\n- Registered the two previously-orphaned case studies in `meta.json`\n- Added Showcase, Templates, and Community sections to both `en/meta.json` and `zh-cn/meta.json`\n- Updated `guides/index.mdx` with a Case Studies card grid and a community CTA\n\n### Landing page\n- Added By the numbers section\n- Added Declarative vs imperative comparison\n- Added Testimonials section\n- Expanded bottom CTAs to Read docs / Browse templates / Join community\n- Bilingual translations extended\n\n## Verification\n- `npm run build -w taskflow-website` passes, generating 70 static pages.