### PR TITLE
feat(website): modernize Fumadocs theme, landing page, and docs layout

### DIFF
--- a/website/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/app/[lang]/docs/[[...slug]]/page.tsx
@@ -1,10 +1,72 @@
-import { source } from '@/lib/source';
-import { DocsPage, DocsBody, DocsDescription, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
-import { notFound } from 'next/navigation';
-import type { Locale } from '@/lib/i18n';
-import { getMDXComponents } from '@/components/mdx';
+import {
+	DocsBody,
+	DocsDescription,
+	DocsPage,
+	DocsTitle,
+} from "fumadocs-ui/layouts/docs/page";
+import { MessageSquare, Pencil } from "lucide-react";
+import { notFound } from "next/navigation";
+import { getMDXComponents } from "@/components/mdx";
+import type { Locale } from "@/lib/i18n";
+import { source } from "@/lib/source";
 
-const SITE_URL = 'https://heggria.github.io/taskflow';
+const SITE_URL = "https://heggria.github.io/taskflow";
+
+const feedbackTranslations = {
+	en: {
+		title: "Was this helpful?",
+		body: "Help us improve the docs or ask a question in the community.",
+		edit: "Edit on GitHub",
+		discuss: "Join Discussions",
+	},
+	"zh-cn": {
+		title: "这页内容对你有帮助吗？",
+		body: "帮助我们改进文档，或在社区中提问。",
+		edit: "在 GitHub 上编辑",
+		discuss: "加入讨论",
+	},
+};
+
+function DocsFeedbackFooter({
+	editUrl,
+	discussionsUrl,
+	lang,
+}: {
+	editUrl: string;
+	discussionsUrl: string;
+	lang: Locale;
+}) {
+	const t = feedbackTranslations[lang] ?? feedbackTranslations.en;
+
+	return (
+		<div className="mt-12 rounded-xl border bg-fd-card p-6">
+			<h3 className="text-lg font-semibold text-fd-card-foreground">
+				{t.title}
+			</h3>
+			<p className="mt-1 text-sm text-fd-muted-foreground">{t.body}</p>
+			<div className="mt-4 flex flex-wrap gap-3">
+				<a
+					href={editUrl}
+					target="_blank"
+					rel="noreferrer"
+					className="inline-flex items-center gap-2 rounded-lg bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
+				>
+					<Pencil className="size-4" />
+					{t.edit}
+				</a>
+				<a
+					href={discussionsUrl}
+					target="_blank"
+					rel="noreferrer"
+					className="inline-flex items-center gap-2 rounded-lg border bg-fd-background px-4 py-2 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-accent"
+				>
+					<MessageSquare className="size-4" />
+					{t.discuss}
+				</a>
+			</div>
+		</div>
+	);
+}
 
 /**
  * Map a taskflow-website locale to a BCP-47 language tag for JSON-LD `inLanguage`.
@@ -12,158 +74,163 @@ const SITE_URL = 'https://heggria.github.io/taskflow';
  * `alternates.languages` entries emitted by the root layout).
  */
 function bcp47Tag(lang: Locale): string {
-  return lang === 'zh-cn' ? 'zh-CN' : 'en';
+	return lang === "zh-cn" ? "zh-CN" : "en";
 }
 
 /** Title-case a slug segment as a last-resort label when no page exists for it. */
 function titleCaseSlug(slug: string): string {
-  return slug
-    .split('-')
-    .map((part) =>
-      part.length > 0 ? `${part[0]?.toUpperCase()}${part.slice(1)}` : part,
-    )
-    .join(' ');
+	return slug
+		.split("-")
+		.map((part) =>
+			part.length > 0 ? `${part[0]?.toUpperCase()}${part.slice(1)}` : part,
+		)
+		.join(" ");
 }
 
 export function generateStaticParams() {
-  return source.generateParams();
+	return source.generateParams();
 }
 
 export default async function Page({
-  params,
+	params,
 }: {
-  params: Promise<{ lang: Locale; slug?: string[] }>;
+	params: Promise<{ lang: Locale; slug?: string[] }>;
 }) {
-  const { lang, slug } = await params;
-  const page = source.getPage(slug, lang);
-  if (!page) notFound();
+	const { lang, slug } = await params;
+	const page = source.getPage(slug, lang);
+	if (!page) notFound();
 
-  const MDX = page.data.body;
+	const MDX = page.data.body;
 
-  const canonicalUrl = `${SITE_URL}${page.url}/`;
-  const language = bcp47Tag(lang);
+	const canonicalUrl = `${SITE_URL}${page.url}/`;
+	const language = bcp47Tag(lang);
 
-  const techArticleJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'TechArticle',
-    headline: page.data.title,
-    description: page.data.description,
-    url: canonicalUrl,
-    inLanguage: language,
-    author: {
-      '@type': 'Organization',
-      name: 'heggria',
-      url: 'https://github.com/heggria',
-    },
-  };
+	const techArticleJsonLd = {
+		"@context": "https://schema.org",
+		"@type": "TechArticle",
+		headline: page.data.title,
+		description: page.data.description,
+		url: canonicalUrl,
+		inLanguage: language,
+		author: {
+			"@type": "Organization",
+			name: "heggria",
+			url: "https://github.com/heggria",
+		},
+	};
 
-  // Build the breadcrumb trail from the slug path:
-  //   []                       → Home → Docs
-  //   ['getting-started']      → Home → Docs → Getting Started
-  //   ['concepts', 'phases']   → Home → Docs → Core Concepts → Phase Types
-  // Intermediate segments resolve to their chapter index page (e.g.
-  // `concepts/index.mdx`) so the label is the real page title, not invented.
-  const segments = page.slugs;
-  const homeLabel = lang === 'zh-cn' ? '首页' : 'Home';
-  const docsLabel = lang === 'zh-cn' ? '文档' : 'Docs';
+	// Build the breadcrumb trail from the slug path:
+	//   []                       → Home → Docs
+	//   ['getting-started']      → Home → Docs → Getting Started
+	//   ['concepts', 'phases']   → Home → Docs → Core Concepts → Phase Types
+	// Intermediate segments resolve to their chapter index page (e.g.
+	// `concepts/index.mdx`) so the label is the real page title, not invented.
+	const segments = page.slugs;
+	const homeLabel = lang === "zh-cn" ? "首页" : "Home";
+	const docsLabel = lang === "zh-cn" ? "文档" : "Docs";
 
-  const breadcrumbItems: { name: string; item: string }[] = [
-    { name: homeLabel, item: `${SITE_URL}/${lang}/` },
-    { name: docsLabel, item: `${SITE_URL}/${lang}/docs/` },
-  ];
+	const breadcrumbItems: { name: string; item: string }[] = [
+		{ name: homeLabel, item: `${SITE_URL}/${lang}/` },
+		{ name: docsLabel, item: `${SITE_URL}/${lang}/docs/` },
+	];
 
-  // Intermediate segments (all but the last): look up the real page title.
-  for (let i = 0; i < segments.length - 1; i++) {
-    const segSlug = segments.slice(0, i + 1);
-    const segSegment = segments[i];
-    if (!segSegment) continue;
-    const segPage = source.getPage(segSlug, lang);
-    breadcrumbItems.push({
-      name: segPage?.data.title ?? titleCaseSlug(segSegment),
-      item: `${SITE_URL}${segPage?.url ?? `/${lang}/docs/${segSlug.join('/')}`}/`,
-    });
-  }
+	// Intermediate segments (all but the last): look up the real page title.
+	for (let i = 0; i < segments.length - 1; i++) {
+		const segSlug = segments.slice(0, i + 1);
+		const segSegment = segments[i];
+		if (!segSegment) continue;
+		const segPage = source.getPage(segSlug, lang);
+		breadcrumbItems.push({
+			name: segPage?.data.title ?? titleCaseSlug(segSegment),
+			item: `${SITE_URL}${segPage?.url ?? `/${lang}/docs/${segSlug.join("/")}`}/`,
+		});
+	}
 
-  // The last segment is the current page. Skip when there are no segments —
-  // for the docs index, "Docs" is already the terminal item.
-  if (segments.length > 0) {
-    breadcrumbItems.push({
-      name: page.data.title,
-      item: canonicalUrl,
-    });
-  }
+	// The last segment is the current page. Skip when there are no segments —
+	// for the docs index, "Docs" is already the terminal item.
+	if (segments.length > 0) {
+		breadcrumbItems.push({
+			name: page.data.title,
+			item: canonicalUrl,
+		});
+	}
 
-  const breadcrumbJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: breadcrumbItems.map((entry, index) => ({
-      '@type': 'ListItem',
-      position: index + 1,
-      name: entry.name,
-      item: entry.item,
-    })),
-  };
+	const breadcrumbJsonLd = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: breadcrumbItems.map((entry, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			name: entry.name,
+			item: entry.item,
+		})),
+	};
 
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(techArticleJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
-      />
-      <DocsPage
-        toc={page.data.toc}
-        full={page.data.full}
-      >
-        <DocsTitle>{page.data.title}</DocsTitle>
-        <DocsDescription>{page.data.description}</DocsDescription>
-        <DocsBody>
-          <MDX components={getMDXComponents()} />
-        </DocsBody>
-      </DocsPage>
-    </>
-  );
+	const editUrl = `https://github.com/heggria/taskflow/edit/main/website/content/docs/${page.path}`;
+	const discussionsUrl = "https://github.com/heggria/taskflow/discussions";
+
+	return (
+		<>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(techArticleJsonLd) }}
+			/>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+			/>
+			<DocsPage toc={page.data.toc} full={page.data.full} className="relative">
+				<DocsTitle>{page.data.title}</DocsTitle>
+				<DocsDescription>{page.data.description}</DocsDescription>
+				<DocsBody>
+					<MDX components={getMDXComponents()} />
+				</DocsBody>
+				<DocsFeedbackFooter
+					editUrl={editUrl}
+					discussionsUrl={discussionsUrl}
+					lang={lang}
+				/>
+			</DocsPage>
+		</>
+	);
 }
 
 export async function generateMetadata({
-  params,
+	params,
 }: {
-  params: Promise<{ lang: Locale; slug?: string[] }>;
+	params: Promise<{ lang: Locale; slug?: string[] }>;
 }) {
-  const { lang, slug } = await params;
-  const page = source.getPage(slug, lang);
-  if (!page) return {};
+	const { lang, slug } = await params;
+	const page = source.getPage(slug, lang);
+	if (!page) return {};
 
-  const canonicalUrl = `${SITE_URL}${page.url}/`;
-  // page.url already includes the locale prefix, e.g. /en/docs/getting-started
-  // Derive the locale-agnostic path by stripping the leading locale segment.
-  const pathWithoutLocale = page.url.replace(/^\/(en|zh-cn)/, '');
+	const canonicalUrl = `${SITE_URL}${page.url}/`;
+	// page.url already includes the locale prefix, e.g. /en/docs/getting-started
+	// Derive the locale-agnostic path by stripping the leading locale segment.
+	const pathWithoutLocale = page.url.replace(/^\/(en|zh-cn)/, "");
 
-  return {
-    title: page.data.title,
-    description: page.data.description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathWithoutLocale}/`,
-        'zh-CN': `${SITE_URL}/zh-cn${pathWithoutLocale}/`,
-        'x-default': `${SITE_URL}/en${pathWithoutLocale}/`,
-      },
-    },
-    openGraph: {
-      title: page.data.title,
-      description: page.data.description,
-      url: canonicalUrl,
-      images: '/opengraph-image',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: page.data.title,
-      description: page.data.description,
-      images: '/opengraph-image',
-    },
-  };
+	return {
+		title: page.data.title,
+		description: page.data.description,
+		alternates: {
+			canonical: canonicalUrl,
+			languages: {
+				en: `${SITE_URL}/en${pathWithoutLocale}/`,
+				"zh-CN": `${SITE_URL}/zh-cn${pathWithoutLocale}/`,
+				"x-default": `${SITE_URL}/en${pathWithoutLocale}/`,
+			},
+		},
+		openGraph: {
+			title: page.data.title,
+			description: page.data.description,
+			url: canonicalUrl,
+			images: "/opengraph-image",
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: page.data.title,
+			description: page.data.description,
+			images: "/opengraph-image",
+		},
+	};
 }

--- a/website/app/[lang]/docs/layout.tsx
+++ b/website/app/[lang]/docs/layout.tsx
@@ -1,31 +1,127 @@
-import type { ReactNode } from 'react';
-import { DocsLayout } from 'fumadocs-ui/layouts/docs';
-import { source } from '@/lib/source';
+import type * as PageTree from "fumadocs-core/page-tree";
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { MessageSquare } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { source } from "@/lib/source";
+
+function TaskflowLogo() {
+	return (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			className="text-fd-primary"
+		>
+			<circle cx="5" cy="12" r="3" fill="currentColor" />
+			<circle cx="19" cy="6" r="3" fill="currentColor" />
+			<circle cx="19" cy="18" r="3" fill="currentColor" />
+			<path
+				d="M5 12h7m0 0l3-4m-3 4l3 4"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
+
+function GitHubIcon() {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			className="size-4"
+		>
+			<path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+		</svg>
+	);
+}
+
+/**
+ * Keep top-level doc sections expanded and disable their collapse trigger.
+ * Nested folders remain collapsible so the sidebar stays scannable.
+ */
+function freezeTopLevelSections(root: PageTree.Root): PageTree.Root {
+	return {
+		...root,
+		children: root.children.map((node) =>
+			node.type === "folder" ? { ...node, collapsible: false } : node,
+		),
+	};
+}
 
 export default async function DocsLayoutPage({
-  children,
-  params,
+	children,
+	params,
 }: {
-  children: ReactNode;
-  params: Promise<{ lang: string }>;
+	children: ReactNode;
+	params: Promise<{ lang: string }>;
 }) {
-  const { lang } = await params;
-  const tree = source.pageTree[lang];
+	const { lang } = await params;
+	const tree = freezeTopLevelSections(source.pageTree[lang]);
 
-  return (
-    <DocsLayout
-      tree={tree}
-      nav={{
-        title: 'taskflow',
-        url: `/${lang}`,
-      }}
-      githubUrl="https://github.com/heggria/taskflow"
-      sidebar={{
-        defaultOpenLevel: 1,
-      }}
-      i18n
-    >
-      {children}
-    </DocsLayout>
-  );
+	return (
+		<DocsLayout
+			tree={tree}
+			nav={{
+				title: (
+					<div className="inline-flex items-center gap-2 text-[0.9375rem] font-semibold">
+						<TaskflowLogo />
+						<span>taskflow</span>
+					</div>
+				),
+				url: `/${lang}`,
+				transparentMode: "none",
+			}}
+			links={[
+				{
+					type: "icon",
+					label: "GitHub",
+					icon: <GitHubIcon />,
+					text: "GitHub",
+					url: "https://github.com/heggria/taskflow",
+					external: true,
+				},
+				{
+					type: "icon",
+					label: "Discussions",
+					icon: <MessageSquare className="size-4" />,
+					text: "Discussions",
+					url: "https://github.com/heggria/taskflow/discussions",
+					external: true,
+				},
+			]}
+			sidebar={{
+				defaultOpenLevel: 1,
+				banner: (
+					<Link
+						href={`/${lang}/docs/templates`}
+						className="block rounded-lg border bg-fd-card p-3 text-sm transition-colors hover:bg-fd-accent"
+					>
+						<span className="inline-flex items-center rounded-full bg-fd-primary/10 px-2 py-0.5 text-xs font-medium text-fd-primary">
+							New
+						</span>
+						<span className="mt-1 block font-medium text-fd-card-foreground">
+							Templates
+						</span>
+						<span className="text-fd-muted-foreground">
+							Browse ready-to-run taskflow examples.
+						</span>
+					</Link>
+				),
+			}}
+			i18n
+		>
+			{children}
+		</DocsLayout>
+	);
 }

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -1,237 +1,242 @@
-import Link from 'next/link';
-import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { i18n } from '@/lib/i18n';
-import type { Locale } from '@/lib/i18n';
+// biome-ignore-all lint/security/noDangerouslySetInnerHtml: JSON-LD uses dangerouslySetInnerHTML
+import { HomeLayout } from "fumadocs-ui/layouts/home";
 import {
-  Network,
-  Zap,
-  RefreshCw,
-  ArrowRight,
-  ExternalLink,
-  Terminal,
-  Server,
-  Layers,
-  Package,
-  History,
-  Quote,
-  BookOpen,
-  FolderOpen,
-  Users,
-} from 'lucide-react';
+	ArrowRight,
+	BookOpen,
+	Check,
+	ExternalLink,
+	FolderOpen,
+	History,
+	Layers,
+	Network,
+	Package,
+	Quote,
+	RefreshCw,
+	Server,
+	Terminal,
+	Users,
+	X,
+	Zap,
+} from "lucide-react";
+import Link from "next/link";
+import type { Locale } from "@/lib/i18n";
+import { i18n } from "@/lib/i18n";
 
 export function generateStaticParams() {
-  return i18n.languages.map((lang) => ({ lang }));
+	return i18n.languages.map((lang) => ({ lang }));
 }
 
 const translations = {
-  en: {
-    title: 'taskflow',
-    tagline: 'Declarative agent orchestration.',
-    valueProp:
-      'Describe multi-step coding-agent work as a DAG, verify it before a token is spent, and return only the final result to your context window.',
-    badge: 'Zero runtime dependencies',
-    getStarted: 'Get Started',
-    whatIs: 'What is taskflow?',
-    github: 'GitHub',
-    featureHeading: 'Built for real agent workflows',
-    features: {
-      dag: {
-        title: 'Declarative DAGs',
-        body: 'Define phases, dependencies, and fan-out as data. The runtime turns your graph into isolated subagent calls.',
-      },
-      isolation: {
-        title: 'Context Isolation',
-        body: 'Intermediate transcripts stay inside the runtime. Only the final phase reaches your conversation.',
-      },
-      resume: {
-        title: 'Cross-Session Resume',
-        body: 'Paused or failed runs pick up where they left off. Cached phases skip automatically on re-run.',
-      },
-    },
-    code: {
-      label: 'review-changes.json',
-      caption: 'A complete review flow: discover files, fan out reviews, then summarize.',
-    },
-    stats: {
-      heading: 'By the numbers',
-      hosts: {
-        value: '4 hosts',
-        label: 'Pi, Codex, Claude Code, OpenCode',
-      },
-      phases: {
-        value: '10 phase types',
-        label: 'agent, map, gate, reduce, and more',
-      },
-      deps: {
-        value: '0 runtime deps',
-        label: 'No production dependencies',
-      },
-      resume: {
-        value: 'Cross-session resume',
-        label: 'Pick up where you left off',
-      },
-    },
-    comparison: {
-      heading: 'Declarative vs imperative',
-      subheading:
-        'Why declare your agent workflows as data instead of scripting them?',
-      aspectHeader: 'Aspect',
-      declarativeHeader: 'Declarative',
-      imperativeHeader: 'Imperative',
-      link: 'Learn more',
-      rows: [
-        {
-          aspect: 'Verifiable before tokens',
-          declarative: 'DAG checked for cycles, dead ends, and budget before any model call.',
-          imperative: 'Bugs surface at runtime, after you have already paid.',
-        },
-        {
-          aspect: 'Context cost',
-          declarative: 'Only the final output returns to your context.',
-          imperative: 'Every transcript floods the host conversation.',
-        },
-        {
-          aspect: 'Resume after failure',
-          declarative: 'Cached phases auto-skip on re-run.',
-          imperative: 'Start over from the beginning.',
-        },
-        {
-          aspect: 'Reusability',
-          declarative: 'Save, version, and call by name.',
-          imperative: 'Copy-paste scripts between runs.',
-        },
-      ],
-    },
-    testimonials: {
-      heading: 'What early users say',
-      quotes: [
-        {
-          body: 'We turned a 50-file security review from a context-window disaster into a 10-minute taskflow.',
-          role: 'Platform Engineer, Series B startup',
-        },
-        {
-          body: 'Cross-session resume alone saved us hours. A run dies at the summary step and we just continue it.',
-          role: 'Staff Engineer, AI infrastructure',
-        },
-        {
-          body: 'The tournament phase consistently beats our single-shot headline and release-note drafts.',
-          role: 'Developer Advocate, open-source tooling',
-        },
-      ],
-    },
-    cta: {
-      title: 'Ready to declare your first DAG?',
-      body: 'Install on Pi or Codex and run a multi-phase workflow in minutes.',
-      docs: 'Read the docs',
-      templates: 'Browse templates',
-      community: 'Join community',
-    },
-  },
-  'zh-cn': {
-    title: 'taskflow',
-    tagline: '声明式智能体编排。',
-    valueProp:
-      '把多步骤编程智能体工作描述成 DAG，在花费 token 之前验证它，并且只把最终结果返回到你的上下文窗口。',
-    badge: '零运行时依赖',
-    getStarted: '开始使用',
-    whatIs: '什么是 taskflow？',
-    github: 'GitHub',
-    featureHeading: '为真实智能体工作流而建',
-    features: {
-      dag: {
-        title: '声明式 DAG',
-        body: '将阶段、依赖和 fan-out 定义为数据。运行时把你的图变成隔离的子代理调用。',
-      },
-      isolation: {
-        title: '上下文隔离',
-        body: '中间记录留在运行时内部。只有最终阶段的结果会进入你的对话。',
-      },
-      resume: {
-        title: '跨会话续跑',
-        body: '暂停或失败的运行从断点继续。重新运行时自动跳过已缓存阶段。',
-      },
-    },
-    code: {
-      label: 'review-changes.json',
-      caption: '一个完整的审查工作流：发现文件、并行审查、然后汇总。',
-    },
-    stats: {
-      heading: '数据一览',
-      hosts: {
-        value: '4 个宿主',
-        label: 'Pi、Codex、Claude Code、OpenCode',
-      },
-      phases: {
-        value: '10 种阶段类型',
-        label: 'agent、map、gate、reduce 等',
-      },
-      deps: {
-        value: '0 个运行时依赖',
-        label: '零生产依赖',
-      },
-      resume: {
-        value: '跨会话续跑',
-        label: '从断点继续运行',
-      },
-    },
-    comparison: {
-      heading: '声明式 vs 命令式',
-      subheading: '为什么把智能体工作流声明为数据，而不是写成脚本？',
-      aspectHeader: '维度',
-      declarativeHeader: '声明式',
-      imperativeHeader: '命令式',
-      link: '了解更多',
-      rows: [
-        {
-          aspect: '花费 token 前可验证',
-          declarative: '在任何模型调用前检查 DAG 的循环、死路和预算。',
-          imperative: 'bug 在运行时才暴露，此时已经花了钱。',
-        },
-        {
-          aspect: '上下文成本',
-          declarative: '只有最终结果返回上下文。',
-          imperative: '每次子代理的完整记录都会涌入宿主对话。',
-        },
-        {
-          aspect: '失败后续跑',
-          declarative: '重新运行时自动跳过已缓存阶段。',
-          imperative: '从头开始重新运行。',
-        },
-        {
-          aspect: '可复用性',
-          declarative: '保存、版本化并按名称调用。',
-          imperative: '每次运行之间复制粘贴脚本。',
-        },
-      ],
-    },
-    testimonials: {
-      heading: '早期用户反馈',
-      quotes: [
-        {
-          body: '我们把一份 50 个文件的安全审查，从上下文窗口灾难变成了 10 分钟的 taskflow。',
-          role: '平台工程师，B 轮初创公司',
-        },
-        {
-          body: '光是跨会话续跑就帮我们省了几个小时。运行死在汇总阶段时，我们只需继续它。',
-          role: '资深工程师，AI 基础设施',
-        },
-        {
-          body: '锦标赛阶段生成的标题和发布说明草稿，始终优于我们的单轮生成。',
-          role: '开发者布道师，开源工具',
-        },
-      ],
-    },
-    cta: {
-      title: '准备好声明你的第一个 DAG 了吗？',
-      body: '在 Pi 或 Codex 上安装，几分钟内运行多阶段工作流。',
-      docs: '阅读文档',
-      templates: '浏览模板',
-      community: '加入社区',
-    },
-  },
+	en: {
+		title: "taskflow",
+		tagline: "Declarative agent orchestration.",
+		valueProp:
+			"Describe multi-step coding-agent work as a DAG, verify it before a token is spent, and return only the final result to your context window.",
+		badge: "Zero runtime dependencies",
+		getStarted: "Get Started",
+		whatIs: "What is taskflow?",
+		github: "GitHub",
+		featureHeading: "Built for real agent workflows",
+		features: {
+			dag: {
+				title: "Declarative DAGs",
+				body: "Define phases, dependencies, and fan-out as data. The runtime turns your graph into isolated subagent calls.",
+			},
+			isolation: {
+				title: "Context Isolation",
+				body: "Intermediate transcripts stay inside the runtime. Only the final phase reaches your conversation.",
+			},
+			resume: {
+				title: "Cross-Session Resume",
+				body: "Paused or failed runs pick up where they left off. Cached phases skip automatically on re-run.",
+			},
+		},
+		code: {
+			label: "review-changes.json",
+			caption:
+				"A complete review flow: discover files, fan out reviews, then summarize.",
+		},
+		stats: {
+			heading: "By the numbers",
+			hosts: {
+				value: "4 hosts",
+				label: "Pi, Codex, Claude Code, OpenCode",
+			},
+			phases: {
+				value: "10 phase types",
+				label: "agent, map, gate, reduce, and more",
+			},
+			deps: {
+				value: "0 runtime deps",
+				label: "No production dependencies",
+			},
+			resume: {
+				value: "Cross-session resume",
+				label: "Pick up where you left off",
+			},
+		},
+		comparison: {
+			heading: "Declarative vs imperative",
+			subheading:
+				"Why declare your agent workflows as data instead of scripting them?",
+			aspectHeader: "Aspect",
+			declarativeHeader: "Declarative",
+			imperativeHeader: "Imperative",
+			link: "Learn more",
+			rows: [
+				{
+					aspect: "Verifiable before tokens",
+					declarative:
+						"DAG checked for cycles, dead ends, and budget before any model call.",
+					imperative: "Bugs surface at runtime, after you have already paid.",
+				},
+				{
+					aspect: "Context cost",
+					declarative: "Only the final output returns to your context.",
+					imperative: "Every transcript floods the host conversation.",
+				},
+				{
+					aspect: "Resume after failure",
+					declarative: "Cached phases auto-skip on re-run.",
+					imperative: "Start over from the beginning.",
+				},
+				{
+					aspect: "Reusability",
+					declarative: "Save, version, and call by name.",
+					imperative: "Copy-paste scripts between runs.",
+				},
+			],
+		},
+		testimonials: {
+			heading: "What early users say",
+			quotes: [
+				{
+					body: "We turned a 50-file security review from a context-window disaster into a 10-minute taskflow.",
+					role: "Platform Engineer, Series B startup",
+				},
+				{
+					body: "Cross-session resume alone saved us hours. A run dies at the summary step and we just continue it.",
+					role: "Staff Engineer, AI infrastructure",
+				},
+				{
+					body: "The tournament phase consistently beats our single-shot headline and release-note drafts.",
+					role: "Developer Advocate, open-source tooling",
+				},
+			],
+		},
+		cta: {
+			title: "Ready to declare your first DAG?",
+			body: "Install on Pi or Codex and run a multi-phase workflow in minutes.",
+			docs: "Read the docs",
+			templates: "Browse templates",
+			community: "Join community",
+		},
+	},
+	"zh-cn": {
+		title: "taskflow",
+		tagline: "声明式智能体编排。",
+		valueProp:
+			"把多步骤编程智能体工作描述成 DAG，在花费 token 之前验证它，并且只把最终结果返回到你的上下文窗口。",
+		badge: "零运行时依赖",
+		getStarted: "开始使用",
+		whatIs: "什么是 taskflow？",
+		github: "GitHub",
+		featureHeading: "为真实智能体工作流而建",
+		features: {
+			dag: {
+				title: "声明式 DAG",
+				body: "将阶段、依赖和 fan-out 定义为数据。运行时把你的图变成隔离的子代理调用。",
+			},
+			isolation: {
+				title: "上下文隔离",
+				body: "中间记录留在运行时内部。只有最终阶段的结果会进入你的对话。",
+			},
+			resume: {
+				title: "跨会话续跑",
+				body: "暂停或失败的运行从断点继续。重新运行时自动跳过已缓存阶段。",
+			},
+		},
+		code: {
+			label: "review-changes.json",
+			caption: "一个完整的审查工作流：发现文件、并行审查、然后汇总。",
+		},
+		stats: {
+			heading: "数据一览",
+			hosts: {
+				value: "4 个宿主",
+				label: "Pi、Codex、Claude Code、OpenCode",
+			},
+			phases: {
+				value: "10 种阶段类型",
+				label: "agent、map、gate、reduce 等",
+			},
+			deps: {
+				value: "0 个运行时依赖",
+				label: "零生产依赖",
+			},
+			resume: {
+				value: "跨会话续跑",
+				label: "从断点继续运行",
+			},
+		},
+		comparison: {
+			heading: "声明式 vs 命令式",
+			subheading: "为什么把智能体工作流声明为数据，而不是写成脚本？",
+			aspectHeader: "维度",
+			declarativeHeader: "声明式",
+			imperativeHeader: "命令式",
+			link: "了解更多",
+			rows: [
+				{
+					aspect: "花费 token 前可验证",
+					declarative: "在任何模型调用前检查 DAG 的循环、死路和预算。",
+					imperative: "bug 在运行时才暴露，此时已经花了钱。",
+				},
+				{
+					aspect: "上下文成本",
+					declarative: "只有最终结果返回上下文。",
+					imperative: "每次子代理的完整记录都会涌入宿主对话。",
+				},
+				{
+					aspect: "失败后续跑",
+					declarative: "重新运行时自动跳过已缓存阶段。",
+					imperative: "从头开始重新运行。",
+				},
+				{
+					aspect: "可复用性",
+					declarative: "保存、版本化并按名称调用。",
+					imperative: "每次运行之间复制粘贴脚本。",
+				},
+			],
+		},
+		testimonials: {
+			heading: "早期用户反馈",
+			quotes: [
+				{
+					body: "我们把一份 50 个文件的安全审查，从上下文窗口灾难变成了 10 分钟的 taskflow。",
+					role: "平台工程师，B 轮初创公司",
+				},
+				{
+					body: "光是跨会话续跑就帮我们省了几个小时。运行死在汇总阶段时，我们只需继续它。",
+					role: "资深工程师，AI 基础设施",
+				},
+				{
+					body: "锦标赛阶段生成的标题和发布说明草稿，始终优于我们的单轮生成。",
+					role: "开发者布道师，开源工具",
+				},
+			],
+		},
+		cta: {
+			title: "准备好声明你的第一个 DAG 了吗？",
+			body: "在 Pi 或 Codex 上安装，几分钟内运行多阶段工作流。",
+			docs: "阅读文档",
+			templates: "浏览模板",
+			community: "加入社区",
+		},
+	},
 };
 
-const SITE_URL = 'https://heggria.github.io/taskflow';
+const SITE_URL = "https://heggria.github.io/taskflow";
 
 const codeExample = `{
   "name": "review-changes",
@@ -265,322 +270,434 @@ const codeExample = `{
   ]
 }`;
 
+type JsonToken = {
+	type: "key" | "string" | "number" | "bool" | "punct" | "plain";
+	value: string;
+};
+
+function tokenizeJsonLine(line: string): JsonToken[] {
+	const tokens: JsonToken[] = [];
+	const regex =
+		/("(?:\\.|[^"\\])*")|(\b(?:true|false|null)\b)|(-?\d+(?:\.\d+)?)|([{}\[\](),:])/g;
+	let match: RegExpExecArray | null = regex.exec(line);
+	let lastIndex = 0;
+
+	while (match !== null) {
+		if (match.index > lastIndex) {
+			tokens.push({
+				type: "plain",
+				value: line.slice(lastIndex, match.index),
+			});
+		}
+
+		const value = match[0];
+		if (match[1] !== undefined) {
+			const after = line.slice(regex.lastIndex);
+			tokens.push({
+				type: /^\s*:/.test(after) ? "key" : "string",
+				value,
+			});
+		} else if (match[2] !== undefined) {
+			tokens.push({ type: "bool", value });
+		} else if (match[3] !== undefined) {
+			tokens.push({ type: "number", value });
+		} else {
+			tokens.push({ type: "punct", value });
+		}
+
+		lastIndex = regex.lastIndex;
+		match = regex.exec(line);
+	}
+
+	if (lastIndex < line.length) {
+		tokens.push({ type: "plain", value: line.slice(lastIndex) });
+	}
+
+	return tokens;
+}
+
+function highlightJson(line: string) {
+	return (
+		<span>
+			{tokenizeJsonLine(line).map((token, i) => (
+				<span
+					// biome-ignore lint/suspicious/noArrayIndexKey: static syntax highlight tokens
+					key={`${token.type}-${token.value}-${i}`}
+					className={token.type === "plain" ? undefined : `json-${token.type}`}
+				>
+					{token.value}
+				</span>
+			))}
+		</span>
+	);
+}
+
 export default async function HomePage({
-  params,
+	params,
 }: {
-  params: Promise<{ lang: Locale }>;
+	params: Promise<{ lang: Locale }>;
 }) {
-  const { lang } = await params;
-  const t = translations[lang] ?? translations.en;
+	const { lang } = await params;
+	const t = translations[lang] ?? translations.en;
 
-  const featureList = [
-    {
-      icon: Network,
-      title: t.features.dag.title,
-      body: t.features.dag.body,
-    },
-    {
-      icon: Zap,
-      title: t.features.isolation.title,
-      body: t.features.isolation.body,
-    },
-    {
-      icon: RefreshCw,
-      title: t.features.resume.title,
-      body: t.features.resume.body,
-    },
-  ] as const;
+	const featureList = [
+		{
+			icon: Network,
+			title: t.features.dag.title,
+			body: t.features.dag.body,
+		},
+		{
+			icon: Zap,
+			title: t.features.isolation.title,
+			body: t.features.isolation.body,
+		},
+		{
+			icon: RefreshCw,
+			title: t.features.resume.title,
+			body: t.features.resume.body,
+		},
+	] as const;
 
-  const statsList = [
-    { icon: Server, value: t.stats.hosts.value, label: t.stats.hosts.label },
-    { icon: Layers, value: t.stats.phases.value, label: t.stats.phases.label },
-    { icon: Package, value: t.stats.deps.value, label: t.stats.deps.label },
-    { icon: History, value: t.stats.resume.value, label: t.stats.resume.label },
-  ] as const;
+	const statsList = [
+		{ icon: Server, value: t.stats.hosts.value, label: t.stats.hosts.label },
+		{ icon: Layers, value: t.stats.phases.value, label: t.stats.phases.label },
+		{ icon: Package, value: t.stats.deps.value, label: t.stats.deps.label },
+		{ icon: History, value: t.stats.resume.value, label: t.stats.resume.label },
+	] as const;
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'SoftwareApplication',
-    name: 'taskflow',
-    description: t.valueProp,
-    applicationCategory: 'DeveloperApplication',
-    operatingSystem: 'Any',
-    url: `${SITE_URL}/${lang}/`,
-    offers: {
-      '@type': 'Offer',
-      price: '0',
-      priceCurrency: 'USD',
-    },
-    author: {
-      '@type': 'Organization',
-      name: 'heggria',
-      url: 'https://github.com/heggria',
-    },
-  };
+	const jsonLd = {
+		"@context": "https://schema.org",
+		"@type": "SoftwareApplication",
+		name: "taskflow",
+		description: t.valueProp,
+		applicationCategory: "DeveloperApplication",
+		operatingSystem: "Any",
+		url: `${SITE_URL}/${lang}/`,
+		offers: {
+			"@type": "Offer",
+			price: "0",
+			priceCurrency: "USD",
+		},
+		author: {
+			"@type": "Organization",
+			name: "heggria",
+			url: "https://github.com/heggria",
+		},
+	};
 
-  return (
-    <HomeLayout
-      i18n
-      githubUrl="https://github.com/heggria/taskflow"
-      nav={{
-        title: 'taskflow',
-        url: `/${lang}`,
-      }}
-    >
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <div className="relative overflow-hidden">
-        <div className="bg-hero-glow absolute inset-x-0 top-0 h-[600px]" />
-        <div className="bg-grid absolute inset-0 opacity-50" />
+	return (
+		<HomeLayout
+			i18n
+			githubUrl="https://github.com/heggria/taskflow"
+			nav={{
+				title: "taskflow",
+				url: `/${lang}`,
+			}}
+		>
+			{/* JSON-LD is a safe static object */}
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+			/>
+			<div className="relative overflow-hidden">
+				<div className="bg-hero-glow pointer-events-none absolute inset-x-0 -top-40 h-[1000px] blur-3xl" />
+				<div className="bg-hero-glow-strong pointer-events-none absolute inset-x-0 top-0 h-[600px] blur-3xl" />
+				<div className="bg-grid pointer-events-none absolute inset-0 opacity-[0.3]" />
 
-        <section className="relative mx-auto flex max-w-[1200px] flex-col items-center px-6 pb-20 pt-24 text-center md:pt-32">
-          <div className="inline-flex items-center gap-2 rounded-full border bg-fd-card px-4 py-1.5 text-sm text-fd-muted-foreground shadow-sm">
-            <Terminal className="size-4" aria-hidden="true" />
-            <span>{t.badge}</span>
-          </div>
+				<section className="relative mx-auto flex max-w-[1200px] flex-col items-center px-6 pb-32 pt-36 text-center md:pt-52">
+					<div className="animate-fade-in animate-float inline-flex items-center gap-2.5 rounded-full glass px-5 py-2 text-sm font-medium text-fd-muted-foreground shadow-sm">
+						<Terminal className="size-4 text-fd-primary" aria-hidden="true" />
+						<span>{t.badge}</span>
+					</div>
 
-          <h1 className="mt-8 text-5xl font-bold tracking-tight sm:text-6xl md:text-7xl">
-            <span className="text-gradient">{t.title}</span>
-          </h1>
+					<h1 className="animate-fade-in animate-fade-in-delay-1 mt-10 text-7xl font-bold tracking-tighter sm:text-8xl md:text-9xl">
+						<span className="text-gradient">{t.title}</span>
+					</h1>
 
-          <p className="mt-5 max-w-2xl text-2xl font-semibold tracking-tight text-fd-foreground md:text-3xl">
-            {t.tagline}
-          </p>
+					<p className="animate-fade-in animate-fade-in-delay-1 mt-7 max-w-2xl text-2xl font-semibold tracking-tight text-fd-foreground md:text-4xl text-balance">
+						{t.tagline}
+					</p>
 
-          <p className="mt-4 max-w-2xl text-base text-fd-muted-foreground md:text-lg">
-            {t.valueProp}
-          </p>
+					<p className="animate-fade-in animate-fade-in-delay-2 mt-5 max-w-2xl text-base leading-relaxed text-fd-muted-foreground md:text-lg text-balance">
+						{t.valueProp}
+					</p>
 
-          <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
-            <Link
-              href={`/${lang}/docs/getting-started`}
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-fd-primary px-7 text-sm font-semibold text-fd-primary-foreground shadow-lg shadow-fd-primary/25 transition-all hover:bg-fd-primary/90 hover:shadow-fd-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-            >
-              {t.getStarted}
-              <ArrowRight className="size-4" aria-hidden="true" />
-            </Link>
-            <Link
-              href={`/${lang}/docs/what-is-taskflow`}
-              className="inline-flex h-11 items-center justify-center rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-            >
-              {t.whatIs}
-            </Link>
-            <a
-              href="https://github.com/heggria/taskflow"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-            >
-              <ExternalLink className="size-4" aria-hidden="true" />
-              {t.github}
-            </a>
-          </div>
+					<div className="animate-fade-in animate-fade-in-delay-2 mt-12 flex flex-wrap items-center justify-center gap-3">
+						<Link
+							href={`/${lang}/docs/getting-started`}
+							className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-fd-primary px-8 text-sm font-semibold text-fd-primary-foreground shadow-lg shadow-fd-primary/25 transition-all hover:bg-fd-primary/90 hover:shadow-fd-primary/45 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+						>
+							{t.getStarted}
+							<ArrowRight className="size-4" aria-hidden="true" />
+						</Link>
+						<Link
+							href={`/${lang}/docs/what-is-taskflow`}
+							className="inline-flex h-12 items-center justify-center rounded-full border bg-fd-background/70 px-8 text-sm font-semibold backdrop-blur-sm transition-all hover:bg-fd-accent hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+						>
+							{t.whatIs}
+						</Link>
+						<a
+							href="https://github.com/heggria/taskflow"
+							target="_blank"
+							rel="noreferrer"
+							className="inline-flex h-12 items-center justify-center gap-2 rounded-full border bg-fd-background/70 px-8 text-sm font-semibold backdrop-blur-sm transition-all hover:bg-fd-accent hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+						>
+							<ExternalLink className="size-4" aria-hidden="true" />
+							{t.github}
+						</a>
+					</div>
 
-          <figure
-            className="mt-16 w-full max-w-3xl overflow-hidden rounded-2xl border bg-fd-card text-left shadow-2xl"
-            aria-label={t.code.label}
-          >
-            <figcaption className="flex items-center gap-2 border-b bg-fd-muted/50 px-4 py-3">
-              <div className="flex gap-1.5" aria-hidden="true">
-                <div className="size-3 rounded-full bg-red-400" />
-                <div className="size-3 rounded-full bg-amber-400" />
-                <div className="size-3 rounded-full bg-green-400" />
-              </div>
-              <span className="ml-2 text-xs font-medium text-fd-muted-foreground">
-                {t.code.label}
-              </span>
-            </figcaption>
-            <pre className="overflow-x-auto p-5 text-sm leading-relaxed">
-              <code className="font-mono text-fd-foreground">{codeExample}</code>
-            </pre>
-          </figure>
-          <p className="mt-3 max-w-xl text-sm text-fd-muted-foreground">
-            {t.code.caption}
-          </p>
-        </section>
-      </div>
+					<figure
+						className="animate-fade-in animate-fade-in-delay-3 mt-24 w-full max-w-3xl overflow-hidden rounded-2xl glass gradient-border shadow-2xl"
+						aria-label={t.code.label}
+					>
+						<figcaption className="flex items-center gap-3 border-b bg-fd-muted/50 px-5 py-3.5">
+							<div className="flex gap-2" aria-hidden="true">
+								<span className="size-3.5 rounded-full bg-[#ff5f57] ring-1 ring-black/5" />
+								<span className="size-3.5 rounded-full bg-[#febc2e] ring-1 ring-black/5" />
+								<span className="size-3.5 rounded-full bg-[#28c840] ring-1 ring-black/5" />
+							</div>
+							<span className="ml-2 text-xs font-medium text-fd-muted-foreground">
+								{t.code.label}
+							</span>
+						</figcaption>
+						<div className="overflow-x-auto bg-fd-background/40 p-5">
+							<pre className="font-mono text-sm leading-7">
+								<code className="text-fd-foreground">
+									{codeExample.split("\n").map((line, i) => (
+										// biome-ignore lint/suspicious/noArrayIndexKey: static code lines
+										<div key={`line-${i + 1}`} className="flex gap-5">
+											<span className="w-6 shrink-0 select-none text-right text-xs text-fd-muted-foreground/50">
+												{i + 1}
+											</span>
+											<span className="whitespace-pre">
+												{highlightJson(line)}
+											</span>
+										</div>
+									))}
+									</code>
+								</pre>
+							</div>
+						</figure>
+						<p className="animate-fade-in animate-fade-in-delay-3 mt-5 max-w-xl text-sm text-fd-muted-foreground">
+							{t.code.caption}
+						</p>
+					</section>
+				</div>
 
-      <section
-        className="mx-auto max-w-[1200px] px-6 py-12"
-        aria-labelledby="stats-heading"
-      >
-        <h2
-          id="stats-heading"
-          className="text-center text-3xl font-bold tracking-tight md:text-4xl"
-        >
-          {t.stats.heading}
-        </h2>
+			<section
+				className="mx-auto max-w-[1200px] px-6 py-28"
+				aria-labelledby="stats-heading"
+			>
+				<h2
+					id="stats-heading"
+					className="text-center text-3xl font-bold tracking-tight md:text-4xl"
+				>
+					{t.stats.heading}
+				</h2>
 
-        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {statsList.map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-2xl border bg-fd-card p-6 text-center transition-shadow hover:shadow-md"
-            >
-              <div className="mx-auto inline-flex rounded-xl bg-fd-primary/10 p-3 text-fd-primary">
-                <stat.icon className="size-6" aria-hidden="true" />
-              </div>
-              <p className="mt-4 text-2xl font-bold">{stat.value}</p>
-              <p className="mt-1 text-sm text-fd-muted-foreground">{stat.label}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+				<div className="mt-14 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+					{statsList.map((stat) => (
+						<div
+							key={stat.label}
+							className="group relative overflow-hidden rounded-2xl glass gradient-border p-7 text-center transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+						>
+							<div className="mx-auto inline-flex rounded-2xl bg-gradient-to-br from-fd-primary/15 to-fd-primary/5 p-3.5 text-fd-primary transition-all duration-300 group-hover:scale-110 group-hover:from-fd-primary/25 group-hover:to-fd-primary/10 group-hover:shadow-lg group-hover:shadow-fd-primary/15">
+								<stat.icon className="size-7" aria-hidden="true" />
+							</div>
+							<p className="mt-5 text-3xl font-extrabold tracking-tight md:text-4xl">
+								{stat.value}
+							</p>
+							<p className="mt-2 text-sm text-fd-muted-foreground">
+								{stat.label}
+							</p>
+						</div>
+					))}
+				</div>
+			</section>
 
-      <section
-        className="mx-auto max-w-[1200px] px-6 py-20"
-        aria-labelledby="features-heading"
-      >
-        <h2
-          id="features-heading"
-          className="text-center text-3xl font-bold tracking-tight md:text-4xl"
-        >
-          {t.featureHeading}
-        </h2>
+			<section
+				className="mx-auto max-w-[1200px] px-6 py-28"
+				aria-labelledby="features-heading"
+			>
+				<h2
+					id="features-heading"
+					className="text-center text-3xl font-bold tracking-tight md:text-4xl"
+				>
+					{t.featureHeading}
+				</h2>
 
-        <div className="mt-12 grid gap-6 md:grid-cols-3">
-          {featureList.map((feature) => (
-            <div
-              key={feature.title}
-              className="group rounded-2xl border bg-fd-card p-7 transition-shadow hover:shadow-lg"
-            >
-              <div className="inline-flex rounded-xl bg-fd-primary/10 p-3 text-fd-primary transition-colors group-hover:bg-fd-primary/15">
-                <feature.icon className="size-7" aria-hidden="true" />
-              </div>
-              <h3 className="mt-5 text-xl font-semibold">{feature.title}</h3>
-              <p className="mt-2 text-fd-muted-foreground">{feature.body}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+				<div className="mt-16 grid gap-6 md:grid-cols-3">
+					{featureList.map((feature) => (
+						<div
+							key={feature.title}
+							className="group relative overflow-hidden rounded-2xl glass gradient-top-border shine p-8 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+						>
+							<div className="inline-flex rounded-2xl bg-gradient-to-br from-fd-primary/15 to-fd-primary/5 p-3.5 text-fd-primary transition-all duration-300 group-hover:from-fd-primary/25 group-hover:to-fd-primary/10 group-hover:scale-110">
+								<feature.icon
+									className="size-7 transition-transform duration-300 group-hover:scale-110"
+									aria-hidden="true"
+								/>
+							</div>
+							<h3 className="mt-6 text-xl font-semibold">{feature.title}</h3>
+							<p className="mt-2.5 leading-relaxed text-fd-muted-foreground">
+								{feature.body}
+							</p>
+						</div>
+					))}
+				</div>
+			</section>
 
-      <section
-        className="mx-auto max-w-[1200px] px-6 py-20"
-        aria-labelledby="comparison-heading"
-      >
-        <div className="text-center">
-          <h2
-            id="comparison-heading"
-            className="text-3xl font-bold tracking-tight md:text-4xl"
-          >
-            {t.comparison.heading}
-          </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-lg text-fd-muted-foreground">
-            {t.comparison.subheading}
-          </p>
-        </div>
+			<section
+				className="mx-auto max-w-[1200px] px-6 py-28"
+				aria-labelledby="comparison-heading"
+			>
+				<div className="text-center">
+					<h2
+						id="comparison-heading"
+						className="text-3xl font-bold tracking-tight md:text-4xl"
+					>
+						{t.comparison.heading}
+					</h2>
+					<p className="mx-auto mt-4 max-w-2xl text-lg text-fd-muted-foreground text-balance">
+						{t.comparison.subheading}
+					</p>
+				</div>
 
-        <div className="mt-10 overflow-x-auto rounded-2xl border bg-fd-card">
-          <table className="w-full min-w-[600px] text-left">
-            <thead>
-              <tr className="border-b bg-fd-muted/50">
-                <th className="px-6 py-4 text-sm font-semibold">
-                  {t.comparison.aspectHeader}
-                </th>
-                <th className="px-6 py-4 text-sm font-semibold">
-                  {t.comparison.declarativeHeader}
-                </th>
-                <th className="px-6 py-4 text-sm font-semibold">
-                  {t.comparison.imperativeHeader}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {t.comparison.rows.map((row, index) => (
-                <tr key={index} className="border-b last:border-b-0">
-                  <td className="px-6 py-4 font-medium">{row.aspect}</td>
-                  <td className="px-6 py-4 text-fd-muted-foreground">
-                    {row.declarative}
-                  </td>
-                  <td className="px-6 py-4 text-fd-muted-foreground">
-                    {row.imperative}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+				<div className="mt-14 overflow-x-auto rounded-2xl glass gradient-border">
+					<table className="w-full min-w-[640px] text-left">
+						<thead>
+							<tr className="border-b bg-fd-primary/[0.08]">
+								<th className="px-6 py-4 text-sm font-semibold text-fd-foreground">
+									{t.comparison.aspectHeader}
+								</th>
+								<th className="px-6 py-4 text-sm font-semibold text-fd-primary">
+									{t.comparison.declarativeHeader}
+								</th>
+								<th className="px-6 py-4 text-sm font-semibold text-fd-muted-foreground">
+									{t.comparison.imperativeHeader}
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{t.comparison.rows.map((row) => (
+								<tr
+									key={row.aspect}
+									className="border-b last:border-b-0 transition-colors even:bg-fd-muted/[0.35] hover:bg-fd-muted/[0.55]"
+								>
+									<td className="px-6 py-4 font-medium">{row.aspect}</td>
+									<td className="px-6 py-4">
+										<div className="flex items-start gap-3 text-fd-foreground">
+											<span className="mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full bg-green-500/12 p-1">
+												<Check
+													className="size-4 text-green-600 dark:text-green-400"
+													aria-hidden="true"
+												/>
+											</span>
+											<span>{row.declarative}</span>
+										</div>
+									</td>
+									<td className="px-6 py-4">
+										<div className="flex items-start gap-3 text-fd-muted-foreground">
+											<span className="mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full bg-red-500/12 p-1">
+												<X
+													className="size-4 text-red-500"
+													aria-hidden="true"
+												/>
+											</span>
+											<span>{row.imperative}</span>
+										</div>
+									</td>
+								</tr>
+							))}
+							</tbody>
+						</table>
+					</div>
 
-        <div className="mt-6 text-center">
-          <Link
-            href={`/${lang}/docs/what-is-taskflow`}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-          >
-            {t.comparison.link}
-            <ArrowRight className="size-4" aria-hidden="true" />
-          </Link>
-        </div>
-      </section>
+					<div className="mt-10 text-center">
+					<Link
+						href={`/${lang}/docs/what-is-taskflow`}
+						className="inline-flex h-12 items-center justify-center gap-2 rounded-full border bg-fd-background/70 px-8 text-sm font-semibold backdrop-blur-sm transition-all hover:bg-fd-accent hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+					>
+						{t.comparison.link}
+						<ArrowRight className="size-4" aria-hidden="true" />
+					</Link>
+				</div>
+			</section>
 
-      <section
-        className="mx-auto max-w-[1200px] px-6 py-20"
-        aria-labelledby="testimonials-heading"
-      >
-        <h2
-          id="testimonials-heading"
-          className="text-center text-3xl font-bold tracking-tight md:text-4xl"
-        >
-          {t.testimonials.heading}
-        </h2>
+			<section
+				className="mx-auto max-w-[1200px] px-6 py-28"
+				aria-labelledby="testimonials-heading"
+			>
+				<h2
+					id="testimonials-heading"
+					className="text-center text-3xl font-bold tracking-tight md:text-4xl"
+				>
+					{t.testimonials.heading}
+				</h2>
 
-        <div className="mt-12 grid gap-6 md:grid-cols-3">
-          {t.testimonials.quotes.map((quote, index) => (
-            <div
-              key={index}
-              className="flex flex-col rounded-2xl border bg-fd-card p-7"
-            >
-              <Quote
-                className="size-8 text-fd-primary/40"
-                aria-hidden="true"
-              />
-              <p className="mt-4 flex-1 text-lg font-medium leading-relaxed">
-                {quote.body}
-              </p>
-              <p className="mt-6 text-sm text-fd-muted-foreground">{quote.role}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+				<div className="mt-16 grid gap-6 md:grid-cols-3">
+					{t.testimonials.quotes.map((quote) => (
+						<div
+							key={quote.body}
+							className="group relative flex flex-col overflow-hidden rounded-2xl glass gradient-border p-8 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+						>
+							<Quote
+								className="size-12 text-fd-primary/20 transition-colors duration-300 group-hover:text-fd-primary/30"
+								aria-hidden="true"
+								strokeWidth={1.5}
+							/>
+							<p className="mt-6 flex-1 text-lg font-medium leading-relaxed text-fd-foreground text-balance">
+								{quote.body}
+							</p>
+							<p className="mt-8 text-sm font-semibold text-fd-muted-foreground">
+								{quote.role}
+							</p>
+						</div>
+					))}
+				</div>
+			</section>
 
-      <section className="border-y bg-fd-muted/30">
-        <div className="mx-auto flex max-w-[1200px] flex-col items-center px-6 py-20 text-center">
-          <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
-            {t.cta.title}
-          </h2>
-          <p className="mt-4 max-w-xl text-lg text-fd-muted-foreground">
-            {t.cta.body}
-          </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-            <Link
-              href={`/${lang}/docs`}
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-fd-primary px-7 text-sm font-semibold text-fd-primary-foreground shadow-lg shadow-fd-primary/25 transition-all hover:bg-fd-primary/90 hover:shadow-fd-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-            >
-              <BookOpen className="size-4" aria-hidden="true" />
-              {t.cta.docs}
-            </Link>
-            <a
-              href="https://github.com/heggria/taskflow/tree/main/examples"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-            >
-              <FolderOpen className="size-4" aria-hidden="true" />
-              {t.cta.templates}
-            </a>
-            <a
-              href="https://github.com/heggria/taskflow/discussions"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border bg-fd-background/50 px-7 text-sm font-semibold backdrop-blur-sm transition-colors hover:bg-fd-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-            >
-              <Users className="size-4" aria-hidden="true" />
-              {t.cta.community}
-            </a>
-          </div>
-        </div>
-      </section>
-    </HomeLayout>
-  );
+			<section className="relative overflow-hidden">
+				<div className="absolute inset-0 bg-gradient-to-b from-fd-primary/[0.12] via-fd-muted/40 to-fd-muted/40" />
+				<div className="bg-grid pointer-events-none absolute inset-0 opacity-[0.22]" />
+				<div className="bg-hero-glow pointer-events-none absolute inset-x-0 bottom-0 h-full opacity-60" />
+				<div className="relative mx-auto flex max-w-[1200px] flex-col items-center px-6 py-28 text-center">
+					<h2 className="text-3xl font-bold tracking-tight md:text-5xl text-balance">
+						{t.cta.title}
+					</h2>
+					<p className="mt-5 max-w-xl text-lg text-fd-muted-foreground md:text-xl text-balance">
+						{t.cta.body}
+					</p>
+					<div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+						<Link
+							href={`/${lang}/docs`}
+							className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-fd-primary px-8 text-base font-semibold text-fd-primary-foreground shadow-lg shadow-fd-primary/30 transition-all hover:bg-fd-primary/90 hover:shadow-fd-primary/50 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+						>
+							<BookOpen className="size-5" aria-hidden="true" />
+							{t.cta.docs}
+						</Link>
+						<a
+							href="https://github.com/heggria/taskflow/tree/main/examples"
+							target="_blank"
+							rel="noreferrer"
+							className="inline-flex h-12 items-center justify-center gap-2 rounded-full border bg-fd-background/80 px-8 text-base font-semibold backdrop-blur-sm transition-all hover:bg-fd-accent hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+						>
+							<FolderOpen className="size-5" aria-hidden="true" />
+							{t.cta.templates}
+						</a>
+						<a
+							href="https://github.com/heggria/taskflow/discussions"
+							target="_blank"
+							rel="noreferrer"
+							className="inline-flex h-12 items-center justify-center gap-2 rounded-full border bg-fd-background/80 px-8 text-base font-semibold backdrop-blur-sm transition-all hover:bg-fd-accent hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+						>
+							<Users className="size-5" aria-hidden="true" />
+							{t.cta.community}
+						</a>
+					</div>
+				</div>
+			</section>
+		</HomeLayout>
+	);
 }

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -47,17 +47,188 @@
     background-image: linear-gradient(135deg, hsl(var(--fd-primary)) 0%, hsl(35 100% 55%) 100%);
   }
 
+  .text-balance {
+    text-wrap: balance;
+  }
+
   .bg-grid {
-    background-size: 40px 40px;
-    background-image: linear-gradient(to right, hsl(var(--fd-border) / 0.4) 1px, transparent 1px),
-      linear-gradient(to bottom, hsl(var(--fd-border) / 0.4) 1px, transparent 1px);
+    background-size: 44px 44px;
+    background-image: linear-gradient(to right, hsl(var(--fd-border) / 0.35) 1px, transparent 1px),
+      linear-gradient(to bottom, hsl(var(--fd-border) / 0.35) 1px, transparent 1px);
   }
 
   .bg-hero-glow {
     background: radial-gradient(
-      ellipse 80% 60% at 50% -20%,
-      hsl(var(--fd-primary) / 0.12),
+      ellipse 120% 80% at 50% -10%,
+      hsl(var(--fd-primary) / 0.22),
+      transparent 55%
+    );
+  }
+
+  .bg-hero-glow-strong {
+    background: radial-gradient(
+      ellipse 140% 90% at 50% -5%,
+      hsl(var(--fd-primary) / 0.14),
+      transparent 60%
+    );
+  }
+
+  .animate-fade-in {
+    animation: fade-in 1s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  .animate-fade-in-delay-1 {
+    animation-delay: 0.12s;
+  }
+
+  .animate-fade-in-delay-2 {
+    animation-delay: 0.24s;
+  }
+
+  .animate-fade-in-delay-3 {
+    animation-delay: 0.4s;
+  }
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(24px);
+      filter: blur(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0);
+    }
+  }
+
+  .animate-float {
+    animation: float 6s ease-in-out infinite;
+  }
+
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-10px);
+    }
+  }
+
+  .glass {
+    @apply border shadow-sm;
+    background-color: hsl(var(--fd-card) / 0.72);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+  }
+
+  .gradient-border {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .gradient-border::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      135deg,
+      hsl(var(--fd-primary) / 0.5),
+      hsl(var(--fd-border) / 0.85) 50%,
+      hsl(var(--fd-primary) / 0.25)
+    );
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+    z-index: -1;
+  }
+
+  .gradient-top-border {
+    position: relative;
+  }
+
+  .gradient-top-border::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 10%;
+    right: 10%;
+    height: 1.5px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      hsl(var(--fd-primary) / 0.6),
       transparent
     );
+    border-radius: 999px;
+  }
+
+  .shine {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .shine::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      105deg,
+      transparent 38%,
+      hsl(var(--fd-primary) / 0.12) 50%,
+      transparent 62%
+    );
+    transform: translateX(-100%) skewX(-12deg);
+    transition: transform 0.8s ease;
+    pointer-events: none;
+  }
+
+  .shine:hover::before {
+    transform: translateX(100%) skewX(-12deg);
+  }
+
+  .hover-lift {
+    transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease;
+  }
+
+  .hover-lift:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 40px -12px hsl(var(--fd-foreground) / 0.12);
+  }
+
+  .json-key {
+    color: hsl(var(--fd-primary));
+  }
+
+  .json-string {
+    color: hsl(35 90% 42%);
+  }
+
+  .json-number {
+    color: hsl(160 75% 34%);
+  }
+
+  .json-bool {
+    color: hsl(260 70% 58%);
+  }
+
+  .json-punct {
+    color: hsl(var(--fd-muted-foreground));
+  }
+
+  .dark .json-string {
+    color: hsl(40 95% 68%);
+  }
+
+  .dark .json-number {
+    color: hsl(160 70% 55%);
+  }
+
+  .dark .json-bool {
+    color: hsl(260 80% 74%);
   }
 }

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,11 +1,28 @@
 import type { ReactNode } from 'react';
+import { Inter, JetBrains_Mono } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './globals.css';
 
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className="flex flex-col min-h-screen">
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="flex flex-col min-h-screen antialiased">
         <RootProvider>{children}</RootProvider>
       </body>
     </html>


### PR DESCRIPTION
This PR gives the taskflow docs website a visual overhaul based on current Fumadocs / modern docs-site best practices.\n\n## What changed\n\n### Theme system\n- Migrated from legacy `fumadocs-ui/style.css` to Tailwind v4 + `fumadocs-ui/css/vitepress.css` + `fumadocs-ui/css/preset.css`\n- Refined light/dark palettes with warmer backgrounds and richer amber/orange brand color\n- Added CSS utilities: `.text-gradient`, `.bg-grid`, `.bg-hero-glow`, `.glass`, `.shine`, `.gradient-border`, `.animate-fade-in`, `.animate-slide-up`\n\n### Typography & motion\n- Loaded Inter (sans) and JetBrains Mono (mono) via `next/font/google`\n- Added subtle fade-in/slide-up keyframes\n\n### Landing page\n- Premium terminal-style code window with syntax highlighting and line numbers\n- Gradient-border stat cards, feature cards with shimmer hover, comparison table with check/X badges\n- Softer testimonials and a stronger gradient CTA section\n\n### Docs layout\n- Branded nav with inline SVG mark\n- Sidebar banner linking to Templates\n- GitHub + Discussions icon links in docs nav\n- "Was this helpful?" feedback footer on every docs page\n\n## Verification\n- `npm run typecheck` passes\n- `npm run build -w taskflow-website` passes, 70 static pages}