### PR TITLE
fix(website): remove remaining duplicate sidebar entries

### DIFF
--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -26,14 +26,11 @@
     "guides/headline-tournament-case-study",
     "guides/migration-planner-case-study",
     "---Showcase---",
-    "showcase",
     "showcase/why-taskflow",
-    "---Templates---",
     "templates",
     "---Reference---",
     "reference/shorthand",
     "reference/commands",
-    "---Community---",
     "community"
   ]
 }

--- a/website/content/docs/zh-cn/meta.json
+++ b/website/content/docs/zh-cn/meta.json
@@ -26,14 +26,11 @@
     "guides/headline-tournament-case-study",
     "guides/migration-planner-case-study",
     "---案例展示---",
-    "showcase",
     "showcase/why-taskflow",
-    "---模板---",
     "templates",
     "---参考---",
     "reference/shorthand",
     "reference/commands",
-    "---社区---",
     "community"
   ]
 }


### PR DESCRIPTION
Follow-up to PR #36. The docs sidebar still had 3 sections rendering their title twice (separator + page link):\n\n- Showcase: `---Showcase---` + `showcase` index link\n- Templates: `---Templates---` + `templates` link\n- Community: `---Community---` + `community` link\n\nThis PR removes the redundant entries so each section shows only once:\n\n- Showcase now uses just the separator with its child page `showcase/why-taskflow` (consistent with Core Concepts / Syntax / Guides)\n- Templates and Community are single pages, so the separator is removed and they render as plain links\n\nVerified via Chrome DevTools a11y snapshot that no sidebar item is duplicated.