### PR TITLE
feat(core): add defineFile param to verify/compile/run a flow from disk

### DIFF
--- a/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
@@ -115,6 +115,26 @@ Call `taskflow_run` with an inline `define` object, or `name` for a saved flow.
 **Before running a non-trivial flow, `taskflow_verify` it — zero tokens,
 catches cycles / missing deps / undefined refs / contract typos.**
 
+### Iterating on a big flow? Use `defineFile` (write once, verify / edit / run by path)
+
+For a non-trivial flow you'll iterate on, **write the definition to a file**
+(typically in the OS tmp dir) and point every call at it with `defineFile`:
+
+```jsonc
+// 1. write /tmp/audit.json with the `write` tool (a full {name, phases:[…]} object)
+// 2. verify, iterate, run — all reference the SAME file by path:
+{ "name": "taskflow_verify", "arguments": { "defineFile": "/tmp/audit.json" } }  // zero tokens
+{ "name": "taskflow_compile", "arguments": { "defineFile": "/tmp/audit.json" } }  // diagram
+{ "name": "taskflow_run",    "arguments": { "defineFile": "/tmp/audit.json" } }
+```
+
+The file can be raw JSON **or** a Markdown doc with a fenced ```json block
+(`write` the JSON form, or paste the flow into a note and fence it). Between
+calls, edit the file (not the call) and re-`verify`. This avoids re-sending a
+large definition on every call and keeps a durable draft you can diff. Falls
+back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
+(saved flow).
+
 ### DSL shape
 
 ```jsonc

--- a/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
@@ -114,6 +114,26 @@ Call `taskflow_run` with an inline `define` object, or `name` for a saved flow.
 **Before running a non-trivial flow, `taskflow_verify` it — zero tokens,
 catches cycles / missing deps / undefined refs / contract typos.**
 
+### Iterating on a big flow? Use `defineFile` (write once, verify / edit / run by path)
+
+For a non-trivial flow you'll iterate on, **write the definition to a file**
+(typically in the OS tmp dir) and point every call at it with `defineFile`:
+
+```jsonc
+// 1. write /tmp/audit.json with the `write` tool (a full {name, phases:[…]} object)
+// 2. verify, iterate, run — all reference the SAME file by path:
+{ "name": "taskflow_verify", "arguments": { "defineFile": "/tmp/audit.json" } }  // zero tokens
+{ "name": "taskflow_compile", "arguments": { "defineFile": "/tmp/audit.json" } }  // diagram
+{ "name": "taskflow_run",    "arguments": { "defineFile": "/tmp/audit.json" } }
+```
+
+The file can be raw JSON **or** a Markdown doc with a fenced ```json block
+(`write` the JSON form, or paste the flow into a note and fence it). Between
+calls, edit the file (not the call) and re-`verify`. This avoids re-sending a
+large definition on every call and keeps a durable draft you can diff. Falls
+back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
+(saved flow).
+
 ### DSL shape
 
 ```jsonc

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -138,6 +138,44 @@ test("mcp: tools/call taskflow_verify flags a cycle as an error", async () => {
 	assert.match(res.result.content[0].text, /FAILED/);
 });
 
+test("mcp: tools/call taskflow_verify validates a flow from defineFile (shared on-disk draft)", async () => {
+	const fs = await import("node:fs");
+	const os = await import("node:os");
+	const path = await import("node:path");
+	const def = { name: "from-file", phases: [{ id: "a", type: "agent", agent: "executor", task: "do", final: true }] };
+	const f = path.join(os.tmpdir(), `tf-definefile-${process.pid}-${Date.now()}.json`);
+	fs.writeFileSync(f, JSON.stringify(def));
+	try {
+		const [res] = await rpcRoundtrip([
+			{
+				jsonrpc: "2.0",
+				id: 99,
+				method: "tools/call",
+				params: { name: "taskflow_verify", arguments: { defineFile: f } },
+			},
+		]);
+		assert.ok(res.result.content[0].text.includes("verification"), "verify reads the flow from defineFile");
+	} finally {
+		fs.unlinkSync(f);
+	}
+});
+
+test("mcp: taskflow_verify with a missing defineFile returns a clear error", async () => {
+	const [res] = await rpcRoundtrip([
+		{
+			jsonrpc: "2.0",
+			id: 100,
+			method: "tools/call",
+			params: {
+				name: "taskflow_verify",
+				arguments: { defineFile: "/tmp/taskflow-definitely-missing-xyz.json" },
+			},
+		},
+	]);
+	assert.equal(res.error.code, -32602);
+	assert.match(res.error.message, /defineFile not found or unparseable/);
+});
+
 test("mcp: tools/call unknown tool returns invalid-params", async () => {
 	const [res] = await rpcRoundtrip([
 		{ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "nope", arguments: {} } },

--- a/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
@@ -115,6 +115,26 @@ Call `taskflow_run` with an inline `define` object, or `name` for a saved flow.
 **Before running a non-trivial flow, `taskflow_verify` it — zero tokens,
 catches cycles / missing deps / undefined refs / contract typos.**
 
+### Iterating on a big flow? Use `defineFile` (write once, verify / edit / run by path)
+
+For a non-trivial flow you'll iterate on, **write the definition to a file**
+(typically in the OS tmp dir) and point every call at it with `defineFile`:
+
+```jsonc
+// 1. write /tmp/audit.json with the `write` tool (a full {name, phases:[…]} object)
+// 2. verify, iterate, run — all reference the SAME file by path:
+{ "name": "taskflow_verify", "arguments": { "defineFile": "/tmp/audit.json" } }  // zero tokens
+{ "name": "taskflow_compile", "arguments": { "defineFile": "/tmp/audit.json" } }  // diagram
+{ "name": "taskflow_run",    "arguments": { "defineFile": "/tmp/audit.json" } }
+```
+
+The file can be raw JSON **or** a Markdown doc with a fenced ```json block
+(`write` the JSON form, or paste the flow into a note and fence it). Between
+calls, edit the file (not the call) and re-`verify`. This avoids re-sending a
+large definition on every call and keeps a durable draft you can diff. Falls
+back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
+(saved flow).
+
 ### DSL shape
 
 ```jsonc

--- a/packages/pi-taskflow/skills/taskflow/SKILL.md
+++ b/packages/pi-taskflow/skills/taskflow/SKILL.md
@@ -106,6 +106,26 @@ Call the `taskflow` tool. To run a brand-new flow you write inline, pass
 **Before running a non-trivial flow, `action: "verify"` it — zero tokens,
 catches cycles / missing deps / undefined refs / contract typos.**
 
+### Iterating on a big flow? Use `defineFile` (write once, verify / edit / run by path)
+
+For a non-trivial flow you'll iterate on, **write the definition to a file**
+(typically in the OS tmp dir) and point every call at it with `defineFile`:
+
+```jsonc
+// 1. write /tmp/audit.json with the `write` tool (a full {name, phases:[…]} object)
+// 2. verify, iterate, run — all reference the SAME file by path:
+{ "action": "verify", "defineFile": "/tmp/audit.json" }        // zero tokens
+{ "action": "compile", "defineFile": "/tmp/audit.json" }        // diagram + report
+{ "action": "run",    "defineFile": "/tmp/audit.json", "args": { … } }
+```
+
+The file can be raw JSON **or** a Markdown doc with a fenced ```json block
+(`write` the JSON form, or paste the flow into a note and fence it). Between
+calls, edit the file (not the call) and re-`verify`. This avoids re-sending a
+large definition on every call and keeps a durable draft you can diff. Falls
+back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
+(saved flow).
+
 ### DSL shape
 
 ```jsonc

--- a/packages/pi-taskflow/src/index.ts
+++ b/packages/pi-taskflow/src/index.ts
@@ -44,6 +44,7 @@ import {
 	saveRun,
 	DEFAULT_KEPT_RUNS,
 	DEFAULT_RUN_AGE_DAYS,
+	readDefineFile,
 } from "taskflow-core";
 import { CacheStore } from "taskflow-core";
 import { safeParse } from "taskflow-core";
@@ -98,6 +99,12 @@ const TaskflowParams = Type.Object({
 		Type.Unknown({
 			description:
 				"Inline taskflow definition (JSON object matching the taskflow DSL). Use to run or save a new flow.",
+		}),
+	),
+	defineFile: Type.Optional(
+		Type.String({
+			description:
+				"Path to a file holding the taskflow definition (raw JSON, or Markdown with a ```json fence). Lets verify/compile/ir/run/save share ONE persisted draft (e.g. in the OS tmp dir) — edit the file between calls instead of re-sending the whole definition each time. Precedence: define (inline) > defineFile (disk) > name (saved flow).",
 		}),
 	),
 	// --- Shorthand (non-DAG) modes, like the subagent tool. No DSL required. ---
@@ -657,9 +664,14 @@ export default function (pi: ExtensionAPI) {
 
 			if (action === "verify") {
 				const { verifyTaskflow } = await import("taskflow-core");
-				// Load definition: inline define takes priority, then saved name
+				// Load definition: inline define takes priority, then defineFile, then saved name
 				let def: Taskflow | undefined;
 				let resolvedDefine: unknown = params.define;
+				if (resolvedDefine === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
+					const fromFile = readDefineFile(params.defineFile);
+					if (fromFile === null) return errorResult(action, `defineFile not found or unparseable: ${params.defineFile}`);
+					resolvedDefine = fromFile;
+				}
 				if (typeof resolvedDefine === "string") {
 					const parsed = safeParse(resolvedDefine);
 					if (parsed && typeof parsed === "object") resolvedDefine = parsed;
@@ -709,9 +721,14 @@ export default function (pi: ExtensionAPI) {
 
 			if (action === "compile") {
 				const { compileTaskflow } = await import("taskflow-core");
-				// Resolve definition: inline define (object or JSON/fenced string) then saved name.
+				// Resolve definition: inline define (object or JSON/fenced string), defineFile, then saved name.
 				let def: Taskflow | undefined;
 				let resolvedDefine: unknown = params.define;
+				if (resolvedDefine === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
+					const fromFile = readDefineFile(params.defineFile);
+					if (fromFile === null) return errorResult(action, `defineFile not found or unparseable: ${params.defineFile}`);
+					resolvedDefine = fromFile;
+				}
 				if (typeof resolvedDefine === "string") {
 					const parsed = safeParse(resolvedDefine);
 					if (parsed && typeof parsed === "object") resolvedDefine = parsed;
@@ -750,9 +767,14 @@ export default function (pi: ExtensionAPI) {
 			if (action === "ir") {
 				const { compileTaskflowToIR } = await import("taskflow-core");
 				// Resolve definition: inline define (object or JSON/fenced string), shorthand,
-				// or saved name. Mirrors action=compile / action=verify.
+				// or defineFile, then saved name. Mirrors action=compile / action=verify.
 				let def: Taskflow | undefined;
 				let resolvedDefine: unknown = params.define;
+				if (resolvedDefine === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
+					const fromFile = readDefineFile(params.defineFile);
+					if (fromFile === null) return errorResult(action, `defineFile not found or unparseable: ${params.defineFile}`);
+					resolvedDefine = fromFile;
+				}
 				if (typeof resolvedDefine === "string") {
 					const parsed = safeParse(resolvedDefine);
 					if (parsed && typeof parsed === "object") resolvedDefine = parsed;
@@ -866,7 +888,13 @@ export default function (pi: ExtensionAPI) {
 
 			// Auto-parse string `define` — LLMs sometimes pass a JSON string
 			// instead of a parsed object. safeParse handles markdown fences too.
+			// `defineFile` lets verify/run share ONE on-disk draft (e.g. in /tmp).
 			let resolvedDefine: unknown = params.define;
+			if (resolvedDefine === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
+				const fromFile = readDefineFile(params.defineFile);
+				if (fromFile === null) return errorResult(action, `defineFile not found or unparseable: ${params.defineFile}`);
+				resolvedDefine = fromFile;
+			}
 			if (typeof resolvedDefine === "string") {
 				const parsed = safeParse(resolvedDefine);
 				if (parsed && typeof parsed === "object") {

--- a/packages/taskflow-core/src/store.ts
+++ b/packages/taskflow-core/src/store.ts
@@ -20,6 +20,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { parseJsonc } from "./jsonc.ts";
 import { getAgentDir } from "./paths.ts";
+import { safeParse } from "./interpolate.ts";
 import type { Taskflow } from "./schema.ts";
 import type { UsageStats } from "./usage.ts";
 import type { DeclaredDeps } from "./flowir/meta.ts";
@@ -611,6 +612,26 @@ function findProjectFlowsDirInternal(cwd: string, create = false): string | null
 		dir = parent;
 	}
 	return create ? path.join(cwd, ".pi", "taskflows") : null;
+}
+
+/**
+ * Read a flow definition from a file on disk. Supports raw JSON or a Markdown
+ * document with a fenced ```json block (reuses safeParse). Used by the
+ * `defineFile` parameter so verify/compile/run can share one persisted draft
+ * (e.g. in the OS temp dir) without saving it into the project's .pi/taskflows.
+ *
+ * Returns the parsed definition (object/array/shorthand), or null if the file
+ * can't be read or parsed. Callers surface an explicit error in that case.
+ */
+export function readDefineFile(filePath: string): unknown {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+	const parsed = safeParse(raw);
+	return parsed ?? null;
 }
 
 function readFlowFile(filePath: string, scope: "user" | "project"): SavedFlow | null {

--- a/packages/taskflow-core/test/define-file.test.ts
+++ b/packages/taskflow-core/test/define-file.test.ts
@@ -1,0 +1,57 @@
+/**
+ * readDefineFile: the disk-backed `defineFile` resolver.
+ *
+ * `defineFile` lets verify/compile/run share ONE persisted draft (typically in
+ * the OS temp dir) so the agent writes the flow once and then verifies / edits
+ * / runs it by path, instead of re-sending the whole definition each call.
+ */
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import { readDefineFile } from "../src/store.ts";
+
+function tmpFile(prefix: string, content: string): string {
+	const p = path.join(os.tmpdir(), `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+	fs.writeFileSync(p, content, "utf-8");
+	return p;
+}
+
+test("readDefineFile: parses a raw JSON flow definition", () => {
+	const def = { name: "raw", phases: [{ id: "a", type: "agent", task: "hi", final: true }] };
+	const f = tmpFile("raw", JSON.stringify(def));
+	assert.equal((readDefineFile(f) as { name: string }).name, "raw");
+	fs.unlinkSync(f);
+});
+
+test("readDefineFile: extracts the flow from a fenced ```json markdown block", () => {
+	const md =
+		"# My draft flow\n\n" +
+		"Some prose explaining the idea.\n\n" +
+		"```json\n" +
+		'{\n  "name": "from-fence",\n  "phases": [\n    { "id": "a", "type": "agent", "task": "x", "final": true }\n  ]\n}\n' +
+		"```\n\n" +
+		"Trailing prose.\n";
+	const f = tmpFile("fence", md);
+	assert.equal((readDefineFile(f) as { name: string }).name, "from-fence");
+	fs.unlinkSync(f);
+});
+
+test("readDefineFile: returns null for a missing file (no throw)", () => {
+	assert.equal(readDefineFile(path.join(os.tmpdir(), "taskflow-definitely-missing-xyz.json")), null);
+});
+
+test("readDefineFile: returns null for an unparseable file", () => {
+	const f = tmpFile("junk", "this is not json {{{");
+	assert.equal(readDefineFile(f), null);
+	fs.unlinkSync(f);
+});
+
+test("readDefineFile: handles a JSON string define value (shorthand forms parse too)", () => {
+	// A bare JSON object is the common case — confirm a minimal valid shape round-trips.
+	const def = { task: "do something", name: "shorthand" };
+	const f = tmpFile("sh", JSON.stringify(def));
+	assert.equal((readDefineFile(f) as { task: string }).task, "do something");
+	fs.unlinkSync(f);
+});

--- a/packages/taskflow-mcp/src/mcp/server.ts
+++ b/packages/taskflow-mcp/src/mcp/server.ts
@@ -35,6 +35,7 @@ import {
 	saveRun,
 	DEFAULT_KEPT_RUNS,
 	DEFAULT_RUN_AGE_DAYS,
+	readDefineFile,
 	compileTaskflow,
 	verifyTaskflow,
 	desugar,
@@ -159,6 +160,7 @@ const TOOLS: McpTool[] = [
 			properties: {
 				name: { type: "string", description: "Name of a saved flow to run." },
 				define: { type: "object", description: "Inline flow definition (full DAG or shorthand)." },
+				defineFile: { type: "string", description: "Path to a file holding the flow definition (raw JSON, or Markdown with a ```json fence). Lets you verify/compile/run share ONE persisted draft (e.g. in the OS tmp dir) — edit the file between calls instead of re-sending the whole definition. Precedence: define > defineFile > name." },
 				args: { type: "object", description: "Invocation arguments interpolated as {args.X}." },
 				incremental: { type: "boolean", description: "Default every phase to cross-run cache reuse." },
 			},
@@ -184,26 +186,28 @@ const TOOLS: McpTool[] = [
 	{
 		name: "taskflow_verify",
 		title: "Verify a taskflow",
-		description: "Statically verify a flow (cycles, missing deps, undefined refs, …) WITHOUT executing it. Provide `name` or `define`.",
+		description: "Statically verify a flow (cycles, missing deps, undefined refs, …) WITHOUT executing it. Provide `name`, `define`, or `defineFile`.",
 		inputSchema: {
 			type: "object",
 			additionalProperties: false,
 			properties: {
 				name: { type: "string" },
 				define: { type: "object" },
+				defineFile: { type: "string", description: "Path to a JSON (or fenced-Markdown) flow file. See taskflow_run.defineFile." },
 			},
 		},
 	},
 	{
 		name: "taskflow_compile",
 		title: "Compile a taskflow to a diagram",
-		description: "Render a flow's DAG as a diagram (an inline SVG image) with issues overlaid (red=error, amber=warning, green=final), plus a compact status line. No execution. Provide `name` or `define`.",
+		description: "Render a flow's DAG as a diagram (an inline SVG image) with issues overlaid (red=error, amber=warning, green=final), plus a compact status line. No execution. Provide `name`, `define`, or `defineFile`.",
 		inputSchema: {
 			type: "object",
 			additionalProperties: false,
 			properties: {
 				name: { type: "string" },
 				define: { type: "object" },
+				defineFile: { type: "string", description: "Path to a JSON (or fenced-Markdown) flow file. See taskflow_run.defineFile." },
 			},
 		},
 	},
@@ -227,8 +231,13 @@ const TOOLS: McpTool[] = [
 	},
 ];
 
-/** Resolve a flow from params: inline `define` (desugared) or saved `name`. */
-function resolveFlow(cwd: string, params: { name?: string; define?: unknown }): Taskflow {
+/** Resolve a flow from params: inline `define` (desugared), `defineFile` (disk), or saved `name`. */
+function resolveFlow(cwd: string, params: { name?: string; define?: unknown; defineFile?: unknown }): Taskflow {
+	if (params.define === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
+		const fromFile = readDefineFile(params.defineFile);
+		if (fromFile === null) throw new RpcError(RPC.INVALID_PARAMS, `defineFile not found or unparseable: ${params.defineFile}`);
+		params = { ...params, define: fromFile };
+	}
 	if (params.define !== undefined && params.define !== null) {
 		return isShorthand(params.define) ? desugar(params.define) : (params.define as Taskflow);
 	}

--- a/skills-src/taskflow/core.md
+++ b/skills-src/taskflow/core.md
@@ -111,6 +111,37 @@ Call `taskflow_run` with an inline `define` object, or `name` for a saved flow.
 catches cycles / missing deps / undefined refs / contract typos.**
 <!-- /host:codex,claude,opencode -->
 
+### Iterating on a big flow? Use `defineFile` (write once, verify / edit / run by path)
+
+For a non-trivial flow you'll iterate on, **write the definition to a file**
+(typically in the OS tmp dir) and point every call at it with `defineFile`:
+
+<!-- host:pi -->
+```jsonc
+// 1. write /tmp/audit.json with the `write` tool (a full {name, phases:[…]} object)
+// 2. verify, iterate, run — all reference the SAME file by path:
+{ "action": "verify", "defineFile": "/tmp/audit.json" }        // zero tokens
+{ "action": "compile", "defineFile": "/tmp/audit.json" }        // diagram + report
+{ "action": "run",    "defineFile": "/tmp/audit.json", "args": { … } }
+```
+<!-- /host:pi -->
+<!-- host:codex,claude,opencode -->
+```jsonc
+// 1. write /tmp/audit.json with the `write` tool (a full {name, phases:[…]} object)
+// 2. verify, iterate, run — all reference the SAME file by path:
+{ "name": "taskflow_verify", "arguments": { "defineFile": "/tmp/audit.json" } }  // zero tokens
+{ "name": "taskflow_compile", "arguments": { "defineFile": "/tmp/audit.json" } }  // diagram
+{ "name": "taskflow_run",    "arguments": { "defineFile": "/tmp/audit.json" } }
+```
+<!-- /host:codex,claude,opencode -->
+
+The file can be raw JSON **or** a Markdown doc with a fenced ```json block
+(`write` the JSON form, or paste the flow into a note and fence it). Between
+calls, edit the file (not the call) and re-`verify`. This avoids re-sending a
+large definition on every call and keeps a durable draft you can diff. Falls
+back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
+(saved flow).
+
 ### DSL shape
 
 ```jsonc


### PR DESCRIPTION
## What

Adds a `defineFile` parameter so `verify` / `compile` / `ir` / `run` / `save` can read a flow definition **from a file path** instead of requiring the full inline `define` on every call.

**Workflow it unlocks:** write the flow to a file (typically in the OS tmp dir), then point every call at it by path. Edit the file between calls — no need to re-send the whole definition each time.

```jsonc
// 1. write /tmp/audit.json (a full {name, phases:[…]} object)
// 2. verify → iterate → run, all referencing the SAME file:
{ "action": "verify", "defineFile": "/tmp/audit.json" }        // zero tokens
{ "action": "compile", "defineFile": "/tmp/audit.json" }        // diagram + report
{ "action": "run",     "defineFile": "/tmp/audit.json", "args": { … } }
```

The file can be **raw JSON** *or* a Markdown doc with a fenced ` ```json ` block (reuses `safeParse`).

## Why

For a non-trivial flow you iterate on, re-sending the whole DSL object on every `verify`/`run` call wastes context and has no durable draft to diff against. `defineFile` lets the agent persist one draft and refine it across calls. Distinct from `save` (which writes into the project's gitignored `.pi/taskflows/` and requires the flow to validate first) — `defineFile` is a scratch draft, lives anywhere on disk, and need not validate to be written.

## Changes

| Package | Change |
|---|---|
| `taskflow-core` | `readDefineFile(filePath)` in `store.ts` — reads a file and parses via `safeParse` (raw JSON **or** fenced-Markdown ` ```json `). Returns `null` when unreadable/unparseable so callers surface an explicit error. |
| `pi-taskflow` | `defineFile` added to `TaskflowParams`; all **4** define-resolution sites (`verify` / `compile` / `ir` / the `save`+`run` fallthrough) fall back to it when inline `define` is absent. |
| `taskflow-mcp` | `resolveFlow` + the `taskflow_run` / `taskflow_verify` / `taskflow_compile` inputSchemas accept `defineFile` — codex / claude / opencode all inherit it from the one host-neutral binding. |
| `skills-src` + generated | New **"Iterating on a big flow? Use `defineFile`"** subsection in `core.md` (with `<!-- host:pi -->` and `<!-- host:codex,claude,opencode -->` blocks), regenerated for all four hosts via `pnpm run build:skills`. |

**Precedence:** `define` (inline) > `defineFile` (disk) > `name` (saved flow). A missing/unparseable file is an explicit error (pi: `errorResult`; MCP: `RpcError(-32602)`) — never silently falls through to `name`.

## Tests

- `packages/taskflow-core/test/define-file.test.ts` (new) — 5 unit tests: raw JSON, fenced Markdown, missing file (no throw), unparseable file, shorthand form.
- `packages/codex-taskflow/test/mcp-server.test.ts` — 2 new integration tests: a valid `defineFile` flows through `taskflow_verify` and passes; a missing file returns `-32602` with `defineFile not found or unparseable`.

Full suite **1099/1099 pass** (was 1092; +7 new). `tsc --noEmit` clean.

## Stacked PR note

This is **stacked on #26** (`feat/claude-and-opencode-hosts`) because it touches `taskflow-mcp/server.ts`, which #26 introduces (the MCP-server-into-core extraction). Base is `feat/claude-and-opencode-hosts`; once #26 lands, GitHub will re-target this PR to `main` automatically. Review the diff against the base branch — it is just the 10 `defineFile` files.