### PR TITLE
fix(website): fix mobile horizontal overflow and enable full git history

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so the lastModified remark plugin can read accurate
+          # git timestamps for every docs page (shallow clone would leave
+          # most pages without a last-updated date).
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -655,7 +655,7 @@ export default async function HomePage({
 						<span>{t.badge}</span>
 					</div>
 
-					<h1 className="animate-fade-in animate-fade-in-delay-1 mt-10 text-8xl font-extrabold tracking-tighter sm:text-8xl md:text-9xl">
+					<h1 className="animate-fade-in animate-fade-in-delay-1 mt-10 text-5xl font-extrabold tracking-tighter sm:text-7xl md:text-8xl lg:text-9xl">
 						<span className="text-gradient text-glow">{t.title}</span>
 					</h1>
 

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -559,3 +559,16 @@
     }
   }
 }
+
+/*
+ * Mobile overflow fix.
+ *
+ * Fumadocs renders <main> as `flex flex-col`, so top-level section children
+ * are flex items. Flex items default to `min-width: auto`, which means wide
+ * content (e.g. a `min-w-[640px]` comparison table) stretches the section
+ * beyond the viewport and causes horizontal page scroll on mobile.
+ * Forcing `min-width: 0` lets `overflow-x-auto` containers do their job.
+ */
+main > * {
+  min-width: 0;
+}


### PR DESCRIPTION
Two fixes found via Chrome DevTools mobile emulation.\n\n## Mobile horizontal overflow\nOn a 375px viewport the page was 690px wide, forcing horizontal scroll. Root cause: Fumadocs renders `<main>` as `flex flex-col`, so section children are flex items with default `min-width: auto` — the comparison table (`min-w-[640px]`) stretched its section to 690px.\n\nFix: `main > * { min-width: 0 }` lets `overflow-x-auto` containers scroll instead of stretching the page.\n\nAlso: the hero `<h1>` was `text-8xl` (96px) on mobile — now starts at `text-5xl` and scales up (`sm:text-7xl md:text-8xl lg:text-9xl`).\n\n## Accurate last-updated times\nThe deploy workflow used a shallow checkout (`fetch-depth: 1`), so the `lastModified` remark plugin could only see the latest commit. Most docs pages showed no last-updated date.\n\nFix: `fetch-depth: 0` in `deploy-website.yml` so every page gets an accurate git timestamp.\n\n## Verification\n- `npm run typecheck` passes\n- Mobile overflow to be confirmed on deploy