### PR TITLE
feat(website): Fumadocs CodeBlock, last-updated, breadcrumb, clerk TOC, hero syntax highlight

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .next
 out
 dist
+tsconfig.tsbuildinfo
 
 # Generated
 .source

--- a/website/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/app/[lang]/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import {
 	DocsDescription,
 	DocsPage,
 	DocsTitle,
+	PageLastUpdate,
 } from "fumadocs-ui/layouts/docs/page";
 import { MessageSquare, Pencil } from "lucide-react";
 import { notFound } from "next/navigation";
@@ -179,11 +180,20 @@ export default async function Page({
 				type="application/ld+json"
 				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
 			/>
-			<DocsPage toc={page.data.toc} full={page.data.full} className="relative">
+			<DocsPage
+				toc={page.data.toc}
+				full={page.data.full}
+				className="relative"
+				breadcrumb={{ includeRoot: true, includePage: true }}
+				tableOfContent={{ style: "clerk" }}
+			>
 				<DocsTitle>{page.data.title}</DocsTitle>
 				<DocsDescription>{page.data.description}</DocsDescription>
 				<DocsBody>
 					<MDX components={getMDXComponents()} />
+					{page.data.lastModified ? (
+						<PageLastUpdate date={page.data.lastModified} />
+					) : null}
 				</DocsBody>
 				<DocsFeedbackFooter
 					editUrl={editUrl}

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -379,6 +379,15 @@ function tokenizeJsonLine(line: string): JsonToken[] {
 	return tokens;
 }
 
+const jsonTokenClass: Record<JsonToken["type"], string | undefined> = {
+	key: "text-sky-600 dark:text-sky-400",
+	string: "text-emerald-600 dark:text-emerald-400",
+	number: "text-amber-600 dark:text-amber-400",
+	bool: "text-amber-600 dark:text-amber-400",
+	punct: "text-fd-muted-foreground",
+	plain: undefined,
+};
+
 function highlightJson(line: string) {
 	return (
 		<span>
@@ -386,7 +395,7 @@ function highlightJson(line: string) {
 				<span
 					// biome-ignore lint/suspicious/noArrayIndexKey: static syntax highlight tokens
 					key={`${token.type}-${token.value}-${i}`}
-					className={token.type === "plain" ? undefined : `json-${token.type}`}
+					className={jsonTokenClass[token.type]}
 				>
 					{token.value}
 				</span>

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -208,38 +208,6 @@
     box-shadow: 0 20px 40px -12px hsl(var(--fd-foreground) / 0.12);
   }
 
-  .json-key {
-    color: hsl(var(--fd-primary));
-  }
-
-  .json-string {
-    color: hsl(35 90% 42%);
-  }
-
-  .json-number {
-    color: hsl(160 75% 34%);
-  }
-
-  .json-bool {
-    color: hsl(260 70% 58%);
-  }
-
-  .json-punct {
-    color: hsl(var(--fd-muted-foreground));
-  }
-
-  .dark .json-string {
-    color: hsl(40 95% 68%);
-  }
-
-  .dark .json-number {
-    color: hsl(160 70% 55%);
-  }
-
-  .dark .json-bool {
-    color: hsl(260 80% 74%);
-  }
-
   @media (prefers-reduced-motion: no-preference) {
     @keyframes float {
       0%,

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1,6 +1,28 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/style.css';
 
+/*
+ * Shiki dual-theme support.
+ *
+ * Fumadocs renders code blocks with Shiki using `defaultColor: false`, so each
+ * token <span> carries inline `--shiki-light` / `--shiki-dark` (and -bg)
+ * custom properties instead of a hardcoded color. These rules swap which set
+ * is applied based on the `.dark` class on <html>. Declared unlayered so they
+ * win over any layered fumadocs defaults and the inline token colors resolve
+ * correctly in both light and dark mode.
+ */
+.shiki,
+.shiki span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
+}
+
 @layer base {
   :root {
     --fd-background: 40 33% 98%;

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -3,16 +3,29 @@ import { Inter, JetBrains_Mono } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './globals.css';
 
+/*
+ * Fonts are loaded via next/font/google. The CSS variables (--font-sans /
+ * --font-mono) are applied to <html> below and cascade to body/code; fumadocs
+ * applies the `font-mono` utility to code blocks, so the variables are used.
+ *
+ * The browser console warning "... preloaded using link preload but not used"
+ * is a known, harmless next/font behavior: next/font emits a preload <link>
+ * for the font file, but `display: 'swap'` defers applying it until render.
+ * `adjustFontFallback: false` disables the extra metric-override preload that
+ * next/font injects, reducing preload overhead. We keep `display: 'swap'`.
+ */
 const inter = Inter({
   subsets: ['latin'],
   variable: '--font-sans',
   display: 'swap',
+  adjustFontFallback: false,
 });
 
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
   variable: '--font-mono',
   display: 'swap',
+  adjustFontFallback: false,
 });
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/website/components/mdx.tsx
+++ b/website/components/mdx.tsx
@@ -5,6 +5,7 @@ import {
 } from 'fumadocs-ui/components/accordion';
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Card, Cards } from 'fumadocs-ui/components/card';
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
 import { File, Files, Folder } from 'fumadocs-ui/components/files';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
@@ -25,6 +26,11 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     Steps,
     Tab,
     Tabs,
+    pre: ({ ref: _ref, ...props }) => (
+      <CodeBlock {...props} keepBackground>
+        <Pre>{props.children}</Pre>
+      </CodeBlock>
+    ),
     ...components,
   } satisfies MDXComponents;
 }

--- a/website/source.config.ts
+++ b/website/source.config.ts
@@ -1,7 +1,12 @@
-import { defineDocs, defineConfig } from 'fumadocs-mdx/config';
+import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import lastModified from "fumadocs-mdx/plugins/last-modified";
 
 export const docs = defineDocs({
-  dir: 'content/docs',
+	dir: "content/docs",
 });
 
-export default defineConfig();
+export default defineConfig({
+	// Injects `lastModified` (Date, from git) into each page's data so that
+	// <PageLastUpdate date={page.data.lastModified} /> can render on docs pages.
+	plugins: [lastModified()],
+});


### PR DESCRIPTION
Brings the docs site up to current Fumadocs best practices based on the official UI docs.\n\n## What changed\n\n### Code blocks (MDX)\n- Registered the official `CodeBlock` + `Pre` components (`fumadocs-ui/components/codeblock`) in `components/mdx.tsx`\n- Enabled `keepBackground` so code blocks use the Shiki-generated background color instead of being transparent\n- Code blocks now render with a proper container, copy button, and language label\n\n### Docs pages\n- Added **Last Updated** time via `PageLastUpdate` + the `lastModified()` remark plugin (reads git timestamps at build time; gracefully omitted if unavailable)\n- Enabled **breadcrumb** with `includeRoot: true, includePage: true`\n- Switched the **table of contents** to the modern `clerk` style\n\n### Landing page hero\n- Added syntax highlighting to the hero JSON code window (regex tokenizer → Tailwind color classes: keys=sky, strings=emerald, numbers=amber), with `dark:` variants for dark mode\n- No new dependencies\n\n### Foundations\n- Added Shiki dual-theme CSS variable swap (`.shiki` / `.dark .shiki`) for correct dark-mode token colors\n- Reduced next/font preload overhead via `adjustFontFallback: false`\n\n## Verification\n- `npm run typecheck` passes\n- CI build (dist emit) pending on this PR}