### PR TITLE
fix(website): allow mobile touch-scroll on hero code window

### DIFF
--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -694,7 +694,7 @@ export default async function HomePage({
 
 					<div className="animate-fade-in animate-fade-in-delay-3 relative z-10 -mt-6 w-full max-w-3xl md:-mt-12">
 						<figure
-							className="code-window pointer-events-none relative w-full overflow-hidden rounded-2xl glass gradient-border"
+							className="code-window relative w-full overflow-hidden rounded-2xl glass gradient-border"
 							aria-label={t.code.label}
 						>
 							<figcaption className="flex items-center gap-3 border-b bg-fd-muted/50 px-5 py-3.5">


### PR DESCRIPTION
The hero code `<figure>` had `pointer-events-none`, which blocked touch scrolling on mobile. Long JSON lines were clipped by `overflow-hidden` with no way to see the full code.\n\nRemoving `pointer-events-none` lets mobile users swipe horizontally to view the complete flow definition. The floating decorative icons are already `pointer-events-none` and `hidden md:block` (hidden on mobile), so they do not interfere with the code window.