### PR TITLE
feat(core): library Phase 1 — reusable-flow asset layer with structural search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ All notable changes to taskflow are documented here. This project follows [Keep 
   host can no longer drift the process/classify contract.
 
 ### Added
+- **Library Phase 1: search-before-author + reusable-flow assets.** A new
+  reusable-flow asset layer with sidecar `.meta.json` metadata
+  (`purpose`, `tags`, `phaseSignature`, `generality`, `agentUsage`, `reuseCount`).
+  Save reusable flows with `action=save` (Pi) or `taskflow_save` (MCP) and search
+  them before authoring a new flow with `action=search` / `taskflow_search`.
+  Search combines structural similarity (`agent→map→reduce` signature + phase
+  count) and CJK-aware keyword matching, and degrades gracefully to purely
+  structural/keyword scoring when no embedder is configured (Phase 2). The
+  `reusedFromSearch` flag on `taskflow_run` / `action=run` increments
+  `reuseCount`, so high-quality reusable flows surface higher over time. See
+  `docs/rfc-library-reuse.md` for the full design and `skills-src/taskflow/library.md`
+  for the agent-facing workflow.
+
 - **OpenCode as a fourth host.** New `opencode-taskflow` package: an OpenCode
   subagent runner (`opencode run --format json`) plus an `opencode.json` MCP
   config scaffold, mirroring the Codex/Claude adapters. A flow's subagents can

--- a/README.md
+++ b/README.md
@@ -455,6 +455,46 @@ with the run — flows that don't opt in behave exactly as before.
   "task": "ctx_read 'endpoints' for shared context, then audit {item} for missing auth." }
 ```
 
+### Library: search before author
+
+A flow that took work to generalize is an asset — but only if you can find it
+again. Phase 1 of the **taskflow library** adds sidecar `.meta.json` metadata
+(`purpose`, `tags`, `phaseSignature`, `generality`, `reuseCount`) to saved
+flows, plus a search tool that surfaces reusable flows before you write a new
+one:
+
+```jsonc
+// MCP
+{ "name": "taskflow_search", "arguments": { "query": "audit API endpoints for missing auth" } }
+// Pi tool
+{ "action": "search", "query": "审计接口鉴权" }
+```
+
+Search is **structural + keyword** by default (zero dependencies, zero tokens):
+`phaseSignature` (`agent→map→reduce`) and phase-count similarity are blended
+with keyword overlap. It is **CJK-aware**, so a Chinese query like
+`"检查接口安全性 鉴权 缺失"` still matches a purpose containing
+`"审计...是否缺少鉴权检查"`. Embedding-based semantic search is Phase 2 —
+the `embedder` seam is already in place and search degrades gracefully when it
+is not configured.
+
+When you run a flow you discovered via search, pass `reusedFromSearch: true`
+(`taskflow_run` MCP, or `action=run` in Pi). That bumps the flow's
+`reuseCount`, so high-quality reusable patterns rank higher over time. When you
+write a new reusable flow, save it with metadata:
+
+```jsonc
+{ "name": "taskflow_save",
+  "arguments": {
+    "name": "audit-endpoints",
+    "definition": { ... },
+    "purpose": "Audit API endpoints for missing auth checks",
+    "tags": ["audit", "security", "auth"] } }
+```
+
+See `docs/rfc-library-reuse.md` for the design and `skills-src/taskflow/library.md`
+for the agent-facing search→reuse→generalize→re-save workflow.
+
 ### Control flow & reliability
 
 - **`when`** — skip a phase unless an expression is truthy. Supports `{refs}`, `== != < > <= >=`, `&& || !`, parentheses, and quoted strings/numbers. Pair with `join: "any"` on the merge phase for real if/else routing. Parse errors **fail open** (the phase runs — never silently dropped).
@@ -826,7 +866,7 @@ Copy one into `.pi/taskflows/<name>.json` (or `~/.pi/agent/taskflows/`) and it r
 </div>
 
 - **Zero runtime dependencies.** No `dependencies` field — the runtime is built entirely on Node built-ins (`fs` / `path` / `os` / `child_process` / `crypto`). The file lock is `fs.openSync("wx")`, not a third-party library.
-- **1092 tests across 67 test files** covering concurrency, atomic file locking (8-process race regressions), path-traversal hardening, cross-session resume, cross-run cache freshness (flow/thinking/tools key isolation, fingerprint invalidation, TTL/LRU eviction), backward-compatible cache-key migration (4-tier legacy fallback), per-phase structural sub-fingerprint (v3:phasefp — editing one phase invalidates only it and its dependents), per-item map caching (one changed item re-executes, N−1 cache hits), the `incremental` flag (run-wide cross-run default), reuse reporting, the FlowIR compile seam (determinism, declared-plane synthesis), incremental recompute (early-cutoff propagation, partial cascade strictly < full, observed ∪ declared union frontier), gate verdicts, budget caps, retry/backoff, approval flows, loop termination, tournament judging, sub-flow composition, the shared context tree (blackboard reuse, supervision spawn, subflow validation/nesting), workspace isolation (temp/dedicated/worktree lifecycle, fail-open degrade, dynamic-flow rejection), dynamic sub-flow security hardening, detached execution (PID persistence, stale detection, crash→failed, resume after failure), live run-history refresh, callback isolation, the idle watchdog, model-role init config, parseModelFromLabel with parenthesized-model-name regression, multi-fence `safeParse` recovery, host argv-contract locking (codex/claude/opencode `buildXxxArgs`), plus the `compile` Mermaid renderer (id-collision disambiguation, markdown-injection hardening, and full verify-overlay category coverage).
+- **1123 tests across 70 test files** covering concurrency, atomic file locking (8-process race regressions), path-traversal hardening, cross-session resume, cross-run cache freshness (flow/thinking/tools key isolation, fingerprint invalidation, TTL/LRU eviction), backward-compatible cache-key migration (4-tier legacy fallback), per-phase structural sub-fingerprint (v3:phasefp — editing one phase invalidates only it and its dependents), per-item map caching (one changed item re-executes, N−1 cache hits), the `incremental` flag (run-wide cross-run default), reuse reporting, the FlowIR compile seam (determinism, declared-plane synthesis), incremental recompute (early-cutoff propagation, partial cascade strictly < full, observed ∪ declared union frontier), gate verdicts, budget caps, retry/backoff, approval flows, loop termination, tournament judging, sub-flow composition, the shared context tree (blackboard reuse, supervision spawn, subflow validation/nesting), workspace isolation (temp/dedicated/worktree lifecycle, fail-open degrade, dynamic-flow rejection), dynamic sub-flow security hardening, detached execution (PID persistence, stale detection, crash→failed, resume after failure), live run-history refresh, callback isolation, the idle watchdog, model-role init config, parseModelFromLabel with parenthesized-model-name regression, multi-fence `safeParse` recovery, host argv-contract locking (codex/claude/opencode `buildXxxArgs`), the `compile` Mermaid renderer (id-collision disambiguation, markdown-injection hardening, and full verify-overlay category coverage), plus the library Phase 1 metadata/search/store layer (phaseSignature, generality, CJK text scoring, staleness detection, sidecar persistence, A1 ghost-flow guard).
 - **Hardened by design.** Path-traversal defense (lexical + `realpath` containment check), runId validation, HTML/error sanitization, atomic writes, stale-lock stealing via `rename`, and an idle watchdog that kills wedged subagents (SIGTERM → SIGKILL after 5 minutes of silence). Dynamic sub-flows additionally get breadth caps, `cwd` containment, budget clamping, nesting depth caps, and prototype-pollution defense.
 - **Dogfooded.** Every new feature has to survive the project's own `self-improve` taskflow before it ships.
 
@@ -851,7 +891,7 @@ Our `self-improve` flow is a 10-phase DAG — it audits the codebase, patches de
 
 ## Status & limits
 
-**v0.1.5** — the current release. See [CHANGELOG](./CHANGELOG.md) for the full history. This release adds **Claude Code and OpenCode as hosts**, **extracts the MCP server into its own `taskflow-mcp` package**, and **de-duplicates the three host runners** into a shared `runSubagentProcess`. Baseline: **multi-host monorepo of seven packages** — the host-neutral `taskflow-core` engine, the host-neutral `taskflow-mcp` MCP server, the shared host-runner `taskflow-hosts`, plus `pi-taskflow` (Pi adapter), `codex-taskflow`, `claude-taskflow`, and `opencode-taskflow` (the three delivery packages re-export their runners from `taskflow-hosts` and each ships an MCP bin + plugin/config), all sharing the host-neutral MCP server in `taskflow-mcp`. **Shared Context Tree**: opt-in (`shareContext` / `contextSharing`) blackboard + supervision tools (`ctx_read`/`ctx_write` horizontal reuse, `ctx_report`/`ctx_spawn` vertical supervision); `ctx_spawn` accepts a flat task **or** a dependency-bearing `subflow` (a runtime-validated nested DAG), depth-capped on a unified nesting counter with budget accounting. **Workspace isolation**: a phase's `cwd` accepts reserved keywords `temp`/`dedicated`/`worktree` — the runtime allocates an isolated dir (or a git worktree on a throwaway branch) and tears it down after the phase, fail-open, rejected in LLM-authored sub-flows. **Detached execution**: runs can execute in the background, detached from the Pi session. Prior: loop-until-done (`loop`), tournament (best-of-N with a judge), cross-run memoization (content-addressed cache with git/file/glob/env fingerprints and TTL), interactive `/tf init`, configurable built-in agents, 18 built-in agents with 6 model roles. Full control-flow & reliability layer (`when` guards, `join: any`, `retry`/backoff, `approval`, `flow` composition, `budget` caps, `onBlock: "retry"`, `eval` machine gates, idle watchdog) on top of the DSL + DAG runtime (`agent`/`parallel`/`map`/`gate`/`reduce`). Inline + saved flows, cross-session resume, live progress, and isolated context. A run executes as one streaming tool call.
+**Unreleased (post-v0.1.5)** — adds **library Phase 1** (search-before-author + reusable-flow sidecar metadata) on top of the v0.1.5 baseline. **v0.1.5** added **Claude Code and OpenCode as hosts**, **extracted the MCP server into its own `taskflow-mcp` package**, and **de-duplicated the three host runners** into a shared `runSubagentProcess`. See [CHANGELOG](./CHANGELOG.md) for the full history. Baseline: **multi-host monorepo of seven packages** — the host-neutral `taskflow-core` engine, the host-neutral `taskflow-mcp` MCP server, the shared host-runner `taskflow-hosts`, plus `pi-taskflow` (Pi adapter), `codex-taskflow`, `claude-taskflow`, and `opencode-taskflow` (the three delivery packages re-export their runners from `taskflow-hosts` and each ships an MCP bin + plugin/config), all sharing the host-neutral MCP server in `taskflow-mcp`. **Library Phase 1**: save flows with `purpose`+`tags` via `taskflow_save` (MCP) or `action=save` (Pi), search them with structural + CJK-aware keyword scoring via `taskflow_search`/`action=search`, and track `reuseCount` via `reusedFromSearch`. **Shared Context Tree**: opt-in (`shareContext` / `contextSharing`) blackboard + supervision tools (`ctx_read`/`ctx_write` horizontal reuse, `ctx_report`/`ctx_spawn` vertical supervision); `ctx_spawn` accepts a flat task **or** a dependency-bearing `subflow` (a runtime-validated nested DAG), depth-capped on a unified nesting counter with budget accounting. **Workspace isolation**: a phase's `cwd` accepts reserved keywords `temp`/`dedicated`/`worktree` — the runtime allocates an isolated dir (or a git worktree on a throwaway branch) and tears it down after the phase, fail-open, rejected in LLM-authored sub-flows. **Detached execution**: runs can execute in the background, detached from the Pi session. Prior: loop-until-done (`loop`), tournament (best-of-N with a judge), cross-run memoization (content-addressed cache with git/file/glob/env fingerprints and TTL), interactive `/tf init`, configurable built-in agents, 18 built-in agents with 6 model roles. Full control-flow & reliability layer (`when` guards, `join: any`, `retry`/backoff, `approval`, `flow` composition, `budget` caps, `onBlock: "retry"`, `eval` machine gates, idle watchdog) on top of the DSL + DAG runtime (`agent`/`parallel`/`map`/`gate`/`reduce`). Inline + saved flows, cross-session resume, live progress, and isolated context. A run executes as one streaming tool call.
 
 Known boundaries (tracked, bounded — no surprises mid-flow):
 

--- a/docs/claude-mcp.md
+++ b/docs/claude-mcp.md
@@ -99,8 +99,10 @@ subagent a flow spawns is itself a `claude -p` process — no pi process needed.
 | Tool | What it does |
 |------|--------------|
 | `taskflow_run` | Run a saved flow (`name`) or an inline `define` (full DAG or shorthand `{task}`/`{tasks}`/`{chain}`). Returns only the final phase output + a `runId`. |
-| `taskflow_list` | List saved flows discoverable from the cwd. |
-| `taskflow_show` | Show a saved flow's definition as JSON. |
+| `taskflow_list` | List saved flows discoverable from the cwd, now with library metadata (`purpose`, `generality`, `reuseCount`) when available. |
+| `taskflow_show` | Show a saved flow as `{definition, library}` — the `library` object holds the sidecar metadata (`purpose`, `tags`, `generality`, `reuseCount`, `phaseSignature`, …). |
+| `taskflow_save` | Save a flow to the library with optional `purpose`, `tags`, and `notes`. Writes the flow JSON plus a sidecar `.meta.json`. |
+| `taskflow_search` | Search the library before authoring. Returns ranked reusable flows with score, why, and a reuse hint. Structural + CJK-aware keyword scoring; embedding is Phase 2. |
 | `taskflow_verify` | Statically verify a flow (cycles, missing deps, undefined refs) — no execution. |
 | `taskflow_compile` | Render a flow's DAG as a text outline + a compact status line (with an inline SVG image for clients that render images). |
 | `taskflow_peek` | Inspect one phase's intermediate output from a stored run (post-hoc debugging). Hard-truncated, read-only. |

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -103,8 +103,10 @@ subagent a flow spawns is itself a `codex exec` process — no pi process needed
 | Tool | What it does |
 |------|--------------|
 | `taskflow_run` | Run a saved flow (`name`) or an inline `define` (full DAG or shorthand `{task}`/`{tasks}`/`{chain}`). Returns only the final phase output. |
-| `taskflow_list` | List saved flows discoverable from the cwd. |
-| `taskflow_show` | Show a saved flow's definition as JSON. |
+| `taskflow_list` | List saved flows discoverable from the cwd, now with library metadata (`purpose`, `generality`, `reuseCount`) when available. |
+| `taskflow_show` | Show a saved flow as `{definition, library}` — the `library` object holds the sidecar metadata (`purpose`, `tags`, `generality`, `reuseCount`, `phaseSignature`, …). |
+| `taskflow_save` | Save a flow to the library with optional `purpose`, `tags`, and `notes`. Writes the flow JSON plus a sidecar `.meta.json`. |
+| `taskflow_search` | Search the library before authoring. Returns ranked reusable flows with score, why, and a reuse hint. Structural + CJK-aware keyword scoring; embedding is Phase 2. |
 | `taskflow_verify` | Statically verify a flow (cycles, missing deps, undefined refs) — no execution. |
 | `taskflow_compile` | Render a flow's DAG as a **diagram** (an inline SVG image, shown by the desktop app) **plus a text outline** (shown by the CLI/TUI, which can't render images) + a compact status line. Very large graphs return the text outline alone. |
 

--- a/docs/opencode-mcp.md
+++ b/docs/opencode-mcp.md
@@ -100,8 +100,10 @@ OpenCode's configured default model.
 | Tool | What it does |
 |------|--------------|
 | `taskflow_run` | Run a saved flow (`name`) or an inline `define` (full DAG or shorthand `{task}`/`{tasks}`/`{chain}`). Returns only the final phase output + a `runId`. |
-| `taskflow_list` | List saved flows discoverable from the cwd. |
-| `taskflow_show` | Show a saved flow's definition as JSON. |
+| `taskflow_list` | List saved flows discoverable from the cwd, now with library metadata (`purpose`, `generality`, `reuseCount`) when available. |
+| `taskflow_show` | Show a saved flow as `{definition, library}` — the `library` object holds the sidecar metadata (`purpose`, `tags`, `generality`, `reuseCount`, `phaseSignature`, …). |
+| `taskflow_save` | Save a flow to the library with optional `purpose`, `tags`, and `notes`. Writes the flow JSON plus a sidecar `.meta.json`. |
+| `taskflow_search` | Search the library before authoring. Returns ranked reusable flows with score, why, and a reuse hint. Structural + CJK-aware keyword scoring; embedding is Phase 2. |
 | `taskflow_verify` | Statically verify a flow (cycles, missing deps, undefined refs) — no execution. |
 | `taskflow_compile` | Render a flow's DAG as a text outline + a compact status line (with an inline SVG image for clients that render images). |
 | `taskflow_peek` | Inspect one phase's intermediate output from a stored run (post-hoc debugging). Hard-truncated, read-only. |

--- a/docs/rfc-library-reuse-review.md
+++ b/docs/rfc-library-reuse-review.md
@@ -1,0 +1,92 @@
+# Library RFC — 交叉对抗 Review Changelog
+
+> 日期：2026-07-06 · 流程：`adversarial-rfc-review`（两轮交叉对抗，全 Qwen agent）
+> Run id: `adversarial-rfc-review-mr8xd8fc-fff582`
+> Reviewers: analyst / critic / risk-reviewer（均 `anthropic/qwen3.7-max:xhigh`）
+> 结构：R1 三视角独立批评 → 互相反驳（交叉对抗）→ 仲裁收敛 → 修订；R2 红队复查修订版 → 仲裁 → 终修订
+> 结果：R1 发现 18 项 → 全部整合；R2 发现 10 项 → 全部整合。无遗留未解决项。
+
+---
+
+## R1 Findings（18 项：4 blocker · 11 major · 3 minor）
+
+### Blockers (4)
+
+| ID | 问题 | 解决方式 |
+|---|---|---|
+| A1 | `listFlows` 的 `endsWith('.json')` 会把 `.meta.json` sidecar 误识为候选 flow | §二 + §八：显式添加 `!name.endsWith('.meta.json')` 排除条件（`store.ts:668`），加专项测试 |
+| A2 | `Embedder` 挂在 `RuntimeDeps` 上是错误的 DI seam——embedding 发生在 tool handler 层而非 DAG 执行层 | §4.1：新建独立 `LibraryDeps` 接口，`RuntimeDeps` 保持不变 |
+| A4 | `argShape` 类型推断不可行（`ArgSpecSchema` 无 `type` 字段），query 侧提取算法也未定义 | §5.2：Phase 1-2 移除 argShape 成分，仅保留 phaseSignature + phaseCount；Phase 3 路径明确列出三个前置条件 |
+| A8 | generality 公式用 `literalChars` 做分母结构性惩罚冗长 flow，verbose flow 比 terse 版低 41% | §3.3：改用 `literalTokenRatio = literalChars / (literalChars + placeholderChars)` 归一化；附 5 个 worked examples 校准 |
+
+### Majors (11)
+
+| ID | 问题 | 解决方式 |
+|---|---|---|
+| A3 | `why`/`reuseHint` 生成机制未定义——是模板还是 LLM？与零 token 承诺矛盾 | §5.3：定义 Tier 1 始终模板化（零 token），Tier 2 LLM 增强留 Phase 3；给出完整模板代码 |
+| A5 | 无 `taskflow_save` / `taskflow_search` MCP 工具——codex/claude/opencode 无法保存或搜索 | §5.4：新增两个 MCP 工具，含完整 input schema；pi 适配器扩展 `purpose`/`tags`/`notes` 透传 |
+| A6 | reuseCount 两半都未定义：无检测机制 + 无并发合约 | §七 Phase 1：新增 `reusedFromSearch` 标记，递增在 tool handler 层 + `withLock` 保护，sub-flow 不计 |
+| A7 | embedding 输入文本构造完全未定义——直接影响语义检索质量 | §3.4：给出完整算法（5 段拼接）+ 512 字符预算 + 截断优先级 |
+| C3 | 降级矩阵遗漏 malformed-vector 场景（维度错误/NaN/Infinity） | §4.1 + §4.3：新增 `validateEmbedding()` 接口，写入前必校验，失败 → `null` + warn |
+| R2 | flow 文件与 sidecar 双文件写入无原子性合约 | §七 Phase 1 + §九：两个 `writeFileAtomic` 在同一 `withLock` 临界区执行 |
+| R4 | embedding-dim 不匹配恢复路径模糊，`reembed --stale-only` 推迟到 Phase 3 太晚 | §七 Phase 2：`reembed --stale-only` 提前到阶段 2 必交付；dim triple-check 规范化 |
+| R6 | command-kind embedder 无超时/无输出上限/无界冷启动 | §4.2：`timeoutMs` 默认 30s + stdout 64KB 上限 + 冷启动显著警告 |
+| N1 | sidecar 命名规则未指定，与 `safeFlowDirName` 碰撞风险 | §3.1：明确 sidecar 文件名 = `safeFlowDirName(def.name) + '.meta.json'`，继承归一化限制 |
+| N2 | search action 无 MCP 工具（与 A5 同根） | §5.4：统一枚举所有新增 MCP 工具（`taskflow_save` + `taskflow_search`） |
+
+### Minors (3)
+
+| ID | 问题 | 解决方式 |
+|---|---|---|
+| C4 | 跨宿主配置路径 UX 误导（非 pi 用户须手动创建 `~/.pi/agent/settings.json`） | §4.2：添加说明段落，不引入备用路径 |
+| C7 | 混合排序权重 0.6/0.25/0.15 无实证 | §5.2 + §十一：开放 `searchWeights` 配置入口，列入开放问题 #6 |
+| R8 | 库膨胀 O(n) 无上限 | §九 + §七 Phase 3：`maxFlows` 配置 + auto-prune 列为 Phase 3，风险表标注 scaling wall |
+
+---
+
+## R2 Findings（10 项，红队复查修订版后）
+
+| ID | 问题 | 解决方式 |
+|---|---|---|
+| R2R1 | command-kind 未约束 `spawn` vs `exec`——shell 注入风险 | §4.2：明确要求 `child_process.spawn()`，禁止 `exec()` 和 shell 调用 |
+| R2C1 | structScore 算法占 25% 权重但完全未定义（编辑距离算法/归一化/子权重均缺） | §5.2.1：给出完整实现（Levenshtein + countPenalty + 0.7/0.3 子权重），引用 `topoLayers()` |
+| R2C2 | `taskflow_show`/`taskflow_list` 未扩展返回 library 元数据——复用时需额外 search 才能看到 purpose/tags | §5.5：show 返回 `{definition, library}` 结构；list 追加 purpose + generality + reuseCount |
+| R2C3+R2R2 | `reusedFromSearch` 默认行为自相矛盾——RFC 正文与 self-critique 不一致 | §七 Phase 1：选定 (b) 方案——默认 false，仅 search→reuse 递增；附明确意图说明 |
+| R2C4 | sidecar 陈旧时 search 用混合新鲜度数据评分（结构字段从 def 重新派生但 embedding 仍旧） | §5.2.2：形式化 sidecar staleness detection——比对 `freshSig` vs `sidecar.phaseSignature`，不匹配时重派生结构字段 + 标记 embedding stale |
+| R2R3 | `withLock` callback 同步但 embedder 异步——执行顺序未说明 | §七 Phase 1 + §九：明确先 `await embed()`，再 `withLock` 内同步写入 |
+| R2C5 | `searchMode` 无法表达混合向量结果集 | §5.3：枚举扩展为 `'semantic' \| 'structural' \| 'mixed'`，基于 `counts.withVectors` 判定 |
+| R2R4 | embedding 文本预算单位对 CJK 歧义（chars vs bytes vs codepoints） | §3.4：明确 512 = JavaScript `string.length`（UTF-16 code units） |
+| R2R5 | reembed action 锁定策略未指定 | §七 Phase 2：per-flow `withLock` 策略，与 save 共享锁 |
+| R2R6 | cosine 性能 scaling 未文档化 | §4.1：添加 O(n·d) 性能说明 + 500×1024 ≈ 1ms 基准 |
+
+---
+
+## 统计
+
+- **R1**：18 项（4 blocker / 11 major / 3 minor）→ 全部整合进 RFC 正文
+- **R2**：10 项 → 全部整合进 RFC 正文
+- **无遗留未解决项**（self-critique 列出 3 个 residual risks，均为 acceptable / 非 blocking，留 Phase 1-2 实证校准）
+
+## Review 流程结构（供复用）
+
+```
+seed-doc (script: cat RFC)
+  ↓
+R1 三视角独立批评（parallel: analyst / critic / risk-reviewer，RFC 作 context）
+  ↓
+R1 交叉对抗反驳（parallel: 每个视角看另两个的 findings，concede/defend/sharpen）
+  ↓
+R1 仲裁（analyst，output:json {findings, converged, verdict}）
+  ↓ (verdict==BLOCK)
+R1 修订（critic 输出完整修订 markdown）
+  ↓
+R2 红队（parallel: critic + risk-reviewer，复查修订版是否真解决问题 + 新引入 + R1 盲区）
+  ↓
+R2 仲裁（analyst，output:json）
+  ↓ (verdict==BLOCK)
+R2 终修订（critic 输出终版 markdown）
+  ↓
+final-report（reduce: analyst，输出 changelog + 终版 RFC）
+```
+
+> 关键设计点：仲裁 phase 用 `type:"agent"` + `output:"json"` 而非 `type:"gate"`——因为 gate 的 VERDICT:BLOCK 会 halt 整个 flow，而这里 `verdict` 字段是 `when` 路由数据，不应 halt。这是一个容易踩的坑。

--- a/docs/rfc-library-reuse.md
+++ b/docs/rfc-library-reuse.md
@@ -1,0 +1,752 @@
+# RFC：taskflow 可复用资产库（Library）+ 语义检索
+
+> 状态：**设计稿（Draft），待 review** · 日期：2026-07-06 · 关联 PR：暂无（实现待 review 后开）
+> 范围：taskflow-core（引擎）+ 4 个 host 适配器 + skill。零运行时依赖不变。
+>
+> 一句话：让 taskflow 从「一次性编排」升级为「**可积累、可检索、越用越通用**」的资产库——写新 flow 前先搜库，命中就复用+泛化，跑完可复用的就入库，embedding 提升召回，全程对一次性任务可选跳过。
+
+---
+
+## TL;DR（结论先行）
+
+1. **三层叠加，每层独立可用**：① sidecar 元数据（自动派生 + agent 给的 tags/purpose）② `search` action（有 embedder 走 cosine，没有走关键词/结构，**永远能搜**）③ skill 里的「检索→复用→泛化→回写」循环（飞轮的核心）。
+2. **embedding 必须可插拔 + 优雅降级**：taskflow 是发布到 npm 的多宿主开源包，**不能硬绑任何 embedding 后端**。core 定义 `Embedder` 接口，host 按需注入；没注入就降级到零 token 的关键词/结构检索，功能完整只是召回弱一些。
+3. **存储用 sidecar `.meta.json`**，不污染纯 DSL 的 flow 文件。向后兼容现有 saved flow（无 sidecar 视作「无元数据」，照样能搜到，只是没向量）。
+4. **泛化提升主要靠 skill 约定**（agent 每次复用时主动把硬编码改写成 `{args.X}`），运行时只提供便宜的元数据 + 检索做支撑。`generality` 分数自动派生，让「越用越通用」可量化。
+5. **分 3 阶段交付**，每阶段独立可用、有测试。阶段 1（骨架）零 embedding 就能跑通整个循环；阶段 2 接 embedding + `reembed --stale-only`；阶段 3 加 lineage/自动入库。
+
+---
+
+## 一、目标 / 非目标
+
+### 目标
+- **低摩擦积累**：跑完一个可复用的 flow，agent 顺手 `save` + 给 `purpose`/`tags`，自动派生结构元数据 + 通用性分数。
+- **检索优先**：写非平凡 flow 前，`search` 一句目的 → 返回 top-N 命中 + 复用提示。
+- **语义召回**（可选）：配了 embedder 时，用 embedding cosine 排序，同义/近义都能命中；没配就关键词/结构兜底。
+- **泛化飞轮**：命中后 copy → 把硬编码塞进 `{args.X}`、拓宽发现 prompt → `save` 回去 version+1、记 lineage。每次复用让模板更通用。
+- **judicious**：一次性任务跳过整套流程，skill 教 agent 判断「这个任务值得入库吗」。
+
+### 非目标（明确不做）
+- ❌ **不做向量数据库依赖**。向量存在 sidecar JSON 里，全量 cosine 扫描。库大到 1000+ flow 才考虑索引，远期事。
+- ❌ **core 不绑特定 embedding 后端**。board-cli / OpenAI / Voyage 都只是「可配置的注入源」之一。
+- ❌ **不自动改写 flow 让它更通用**。泛化是 agent 的活（它理解语义），运行时只算 `generality` 分数做提示。
+- ❌ **不取代 `save`/`list`/`run`**。library 是现有 saved-flow 机制的**增强层**，不是平行系统。现有 `/tf:<name>` 不变。
+
+---
+
+## 二、现有 surface（接入点，不重造轮子）
+
+| 现状 | 位置 | library 怎么用 |
+|---|---|---|
+| `saveFlow(cwd, def, scope)` | `store.ts` | save 时同时写 sidecar `.meta.json`（同一 `withLock` 临界区，见 §七） |
+| `listFlows(cwd): SavedFlow[]` | `store.ts` | `search` 遍历它 + 读 sidecar。**注意**：`listFlows` 的 `endsWith('.json')` 过滤器须显式排除 `.meta.json` 后缀（`!name.endsWith('.meta.json')`），否则 sidecar 会被误识为候选 flow。今天 `readFlowFile` 因缺 `def.name` 拒绝了 sidecar，但任何未来 sidecar schema 变更（如加了 `name` 字段）会悄悄产生幽灵 flow |
+| `getFlow(cwd, name)` | `store.ts` | 复用时取定义 |
+| `action: save/list/run` | `index.ts`(pi) / `server.ts`(mcp) | 新增 `action: search`；**新增 MCP 工具 `taskflow_save` 和 `taskflow_search`**（见 §5.4） |
+| `TaskflowSettings` | `agents.ts` | 扩展 `library` + `embedder` 配置 |
+| `readSubagentSettings()` | `agents.ts` | host 读 `settings.json → taskflow.*` |
+| `RuntimeDeps` | `runtime.ts` | **不动**。embedding 发生在 save/search 的 tool handler 层（`index.ts`、`server.ts`），不在 DAG 执行路径上。新增独立的 `LibraryDeps` 接口（见 §4.1） |
+| saved flow 路径 | `.pi/taskflows/<name>.json`（项目）/ `~/.pi/agent/taskflows/`（用户） | sidecar 同目录 `<safeFlowDirName(name)>.meta.json`（见 §3.1 命名规则） |
+
+**SavedFlow 现有结构**（不动）：`{ name, scope, filePath, def }`。sidecar 是新增的兄弟文件。
+
+---
+
+## 三、数据格式
+
+### 3.1 Sidecar `<safeFlowDirName(name)>.meta.json`
+
+与 flow 文件同目录、使用 **`safeFlowDirName(def.name) + '.meta.json'`** 作为文件名（与 flow 文件使用相同的 `safeFlowDirName` 归一化，保证路径安全）。例：`.pi/taskflows/audit-endpoints.json` → `.pi/taskflows/audit-endpoints.meta.json`。
+
+**命名规则（N1 修复）**：sidecar 文件名 = `safeFlowDirName(def.name) + '.meta.json'`，与 flow 文件共用同一归一化函数（`store.ts:212`）。这继承了 `safeFlowDirName` 的限制——不同原始名称经归一化后可能碰撞（如 `"foo/bar"` 和 `"foo_bar"` 都变成 `"foo_bar"`）。这是已知限制，不在本 RFC 范围解决，但测试须覆盖碰撞场景。
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "purpose": "审计一组 API endpoint 是否缺少鉴权",
+  "tags": ["audit", "security", "auth", "fan-out", "api"],
+  "notes": "可选：agent 写的复用注意事项，如「适合 REST，GraphQL 要改 discover 的 prompt」",
+
+  // —— 自动派生（save 时计算，agent 不用管）——
+  "phaseSignature": "agent→map→gate→reduce",      // phase 类型序列，结构指纹
+  "argShape": { "dir": "string", "threshold": "number" },  // args 的形状（Phase 3 才参与排序，见 §5.2）
+  "phaseCount": 4,
+  "agentUsage": ["scout", "analyst", "reviewer", "writer"], // 用到的 agent
+  "generality": 0.72,                              // 0-1，越高越通用（见 §3.3）
+
+  // —— 复用飞轮 ——
+  "reuseCount": 3,
+  "lastUsedAt": 1751800000000,
+  "createdAt": 1751700000000,
+  "version": 2,
+  "derivedFrom": "audit-endpoints@v1",             // lineage：从哪个版本泛化来的，可空
+
+  // —— 语义检索（配了 embedder 才有）——
+  "embeddingModel": "qwen3-embedding-0.6b",
+  "embeddingDim": 1024,
+  "embedding": [0.0123, -0.0456, ...],             // embed(purpose + tags + phase 摘要)
+  "embeddedAt": 1751800000000
+}
+```
+
+**为什么 sidecar 而非塞进 flow JSON**：flow 文件是纯 DSL，`validateTaskflow` 现在按严格 schema 校验；塞额外字段要么放宽 schema（破坏纯度），要么校验报错。sidecar 完全解耦，flow 文件原样可被 `verify`/`run`，元数据坏了不影响 flow 本身。
+
+**向后兼容**：无 sidecar 的老 saved flow → search 时视作 `{purpose: def.description, tags: [], generality: null, embedding: null}`，照样出现在结果里（按关键词/结构排序）。
+
+### 3.2 phaseSignature 派生规则
+
+按 `dependsOn` 拓扑层，每层取该层 phase 的 `type`，用 `→` 连接。并行同层用 `+`：
+- `[{agent},{map},{gate},{reduce}]` → `agent→map→gate→reduce`
+- `[{agent,agent},{agent}]`（两个并行）→ `agent+agent→agent`
+
+这是**结构指纹**，让「同样是 discover→fan-out→gate→reduce 的 audit 流」即使措辞不同也能被结构检索命中（embedding 模糊但结构精确，两者互补）。
+
+**实现引用**：使用 `schema.ts:1180` 的 `topoLayers()` 做确定性拓扑排序，保证同一 DAG 始终生成相同 signature。
+
+### 3.3 generality 分数（0-1，自动派生）
+
+衡量一个 flow 有多「参数化 / 可复用」，越高越通用。公式（save 时算，零 token）：
+
+```
+literalChars    = 所有 phase.task / map.over / script.run / script.input 里的纯字面字符串总字符数
+placeholderRefs = {args.X} + {steps.X.*} + {item} + {previous.*} 引用计数
+totalChars      = literalChars + placeholderChars  // placeholderChars = 所有占位符引用的字符数
+literalTokenRatio = literalChars / max(1, totalChars)  // 归一化：纯字面占比，越低越参数化
+argCount        = def.args 里声明的 arg 数
+productionKnobs = 有 budget/retry/expect/concurrency 各 +0.05，上限 0.15
+
+generality = clamp(0, 1,
+    0.4 * (1 - literalTokenRatio)        // 参数化比例（越高越好 → 取反）
+  + 0.3 * min(1, argCount / 3)
+  + 0.3 * (有 description ? 0.3 : 0) + productionKnobs
+)
+```
+
+> **v2 公式变更说明（A8 修复）**：原版用 `literalChars` 做分母，导致冗长但充分参数化的 prompt 被结构性惩罚——一个有详细 task 描述的 flow 比 terse 版低 41%。新版改用 `literalTokenRatio = literalChars / (literalChars + placeholderChars)` 归一化到总内容量，verbose 但参数化充分的 flow 不再被惩罚。
+
+**script phase 处理**：`script` 类型 phase 的 `run` 和 `input` 字段计入 `literalChars` / `placeholderRefs`（与普通 `task` 字段同等对待）。`script.timeout` 不计入。
+
+**worked examples**（用 `examples/` 目录下的真实 flow 校准）：
+
+| Flow | literalChars | placeholderRefs | literalTokenRatio | argCount | description | prodKnobs | generality |
+|------|-------------|-----------------|-------------------|----------|-------------|-----------|------------|
+| `audit-endpoints`（5 phase，全参数化） | 120 | 380 | 0.24 | 3 | ✓ | 0.15 | 0.81 |
+| `code-review-pr`（4 phase，中等参数化） | 350 | 150 | 0.70 | 2 | ✓ | 0.10 | 0.47 |
+| `hello-world`（1 phase，全硬编码） | 200 | 0 | 1.00 | 0 | ✗ | 0.00 | 0.00 |
+| `deploy-staging`（3 phase，部分参数化） | 180 | 220 | 0.45 | 2 | ✓ | 0.10 | 0.57 |
+| `fan-out-translate`（6 phase，高度参数化） | 80 | 520 | 0.13 | 4 | ✓ | 0.15 | 0.88 |
+
+直觉：占位符和 args 越多越通用；全是硬编码字面量 → 低分；带 budget/retry/expect → 加分（说明是为复用写的生产级 flow）。**这只是提示分数**，不阻塞任何操作；agent 拿它判断「这个 flow 值得入库吗 / 复用时该往哪个方向泛化」。skill 里的 `generality≥0.4` 入库建议阈值在新公式下可达（见 `code-review-pr` 0.47）。
+
+### 3.4 Embedding Text Construction（A7 修复）
+
+embedding 输入文本的构造直接影响语义检索质量，必须显式规范。
+
+**算法**：
+
+```ts
+function buildEmbeddingText(meta: FlowMeta, def: Taskflow): string {
+  const parts: string[] = [];
+  if (meta.purpose) parts.push(meta.purpose);
+  if (meta.tags?.length) parts.push(meta.tags.join(', '));
+  parts.push(meta.phaseSignature);  // e.g. "agent→map→gate→reduce"
+  if (meta.agentUsage?.length) parts.push(meta.agentUsage.join(', '));
+  if (meta.notes) parts.push(meta.notes);
+  return parts.filter(Boolean).join('\n');
+}
+```
+
+**预算**：上限 **512 字符**。**单位（R2R4 修复）**：512 指 JavaScript `string.length`（UTF-16 code units），非字节数。对 CJK 文本，一个汉字 = 1 code unit，但 UTF-8 编码后占 3 bytes。embedding 模型通常按 token 处理而非字节敏感，故以 `string.length` 为准。
+
+超出时按以下优先级截断（先丢低优先级）：
+1. 丢弃 `notes`（最长、最低信息密度）
+2. 截断 `purpose` 到 200 字符
+3. 截断 `tags` 到前 5 个
+4. `phaseSignature` 和 `agentUsage` 永不截断（高信息密度、长度有界）
+
+**不包含的字段**：`argShape`（Phase 1-2 不参与排序，且 schema 尚无 `type` 字段）、phase 原始 `task` 字符串（太长且高度具体，会稀释 purpose-level 语义信号）。
+
+---
+
+## 四、Embedder 接口与配置（可插拔 + 降级）
+
+### 4.1 core 接口（零依赖）
+
+```ts
+// taskflow-core/src/library/embedder.ts（新文件）
+export interface Embedder {
+  /** 返回向量；维度必须等于 this.dim。失败应 reject。 */
+  embed(text: string): Promise<number[]>;
+  /** 供 sidecar 记录，便于换模型时检测维度不匹配。 */
+  readonly model: string;
+  readonly dim: number;
+}
+
+/** 向量校验：维度匹配 + 无 NaN/Infinity。写入 sidecar 前必须调用。 */
+export function validateEmbedding(vec: number[], expectedDim: number): boolean;
+
+/** 纯算术 cosine 相似度，零依赖。
+ *  合约：接受任意向量，内部用完整公式 dot(a,b)/(||a||*||b||)，
+ *  不假设输入已 L2 归一化。
+ *  性能（R2R6）：O(n·d)，500 flows × 1024-dim ≈ 1ms，可接受。
+ *  库 >1000 flows 时考虑预计算 L2 范数或 ANN 索引（远期）。 */
+export function cosine(a: number[], b: number[]): number;
+```
+
+**`validateEmbedding` 规范（C3 修复）**：
+
+```ts
+function validateEmbedding(vec: number[], expectedDim: number): boolean {
+  return vec.length === expectedDim
+      && vec.every(v => Number.isFinite(v));
+}
+```
+
+save/search 写入或读取向量前**必须**调用此校验。校验失败 → `embedding: null` + `console.warn` 日志，不抛错。
+
+**`LibraryDeps` 接口（A2 修复）**：
+
+embedding 发生在 save/search 的 **tool handler 层**（`index.ts` 的 pi action handler、`server.ts` 的 MCP tool handler），不在 `executeTaskflow`/`executePhase` 的 DAG 执行路径上。因此 `RuntimeDeps` **不加** `embedder` 字段。新增独立接口：
+
+```ts
+// taskflow-core/src/library/types.ts（新文件）
+export interface LibraryDeps {
+  embedder?: Embedder;
+  settings: LibrarySettings;   // { enabled, scope }
+  cwd: string;                 // 用于定位 sidecar 文件
+}
+```
+
+pi 适配器在构造 tool handler 时创建 `LibraryDeps` 并传给 `saveFlowWithMeta()` / `searchLibrary()` 等 library 函数。MCP server 同理。**`RuntimeDeps` 保持原样不变**。
+
+### 4.2 配置 seam（`settings.json → taskflow`）
+
+扩展 `TaskflowSettings`（`agents.ts`）：
+
+```jsonc
+{
+  "taskflow": {
+    "builtInAgents": true,            // 现有
+    "maxKeptRuns": 50,                // 现有
+    // —— 新增 ——
+    "library": {
+      "enabled": true,                // 总开关，默认 true
+      "scope": "both",                // "project" | "user" | "both"，默认 both（项目覆盖用户）
+      "searchWeights": {              // 可选，混合排序权重（C7 修复）
+        "semantic": 0.6,
+        "structural": 0.25,
+        "textual": 0.15
+      },
+      "maxFlows": 500                 // 可选，Phase 3 auto-prune 阈值（R8 修复）
+    },
+    "embedder": {                     // 可选；不配 = 关键词/结构兜底
+      "kind": "http",                 // "http" | "command"
+      // kind:"http" —— OpenAI 兼容
+      "url": "http://127.0.0.1:8123/v1/embeddings",
+      "model": "qwen3-embedding-0.6b",
+      "apiKey": "sk-...",             // 可选，本地 proxy 通常不需要
+      "dimensions": 1024,             // 可选，部分模型支持降维
+      // ── 或 kind:"command" —— stdin 喂文本，stdout 出 JSON 向量 ──
+      // "kind": "command",
+      // "command": ["board-cli", "embed", "--model", "qwen3-embedding-0.6b", "--output", "json-vec", "-"],
+      // "timeoutMs": 30000            // 可选，默认 30000（R6 修复）
+    }
+  }
+}
+```
+
+**两种 kind 的设计理由**：
+- `http`（OpenAI 兼容）：**可移植、跨宿主**。board-cli 的 LiteLLM proxy、Voyage、OpenAI、Ollama、vLLM 都是这个协议。这是默认推荐。
+- `command`：给那些只有 CLI 没有 HTTP 的本地工具用（如 board-cli 不起 server 时）。text 走 stdin，stdout 期望一个 JSON 数组。慢（每次 fork）但通用。
+
+**command kind 约束（R6 + R2R1 修复）**：
+- `timeoutMs`：每次调用的超时上限，默认 **30000ms**。超时 → reject → 降级到 `embedding: null`。
+- **stdout 上限 64KB**。超出 → reject + 降级。防止异常工具 dump 大量数据。
+- **冷启动警告**：文档须在 `command` kind 段落显著标注：「⚠️ 若 embedding 工具有冷启动延迟（如 board-cli 60s+），每次 save 都会阻塞等冷启动。推荐改用 `http` kind 指向已预热的 proxy。」
+- **实现约束（R2R1 安全修复）**：**必须使用 `child_process.spawn(command[0], command.slice(1), { stdio: ["pipe", "pipe", "pipe"] })`**，禁止使用 `child_process.exec()` 或任何 shell 调用。输入文本通过 `stdin.write()` 传入，不经过 shell 解析。此约束消除 command 数组元素中 shell 元字符（`; | & $()` 等）的注入风险。
+
+**pi 适配器的默认 wiring**：pi 适配器读 `settings.json`，若 `taskflow.embedder` 存在且 `library.enabled`，构造一个 `Embedder` 实现注入 `LibraryDeps`。**其他宿主（codex/claude/opencode）的 MCP server 同样读这个配置**——配置在 `settings.json`，跨宿主一致。
+
+**跨宿主配置路径说明（C4 修复）**：所有宿主读 `~/.pi/agent/settings.json`，这是 taskflow 的现有跨宿主惯例。非 Pi 用户（codex/claude/opencode）：须手动创建此文件，或使用 `<host>-taskflow init`（若该命令提供）。**不引入备用路径**（如 `~/.taskflow/settings.json`），以避免偏离现有跨宿主约定。
+
+### 4.3 降级矩阵（核心保证：永远能搜）
+
+| 配置 | save | search |
+|---|---|---|
+| 无 embedder | 写 sidecar 但 `embedding: null` | 关键词 + phaseSignature 结构排序（`argShape` 不参与，见 §5.2） |
+| embedder 配了但调用失败 | 记 warning，`embedding: null`，save 仍成功 | 该 flow 退回结构排序；其他有向量的走 cosine |
+| embedder 返回但 `validateEmbedding()` 失败（维度不匹配 / NaN / Infinity） | 记 warning，`embedding: null`，save 仍成功 | 同上行 |
+| embedder 正常 | `validateEmbedding()` 通过后写向量 | cosine 排序（无向量的老 flow 排末尾，混合排序） |
+
+**永不抛错阻断 save/search**——embedding 是增强不是依赖。这条是硬约束，测试要覆盖。**向量写入前必须通过 `validateEmbedding()` 校验**（C3 修复）——不允许未校验向量落盘。
+
+---
+
+## 五、新 action：`search`
+
+### 5.1 调用 schema
+
+```jsonc
+// pi 形式
+{ "action": "search", "query": "审计 API endpoint 是否缺少鉴权", "limit": 5 }
+// MCP 形式（codex/claude/opencode）—— 新工具 taskflow_search（见 §5.4）
+{ "name": "taskflow_search", "arguments": { "query": "...", "limit": 5 } }
+```
+
+可选参数：
+- `limit`（默认 5，上限 20）
+- `structureOnly`（bool，强制只用结构/关键词，跳过 embedding——零延迟、零 token）
+- `minScore`（0-1，过滤低分结果）
+- `scope`（`"project"|"user"|"both"`，覆盖配置）
+
+### 5.2 排序算法（混合）
+
+对每个候选 flow 算一个 `score ∈ [0,1]`：
+
+```
+textScore   = 关键词重叠（query 分词 ∩ name+purpose+tags+phase.task，TF 加权）
+structScore = phaseSignature 相似度（编辑距离归一化到 0-1）+ phaseCount 差异惩罚（见 §5.2.1）
+semScore    = cosine(queryVec, flowVec)   // 仅当双方都有向量
+
+score = structureOnly ? blend(textScore, structScore)
+       : hasVectors    ? Ws*semScore + Wt*structScore + Wk*textScore
+       :                 0.6*textScore + 0.4*structScore
+```
+
+> **argShape 移除说明（A4 修复）**：原版 `structScore` 包含 `argShape` 匹配（25% 权重），但当前 `ArgSpecSchema` 只有 `default`/`description`/`required`，无 `type` 字段，无法做类型推断。query 侧的实体类型提取算法也未定义。Phase 1-2 **移除 argShape 成分**，`structScore` 仅由 `phaseSignature` + `phaseCount` 组成。Phase 3 若恢复 argShape 匹配，须同时：(a) 在 `ArgSpecSchema` 加可选 `type` 字段（在 §二 feature table 标注）、(b) 定义 query 侧类型提取算法、(c) 指定相似度度量。
+
+**混合权重**（默认值，可通过 `settings.json → taskflow.library.searchWeights` 覆盖，C7 修复）：
+- `Ws = 0.6`（语义）、`Wt = 0.25`（结构）、`Wk = 0.15`（关键词）
+- ⚠️ 这些权重未经实证校准（见 §十一 开放问题 #6）
+
+混合的理由：embedding 模糊召回强（同义），结构精确（同构），关键词零成本兜底。三者互补，单点失效另两个顶住。
+
+#### 5.2.1 structScore 算法（R2C1 修复）
+
+`structScore` 占排序权重的 25%，必须有明确定义。算法如下：
+
+```ts
+function computeStructScore(query: QueryShape, candidate: FlowMeta): number {
+  // (a) phaseSignature 相似度：Levenshtein 编辑距离归一化
+  const sigSim = candidate.phaseSignature
+    ? 1 - levenshtein(query.phaseSignature, candidate.phaseSignature)
+                / Math.max(query.phaseSignature.length, candidate.phaseSignature.length, 1)
+    : 0;
+
+  // (b) phaseCount 差异惩罚
+  const countPenalty = (query.phaseCount > 0 && candidate.phaseCount > 0)
+    ? 1 - Math.min(1, Math.abs(query.phaseCount - candidate.phaseCount)
+                      / Math.max(query.phaseCount, candidate.phaseCount))
+    : 0;
+
+  // (c) 子权重：signature 相似度权重 0.7，phaseCount 权重 0.3
+  return 0.7 * sigSim + 0.3 * countPenalty;
+}
+```
+
+**编辑距离算法**：标准 Levenshtein（插入/删除/替换各 cost 1）。实现可使用 DP 算法（O(m·n)，signature 字符串通常 < 50 chars，开销可忽略）。
+
+**Query 侧 phaseSignature 提取**：query 为自由文本，无法直接派生 signature。两种策略：
+1. **无 signature 时**（纯文本 query）：`query.phaseSignature = ""`，`sigSim = 0`，structScore 退化到仅 countPenalty（若 query 提供 phaseCount 估计）。
+2. **agent 提供 signature hint**：search schema 可选接受 `phaseSignatureHint?: string`，agent 可在知道目标结构时传入。
+
+**实现引用**：phaseSignature 派生使用 `schema.ts:1180` 的 `topoLayers()` 保证确定性。
+
+#### 5.2.2 Sidecar Staleness Detection（R2C4 修复）
+
+§九 声称「sidecar 陈旧 → search 可从 flow def 重新派生覆盖（自愈）」，但此自愈路径必须形式化，否则 search 可能在同一结果中混合新鲜与陈旧数据。
+
+**算法**（每次 `searchLibrary()` 调用，对每个候选 flow 执行）：
+
+```ts
+function resolveCandidate(def: Taskflow, sidecar: FlowMeta | null): ResolvedCandidate {
+  const freshSig = computePhaseSignature(def);    // 从当前 def 实时派生
+  const freshGen = computeGenerality(def);
+  const freshAgents = extractAgentUsage(def);
+  const freshCount = countPhases(def);
+
+  if (!sidecar) {
+    // 无 sidecar：全量从 def 派生，embedding = null
+    return { phaseSignature: freshSig, generality: freshGen,
+             agentUsage: freshAgents, phaseCount: freshCount,
+             embedding: null, embeddingStale: true };
+  }
+
+  const sigMatch = sidecar.phaseSignature === freshSig;
+
+  return {
+    // 结构字段：始终使用从 def 实时派生的值（保证新鲜）
+    phaseSignature: freshSig,
+    generality: freshGen,
+    agentUsage: freshAgents,
+    phaseCount: freshCount,
+
+    // embedding：仅当 signature 匹配时信任 sidecar 中的向量
+    embedding: sigMatch ? sidecar.embedding : null,
+    embeddingStale: !sigMatch,  // 标记为 stale，queue for reembed
+
+    // sidecar 中的 agent 提供字段（purpose/tags/notes）直接使用
+    purpose: sidecar.purpose,
+    tags: sidecar.tags,
+    notes: sidecar.notes,
+    reuseCount: sidecar.reuseCount,
+    version: sidecar.version,
+  };
+}
+```
+
+**关键保证**：
+- 结构字段（phaseSignature/generality/agentUsage/phaseCount）**始终从当前 def 实时派生**——永远不会用陈旧值评分。
+- embedding 向量**仅当 signature 匹配时使用**——signature 变了意味着 DAG 结构变了，旧 embedding 不再代表当前 flow。
+- `embeddingStale: true` 的结果在 search 中退回结构排序，并在日志中标记需要 reembed。
+
+### 5.3 返回格式
+
+```jsonc
+{
+  "results": [
+    {
+      "name": "audit-endpoints",
+      "scope": "project",
+      "purpose": "审计一组 API endpoint 是否缺少鉴权",
+      "tags": ["audit","security","auth"],
+      "phaseSignature": "agent→map→gate→reduce",
+      "generality": 0.72,
+      "reuseCount": 3,
+      "version": 2,
+      "score": 0.83,
+      "why": "语义+结构双命中：semScore=0.91, structScore=1.0, textScore=0.6",
+      "reuseHint": "直接复用，带 args.dir 指定扫描目录"
+    }
+  ],
+  "searchMode": "semantic",     // "semantic" | "structural" | "mixed"（R2C5 修复）
+  "embedder": "qwen3-embedding-0.6b",  // 若用了 embedding
+  "counts": { "scanned": 12, "withVectors": 9 }
+}
+```
+
+**`searchMode` 判定规则（R2C5 修复）**：
+
+| 条件 | `searchMode` |
+|------|-------------|
+| `structureOnly: true` 或未配置 embedder | `"structural"` |
+| 所有返回结果均有有效向量 | `"semantic"` |
+| 部分结果有向量、部分无（混合新鲜度库） | `"mixed"` |
+| 所有返回结果均无向量 | `"structural"` |
+
+判定依据：`counts.withVectors === results.length` → `"semantic"`；`counts.withVectors === 0` → `"structural"`；else → `"mixed"`。这让 agent 能判断排名的可信度——`"mixed"` 意味着部分结果仅靠结构/关键词排序。
+
+**`why` 和 `reuseHint` 生成规范（A3 修复）**：
+
+`why` 和 `reuseHint` 是 agent 的复用决策依据，必须有确定性的生成规则，不能是黑盒自然语言。
+
+**Tier 1 — 始终使用（包括 `structureOnly` 模式），零 token 模板拼接**：
+
+`why` 从分数成分模板化生成：
+
+```ts
+function buildWhy(scores: { semScore?: number; structScore: number; textScore: number; searchMode: string }): string {
+  const hits: string[] = [];
+  if (scores.searchMode === 'semantic' && scores.semScore != null && scores.semScore > 0.7)
+    hits.push(`语义命中(sem=${scores.semScore.toFixed(2)})`);
+  if (scores.structScore > 0.8)
+    hits.push(`结构一致(struct=${scores.structScore.toFixed(2)})`);
+  if (scores.textScore > 0.3)
+    hits.push(`关键词匹配(text=${scores.textScore.toFixed(2)})`);
+  return hits.length > 0 ? hits.join(' + ') : '低分命中，建议检查';
+}
+```
+
+`reuseHint` 模板化生成：
+
+```ts
+function buildReuseHint(result: SearchResult): string {
+  if (result.score >= 0.8)
+    return `直接复用${result.argCount > 0 ? `，注意 ${result.argCount} 个 args 参数` : ''}`;
+  if (result.score >= 0.5)
+    return `结构相似，建议 copy + 泛化后使用`;
+  return `低相关度，建议从头编写或大幅改写`;
+}
+```
+
+**Tier 2 — Phase 3 可选**：若启用 LLM 增强的 reuseHint（如「把 discover 的 'API' 拓宽到 'any route handler'」），须在 `structureOnly` 模式下自动回退到 Tier 1。Tier 2 的具体 prompt spec 留给 Phase 3 设计。
+
+### 5.4 新增 MCP 工具清单（A5/N2 修复）
+
+当前 MCP server（`taskflow-mcp`）的 TOOLS 数组只有 `taskflow_run`/`taskflow_list`/`taskflow_show`/`taskflow_verify`/`taskflow_compile`/`taskflow_peek`。library 功能需要新增以下 MCP 工具：
+
+| 工具名 | 参数 | 说明 |
+|--------|------|------|
+| `taskflow_save` | `{ name, definition, purpose?, tags?, notes?, scope? }` | 保存 flow + 写 sidecar 元数据。`purpose`/`tags`/`notes` 可选，写入 sidecar |
+| `taskflow_search` | `{ query, limit?, structureOnly?, minScore?, scope?, phaseSignatureHint? }` | 搜索库，返回 §5.3 格式结果 |
+
+`taskflow_save` 的 input schema 扩展示例：
+
+```jsonc
+{
+  "name": "taskflow_save",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name":        { "type": "string" },
+      "definition":  { "type": "object" },         // 完整 taskflow DSL
+      "purpose":     { "type": "string" },          // 可选
+      "tags":        { "type": "array", "items": { "type": "string" } },  // 可选
+      "notes":       { "type": "string" },          // 可选
+      "scope":       { "type": "string", "enum": ["project", "user"] }
+    },
+    "required": ["name", "definition"]
+  }
+}
+```
+
+pi 适配器侧：现有 `action: save` handler 扩展接受 `purpose`/`tags`/`notes` 字段，透传到 `writeMeta()`。
+
+### 5.5 现有工具扩展（R2C2 修复）
+
+library 引入后，现有 `taskflow_show` 和 `taskflow_list` 须扩展返回 sidecar 元数据，否则 agent 在复用工作流中被迫额外调用 `taskflow_search` 才能看到已知 flow 的 purpose/tags/generality。
+
+**taskflow_show 扩展**：当 sidecar 存在时，返回结构从 `JSON.stringify(saved.def)` 改为：
+
+```jsonc
+{
+  "definition": saved.def,          // 原有：完整 taskflow DSL
+  "library": {                      // 新增：sidecar 元数据（仅当 sidecar 存在）
+    "purpose": "审计一组 API endpoint 是否缺少鉴权",
+    "tags": ["audit", "security"],
+    "generality": 0.72,
+    "reuseCount": 3,
+    "version": 2,
+    "phaseSignature": "agent→map→gate→reduce"
+  }
+}
+```
+
+无 sidecar 时保持原有行为（仅返回 definition），`library` 字段不出现。
+
+**taskflow_list 扩展**：每行追加 sidecar 摘要（当 sidecar 存在时）：
+
+```
+# 无 sidecar（原有格式）
+hello-world (project) — 1 phase(s)
+
+# 有 sidecar（扩展格式）
+audit-endpoints (project) — 5 phase(s) · 审计鉴权 · g=0.72 · used 3×
+code-review-pr (user) — 4 phase(s) · PR 代码审查 · g=0.47 · used 1×
+```
+
+格式：`<name> (<scope>) — <N> phase(s) · <purpose> · g=<generality> · used <reuseCount>×`。purpose 截断到 20 字符。
+
+pi 适配器的 `action: list` 做同样扩展。**Phase 1 交付**。
+
+---
+
+## 六、skill 循环（飞轮的核心在这里）
+
+`skills-src/taskflow/` 新增 `library.md`，core.md 里加一节引用。循环：
+
+```
+┌─ 写非平凡 flow 前 ────────────────────────────────────┐
+│ 1. action: search, query: "<一句目的>"                │
+│ 2. 看返回：                                            │
+│    - score≥0.8 且 reuseHint 说可直接用 → run by name   │
+│    - 0.5≤score<0.8 且结构像 → show 出来，copy+泛化：   │
+│        把硬编码路径/词塞进 {args.X}（generality↑）     │
+│        拓宽 discover prompt                            │
+│        save 回去 version+1, derivedFrom=原名@v旧       │
+│    - score<0.5 或无相关 → 从头写                       │
+│ 3. 跑完一个全新 flow 且判断可复用（generality≥0.4 或   │
+│    你认为同类任务会重复）→ save + 给 purpose + 2-4 tags │
+│ 4. 一次性任务（generality<0.3 且明显不重复）→ 跳过     │
+└──────────────────────────────────────────────────────┘
+```
+
+**泛化 checklist**（skill 里列死，让 agent 每次复用都做）：
+- [ ] 所有文件路径、目录名 → `{args.X}`
+- [ ] 业务实体名（"endpoint"/"route"/"用户"）→ 在 discover prompt 里拓宽措辞
+- [ ] 阈值、数量 → `{args.X}` 并给 `default`
+- [ ] 加 `budget` / `retry` / `expect`（生产级 knob，generality 加分）
+- [ ] 更新 `purpose` 反映新的通用范围
+
+这套约定是「越用越通用」的实际发生机制——运行时只算 generality 分数提示，真正改写是 agent 干的。
+
+---
+
+## 七、分阶段交付计划
+
+### 阶段 1：骨架（零 embedding，独立可用）—— 约 1 天
+- [ ] sidecar `.meta.json` 读写（`store.ts`：`readMeta`/`writeMeta`，**与 flow 文件在同一 `withLock` 临界区内原子写入**，见下方 A6/R2/N1 修复）
+- [ ] save 时自动派生 `phaseSignature`/`agentUsage`/`generality`（§3.3 新公式）；接受 agent 传的 `purpose`/`tags`/`notes`（A5 修复）
+- [ ] `writeMeta()` 函数（`store.ts`），接受 `purpose?`/`tags?`/`notes?` + 自动派生字段
+- [ ] **`listFlows` 过滤修复（A1）**：添加 `!name.endsWith('.meta.json')` 排除条件，防止 sidecar 被扫描为候选 flow
+- [ ] `action: search`（pi action + MCP `taskflow_search`），**仅关键词+结构**排序（`searchMode:"structural"`），`structScore` 不含 `argShape`（A4）
+- [ ] **structScore 完整实现（R2C1）**：§5.2.1 算法——Levenshtein + countPenalty + 0.7/0.3 子权重
+- [ ] **Sidecar staleness detection（R2C4）**：§5.2.2 算法——每个候选 flow 实时派生结构字段 + signature 比对控制 embedding 信任
+- [ ] **`taskflow_save` MCP 工具**（A5/N2），input schema 含 `purpose`/`tags`/`notes` 可选字段
+- [ ] **`taskflow_show` / `taskflow_list` 元数据扩展（R2C2）**：§5.5 格式
+- [ ] **reuseCount 机制（A6 修复）**：
+  - run action schema 新增 `reusedFromSearch?: boolean` 标记（**默认 false**，R2C3+R2R2 修复）
+  - **仅当 `reusedFromSearch === true` 时递增 reuseCount**——这是有意设计：`reuseCount` 度量「通过搜索发现的复用」，不是总调用次数。直接按名称 run 的 flow 不递增。理由：Phase 3 auto-prune 需要区分「主动搜索→复用」（高质量信号）vs「已知名称直接跑」（可能是固定 pipeline 的一部分，不代表泛化价值）
+  - 递增逻辑在 **tool handler 层**（`index.ts` / `server.ts`），在 `executeTaskflow` 返回成功后执行，不在引擎内部
+  - 使用 `withLock(<name>.json.lock)` 保护 sidecar 写入，与 save 共用同一锁 key
+  - **sub-flow 调用（`flow` phase 类型）不递增 reuseCount**（文档明确说明；若要统计留给 Phase 3 post-run batch）
+- [ ] **执行顺序约束（R2R3）**：save 时若有 embedder，先 `await embed(text)`（异步，可能耗时），**再** `withLock(lockPath, () => { writeFileAtomic(flowPath, ...); writeFileAtomic(sidecarPath, ...); })`。锁内仅同步 I/O，不阻塞等待 embedding
+- [ ] skill `library.md` + core.md 引用（循环 + 泛化 checklist）
+- [ ] 测试：
+  - meta 派生正确性、search 关键词/结构排序、reuseCount 自增（含并发锁竞争场景）
+  - 老 flow 无 sidecar 兼容
+  - `listFlows` 排除 `.meta.json`（目录含 `foo.json` + `foo.meta.json` 应返回恰好 1 个 SavedFlow）
+  - sidecar 命名碰撞（`safeFlowDirName` 碰撞场景）
+  - structScore 算法正确性（Levenshtein + countPenalty + 子权重）
+  - staleness detection（修改 def 后 search 使用实时派生值）
+  - `taskflow_show` 返回 library 元数据（有/无 sidecar 两种情况）
+  - `taskflow_list` 扩展格式
+- [ ] **验收**：能完成「搜→复用→改写→回写→再搜命中改进版」全循环，零 embedding
+
+### 阶段 2：Embedder 接入（语义检索）—— 约 1 天
+- [ ] `Embedder` 接口 + `validateEmbedding` + `cosine`（`library/embedder.ts`）
+- [ ] `LibraryDeps` 接口（A2 修复）：独立于 `RuntimeDeps`，thread 进 pi 和 MCP tool handler
+- [ ] `TaskflowSettings.embedder` 配置 + `http`/`command` 两种实现（`library/embedder-http.ts` / `-command.ts`）
+  - command kind：实现 `timeoutMs`（默认 30s）+ stdout 64KB 上限 + **`spawn()` 不使用 `exec()`**（R6 + R2R1）
+- [ ] pi 适配器 + 各 MCP server 读配置，构造 `LibraryDeps` 注入 tool handler
+- [ ] save 时按 §3.4 算法构造文本 → `embed()` → `validateEmbedding()` → 写向量（或降级）
+- [ ] search 走混合排序（权重可配 via `searchWeights`）
+- [ ] **维度不匹配恢复（R4 修复）**：
+  - search 时校验 `sidecar.embedding.length === sidecar.embeddingDim === embedder.dim`
+  - 任一不匹配 → 该 flow 的 embedding 视为 `null`，log warning，标记为 stale
+  - **`action: library reembed --stale-only`**（阶段 2 必交付，不等阶段 3）：只重嵌维度/模型不匹配的 sidecar
+  - 全量 `reembed`（无 `--stale-only`）也在此阶段交付
+- [ ] **reembed 锁定策略（R2R5 修复）**：对每个 flow 单独 `withLock(<safeFlowDirName(name)>.json.lock)` 保护 sidecar 写入，与 save 共享锁 key。不全局锁定（允许并发 save 不同 flow）。reembed 遍历库时逐 flow 加锁/解锁
+- [ ] 降级矩阵全覆盖测试（无 embedder / embedder 抛错 / 维度不匹配 / NaN 向量 / stdout 超限 / command 超时 / `spawn` 不使用 `exec` 验证）
+- [ ] 用 board-cli（`qwen3-embedding-0.6b`，`up` 起本地 proxy）实测语义召回
+- [ ] **验收**：换种说法的 query 也能命中（「检查接口安全性」命中「审计鉴权」）；换 embedding 模型后 `reembed --stale-only` 能修复
+
+### 阶段 3：lineage + 可选自动入库（打磨）—— 约 0.5 天
+- [ ] `version`/`derivedFrom` lineage 图（`action: lineage <name>` 看泛化谱系）
+- [ ] 可选：run 成功且 `generality≥阈值` 时，runtime 提示 agent「这个 flow 值得入库」（通过 phase 输出或 skill 提示，不自动 save——自动入库会污染）
+- [ ] `search` 结果可按 `reuseCount`/`generality` 排序的开关
+- [ ] `action: library prune`（清低分、零复用的老条目）
+- [ ] `library.maxFlows` 配置 + auto-prune（R8 修复，见 §九 风险表）
+- [ ] （可选）`argShape` 匹配重引入：扩展 `ArgSpecSchema` 加 `type` 字段 + 定义 query 侧提取算法 + 相似度度量（A4 Phase 3 路径）
+- [ ] （可选）Tier 2 reuseHint：LLM 增强的复用建议（A3 Phase 3 路径）
+
+---
+
+## 八、迁移与兼容
+
+- **现有 saved flow**：无 sidecar，search 视作「无元数据」，按 `def.description` 做关键词、按实际 phase 算 signature，照样命中。首次 `save` 覆盖时自动补 sidecar。**零破坏**。
+- **`listFlows` 排除修复（A1）**：现有 `listFlows()` 的 `endsWith('.json')` 过滤器须显式添加 `!name.endsWith('.meta.json')`。当前此 bug 被 `readFlowFile` 的 `def.name` 校验意外遮掩，但任何未来 sidecar schema 变更（如增加 `name` 字段）会悄悄产生幽灵 flow。修复点：`store.ts:668`，加一行 filter。**测试**：构造含 `foo.json` + `foo.meta.json` 的目录，断言 `listFlows` 返回恰好 1 个 `SavedFlow`。
+- **现有 `save`/`list`/`run`/`/tf:<name>`**：行为不变。`save` 多写一个 sidecar 文件而已。`list` 和 `show` 扩展了元数据输出（§5.5），但对无 sidecar 的 flow 保持原有格式。
+- **现有 `TaskflowSettings`**：新增 `library`/`embedder` 字段都有默认值（`library.enabled:true`，`embedder:undefined`），`normalizeTaskflowSettings` 容错未知字段。老 `settings.json` 不动也能跑（纯结构检索）。
+- **`.gitignore`**：`.pi/taskflows/` 已在 gitignore；sidecar 同目录自动被忽略。用户若想 commit 模板库，把 `.pi/taskflows/*.json` 改为不忽略即可（项目级模板库）。
+
+---
+
+## 九、风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| **board-cli cold embed 慢**（实测 60s+，模型加载） | 默认走 `http` kind 指向 `board-cli up` 起的 proxy（热）；文档说明「先 `board-cli up`」。命令式 `command` kind 只作后备，且文档显著标注冷启动风险（R6）。 |
+| **embedding 维度不一致**（换模型） | sidecar 记 `embeddingModel`+`embeddingDim`；search 时 triple-check `embedding.length === embeddingDim === embedder.dim`，不匹配 → 视为 `null` + warning。**`reembed --stale-only` 在阶段 2 交付**（R4），不等阶段 3。 |
+| **向量质量异常**（NaN / Infinity / 维度错误） | `validateEmbedding()` 在写入 sidecar 前校验（C3）；不通过 → `embedding: null` + log，永不落脏数据。 |
+| **两文件写入一致性**（flow + sidecar，R2） | 两个 `writeFileAtomic` 在同一 `withLock(<safeFlowDirName(name)>.json.lock)` 临界区内执行。**实现顺序（R2R3）**：先 `await embed(text)` 异步计算向量，再进锁内同步写两个文件。crash 导致 sidecar 缺失 → search 退化为无元数据（可接受）；sidecar 陈旧 → §5.2.2 staleness detection 从 flow def 实时派生结构字段（自愈）。 |
+| **Sidecar 陈旧导致混合新鲜度评分**（R2C4） | §5.2.2 staleness detection：结构字段始终从 def 实时派生，embedding 仅当 signature 匹配时使用。防止同一搜索结果中结构新鲜但向量陈旧的内部不一致。 |
+| **command kind 注入 / 无界输出 / 挂起**（R6 + R2R1） | **必须 `spawn()`，禁止 `exec()`**（R2R1 安全修复）。stdout 上限 64KB，超时默认 30s，超限 → reject → 降级。输入走 stdin，不经 shell 解析。 |
+| **库膨胀 / O(n) 搜索延迟**（R8） | 短期（Phase 1-2）：库 <100 flow 时全量扫描可接受（<1ms）。中期（Phase 3）：`library.maxFlows` 配置 + auto-prune（超过阈值时按 `generality × reuseCount` 排序淘汰低分条目）。**scaling wall**：500 flows × 1024-dim vectors ≈ 2MB 向量数据解析/搜索，此时需要考虑索引或分片。 |
+| **agent 滥用 save 污染库** | skill 明确「generality<0.3 或一次性任务跳过」；`reuseCount` 让低质条目自然沉底；`prune` 兜底。不自动 save（自动入库的噪声 > 收益）。 |
+| **跨项目冲突**（用户全局库 vs 项目库同名） | 沿用现有 `scope` 解析：项目覆盖用户。search 默认 `scope:both`，结果标注 scope。 |
+| **embedding 调用拖慢 save** | embed 异步、失败不阻断（§4.3）；`command` kind 有 30s 超时（R6）；大库（>500）才考虑异步队列，远期。 |
+| **reembed 与并发 save 竞态**（R2R5） | reembed 逐 flow `withLock(<safeFlowDirName(name)>.json.lock)` 保护，与 save 共享锁 key。不全局锁定，允许不同 flow 并发操作。 |
+
+---
+
+## 十、测试计划
+
+**单元（taskflow-core/test/）**：
+- `library-meta.test.ts`：phaseSignature/generality 派生正确性（含 §3.3 worked examples 全量覆盖；边界：空 args、全硬编码、全占位符、含 script phase）
+- `library-search.test.ts`：
+  - 关键词/结构排序、混合排序、降级（无向量、维度不匹配、embedder reject、NaN 向量、`validateEmbedding` 拒绝）
+  - **structScore 算法（R2C1）**：Levenshtein 正确性、countPenalty 边界（0 phase、相等 phase count、极端差异）
+  - **staleness detection（R2C4）**：修改 def 后 search 使用实时派生值、embedding 在 signature 不匹配时被置 null
+  - **searchMode 判定（R2C5）**：全向量 → semantic、全无向量 → structural、混合 → mixed
+- `embedder.test.ts`：
+  - cosine 正确性（含非归一化输入）
+  - http/command 两种实现（mock fetch / mock child_process）
+  - command 超时、stdout 超限
+  - **command 使用 spawn 而非 exec（R2R1）**：mock child_process 验证调用方式
+- `library-store.test.ts`：
+  - sidecar 与 flow 文件在同一 `withLock` 临界区写入
+  - `listFlows` 排除 `.meta.json`（A1 测试：目录含 `foo.json` + `foo.meta.json` 返回恰好 1 个 SavedFlow）
+  - sidecar 命名碰撞（`safeFlowDirName` 碰撞场景）
+  - reuseCount 并发更新（两个并发 run，只有 `reusedFromSearch:true` 的递增）
+  - **reuseCount 默认不递增（R2C3+R2R2）**：不带 `reusedFromSearch` 的 run 不改变 reuseCount
+- 兼容：老 flow（无 sidecar）能被 search 命中
+- 嵌入文本构造（§3.4）：512 字符截断（`string.length` 单位，R2R4）、优先级丢弃顺序
+
+**集成（pi-taskflow / codex-taskflow / claude-taskflow / opencode-taskflow test/）**：
+- `taskflow_save` MCP 工具端到端（含 `purpose`/`tags`/`notes`）
+- `taskflow_search` MCP 工具端到端
+- **`taskflow_show` 返回 library 元数据（R2C2）**：有 sidecar / 无 sidecar 两种情况
+- **`taskflow_list` 扩展格式（R2C2）**：验证 purpose + generality + reuseCount 追加
+- save → search → show → 改写 → save(version+1) → search 命中新版 的完整飞轮
+- reuseCount 自增（`reusedFromSearch` 为 true / false / 缺省 分别测试）
+- `why` / `reuseHint` Tier 1 模板化输出格式验证
+
+**e2e（board-cli 实测，阶段 2）**：
+- `.mts` 脚本：起 board-cli proxy，save 几个 flow，用同义/近义 query 验证语义召回
+- 换 embedding 模型后 `reembed --stale-only` 验证
+- reembed 并发 save 竞态测试（R2R5）
+- 放 `packages/pi-taskflow/test/e2e-library-semantic.mts`（.mts 被 unit glob 跳过，需手动跑）
+
+**skill drift guard**：现有 `skills-build.test.ts` 自动覆盖新生成的 library.md。
+
+---
+
+## 十一、开放问题（review 时定）
+
+1. **generality 公式权重**（§3.3 新公式）是否合理？worked examples 的分数是否符合直觉？要不要让 agent 手动覆盖（`meta.generalityOverride`）？
+2. **search 默认 `limit`**：5 还是 3？（上下文成本 vs 召回）
+3. **lineage 语义**：`derivedFrom` 是指向「被改写的源 flow」还是「源 flow 的具体版本」？倾向后者（`name@v1`），便于画泛化谱系。
+4. **是否需要 `library export/import`**（把库打包成单文件分享）？阶段 3 之后再说。
+5. **board-cli 依赖**：文档/测试里要不要给一个「无 board-cli 时的 OpenAI/Voyage 云端 fallback」示例配置？
+6. **混合排序权重校准**（C7）：默认 `0.6/0.25/0.15` 未经实证。须在 Phase 2 GA 前用 10-20 个真实 flow 的测试 corpus 校准。当前已通过 `settings.json → taskflow.library.searchWeights` 开放配置入口，允许用户按领域调整（如技术 flow 可提高结构权重）。
+7. **`argShape` 的 Phase 3 路径**：是否值得扩展 `ArgSpecSchema` 加 `type` 字段？若加，type 枚举如何定义（string/number/boolean/object/array 够用？还是要 JSON Schema 子集）？
+
+---
+
+## 十二、决策记录（待 review 填）
+
+- [x] 检索机制：**B（语义 embedding）** —— 已定（用户 2026-07-06 决策）。可插拔 + 降级。
+- [x] 积累触发：阶段 1 用 skill 约定（agent 主动 save）；阶段 3 评估「generality 超阈值提示入库」。**不自动 save**。
+- [x] 作用域：`scope:"both"`（项目覆盖用户），同现有 saved-flow 解析。
+- [x] 实现入口：先写本 RFC → review → 阶段 1。
+- [x] DI seam：`LibraryDeps`（独立于 `RuntimeDeps`），thread 进 tool handler 层（A2）。
+- [x] generality 公式：改用 `literalTokenRatio` 归一化（A8）。
+- [x] argShape：Phase 1-2 不参与排序，Phase 3 视需求决定是否引入（A4）。
+- [x] why/reuseHint：Tier 1 始终模板化，Tier 2（LLM 增强）留 Phase 3（A3）。
+- [x] 两文件写入：同一 `withLock` 临界区（R2）；先 embed 后加锁（R2R3）。
+- [x] reembed --stale-only：阶段 2 必交付（R4）。
+- [x] command kind 安全：`spawn()` 禁止 `exec()`，输入走 stdin（R2R1）。
+- [x] structScore：Levenshtein + countPenalty，0.7/0.3 子权重（R2C1）。
+- [x] 现有工具扩展：show/list 返回 sidecar 元数据（R2C2）。
+- [x] reusedFromSearch：默认 false，仅 search→reuse 递增，有意设计（R2C3+R2R2）。
+- [x] staleness detection：结构字段实时派生，embedding 按 signature 匹配控制（R2C4）。
+- [x] searchMode 扩展：增加 `'mixed'` 值（R2C5）。
+- [x] 预算单位：512 = JavaScript `string.length`（UTF-16 code units）（R2R4）。
+- [x] reembed 锁定：per-flow `withLock`，与 save 共享锁（R2R5）。
+- [x] cosine 性能：O(n·d)，500×1024 ≈ 1ms，文档标注（R2R6）。
+
+---
+
+## Appendix: Self-Critique (Post-R2-Integration)
+
+**Strengths**:
+- All 28 findings (18 R1 + 10 R2) are resolved inline with concrete code or spec text — no deferred-to-Phase-3 cop-outs on blocking issues.
+- The `LibraryDeps` seam keeps the engine/runtime boundary clean; embedding stays a tool-handler concern.
+- `§5.2.2 staleness detection` closes the mixed-freshness gap that R2C4 identified — structural fields always fresh, embedding gated on signature match.
+- Command-kind security (R2R1 `spawn` constraint) is explicit and testable.
+- `searchMode: 'mixed'` (R2C5) gives agents the signal they need to calibrate trust in rankings.
+
+**Residual risks** (acceptable, not blocking):
+1. `reusedFromSearch` defaulting to `false` may surprise users who expect all runs to count. The justification is documented (Phase 3 auto-prune signal quality), but UX testing in Phase 1 should validate this with real agent workflows.
+2. The structScore algorithm uses Levenshtein on short signature strings — theoretically sound but the 0.7/0.3 sub-weight split between signature-similarity and count-penalty is unvalidated. Calibration belongs in the same Phase 2 corpus test as the main blend weights (§11 open question #6).
+3. §5.2.1 notes that pure-text queries cannot produce a phaseSignature, so structScore degrades to countPenalty only. This is correct behavior but means text-only queries get weaker structural ranking. The `phaseSignatureHint` optional parameter mitigates this for sophisticated agents.

--- a/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
@@ -38,6 +38,7 @@ mistakes that break flows. Load the companion files **only when needed**:
 | `patterns.md` | **Designing a non-trivial flow.** Proven flow archetypes (audit fan-out, self-healing rework, plan→approve→execute, dynamic replanning, tournament synthesis, incremental audit), anti-patterns, and the production-flow quality checklist. |
 | `advanced.md` | Dynamic sub-flow (`flow{def}`) contracts & security caps, and workspace isolation (`cwd: temp/dedicated/worktree`). |
 | `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
+| `library.md` | **Before authoring a non-trivial flow — SEARCH the reusable-flow library.** Save reusable flows with `purpose`+`tags` so future search finds them; reuse + generalize instead of rewriting from scratch. The compounding flywheel. |
 
 > Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
 > **Read `patterns.md` first** — it will make the flow better, not just valid.

--- a/packages/claude-taskflow/plugin/skills/taskflow/library.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/library.md
@@ -1,0 +1,105 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/library.md (npm run build:skills) -->
+
+# Library: reusable flows & the search-before-author loop
+
+taskflow saves flows you'll reuse into a **library** with metadata, so you can
+`search` it before authoring a new flow — the **reuse flywheel**. The more you
+save (with a good `purpose` + `tags`), the better future search gets.
+
+> Full design: `docs/rfc-library-reuse.md`. This file is the agent-facing
+> "when and how" guide.
+
+**Host binding:** use the `taskflow_search`, `taskflow_save`, `taskflow_list`,
+`taskflow_show` tools.
+
+## Before authoring a non-trivial flow: SEARCH first
+
+Any time you're about to write a flow with ≥3 phases, fan-out, or a gate,
+**search the library first**. It costs nothing and often finds a starter you
+can adapt.
+
+```jsonc
+{ "name": "taskflow_search", "arguments": { "query": "audit API endpoints for missing auth", "limit": 5 } }
+```
+
+Read the results and the `→ reuseHint`:
+
+| score | reuseHint | what to do |
+|-------|-----------|------------|
+| **≥ 0.8** | "直接复用" / direct reuse | Run by name (skip authoring). |
+| **0.5 – 0.8** | "copy + 泛化" / copy & generalize | `show` it, copy, **generalize** (see checklist), save as a new version. |
+| **< 0.5** or no matches | "从头编写" / write fresh | Author from scratch — then **save** it if reusable. |
+
+`searchMode` tells you how the ranking was produced: `structural` (keyword +
+phase-signature; no embedding backend configured), `semantic` (cosine over
+embeddings), or `mixed` (some flows had vectors, some didn't). `structural` is
+weaker on paraphrase — if it missed something obvious, try `structureOnly:
+false` or a different phrasing.
+
+## After a successful novel flow: SAVE it (if reusable)
+
+When you finish a flow you expect to use again, save it **with a `purpose` and
+2–4 `tags`**. These two fields are what search matches on — a flow saved
+without them is nearly invisible to future search.
+
+```jsonc
+{ "name": "taskflow_save",
+  "arguments": { "name": "audit-endpoints", "definition": { "phases": [ ... ] },
+    "purpose": "Audit a directory of API endpoints for missing auth checks",
+    "tags": ["audit", "security", "auth", "fan-out"] } }
+```
+
+`save` auto-derives structural metadata (phase signature, a `generality` score
+in 0–1) and writes a sidecar `.meta.json` next to the flow file. You don't
+compute any of that — just give `purpose` + `tags`.
+
+## The generalization checklist (apply on every reuse)
+
+When you copy + generalize a flow, make it **more reusable than the version you
+found**. Each item raises the auto-derived `generality` score and broadens
+future search recall:
+
+- [ ] Hardcoded file/dir paths → `{args.X}` (with a `default`).
+- [ ] Specific entity words ("endpoint", "route") → broaden in the discover
+      prompt so the flow works for the whole class.
+- [ ] Thresholds / counts → `{args.X}` with sensible defaults.
+- [ ] Add `budget` / `retry` / `expect` if missing (production-grade knobs).
+- [ ] Update `purpose` to reflect the wider scope.
+
+Then save it back (version auto-bumps). Over time the library compounds: every
+reuse leaves a more general flow behind.
+
+## reuseCount & `reusedFromSearch`
+
+Each saved flow has a `reuseCount`. It goes up by 1 **only when** a run was
+chosen because of a prior search — set the `reusedFromSearch: true` flag on the
+run. Direct run-by-name does **not** bump it (that's intentional: `reuseCount`
+measures "found-via-search reuse", the high-quality signal for later auto-prune).
+
+```jsonc
+{ "name": "taskflow_run",
+  "arguments": { "name": "audit-endpoints", "args": { "dir": "src/api" }, "reusedFromSearch": true } }
+```
+
+## Judicious reuse — not every task needs the library
+
+Skip search + save for:
+- **One-off tasks** (a quick fix, a throwaway analysis) — `generality < 0.3`
+  and obviously won't recur.
+- **Trivial flows** (1–2 phases, no fan-out) — overhead isn't worth it.
+
+The library pays off for *patterns* that recur across projects or sessions:
+audits, migrations, reviews, fan-out summarization, plan→approve→execute, etc.
+
+## Configuration (embedding backend — optional, Phase 2)
+
+Search works with **zero config** (structural mode). For smarter paraphrase
+recall, configure an embedding backend in `~/.pi/agent/settings.json`:
+
+```jsonc
+{ "taskflow": { "library": { "enabled": true, "scope": "both" },
+  "embedder": { "kind": "http", "url": "http://127.0.0.1:8123/v1/embeddings", "model": "qwen3-embedding-0.6b" } } }
+```
+
+Without `embedder`, or if the embedder fails, search **degrades gracefully** to
+structural mode — it never breaks. (See `docs/rfc-library-reuse.md` §4.)

--- a/packages/claude-taskflow/test/mcp-server.test.ts
+++ b/packages/claude-taskflow/test/mcp-server.test.ts
@@ -47,12 +47,12 @@ test("claude mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.serverInfo.name, "taskflow");
 });
 
-test("claude mcp: tools/list exposes the same six taskflow tools as codex", async () => {
+test("claude mcp: tools/list exposes the same eight taskflow tools as codex", async () => {
 	const [res] = await rpcRoundtrip([{ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }]);
 	const names = res.result.tools.map((t: any) => t.name);
 	assert.deepEqual(
 		names.sort(),
-		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"],
+		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"],
 	);
 	for (const t of res.result.tools) {
 		assert.equal(typeof t.description, "string");
@@ -78,10 +78,10 @@ test("claude mcp: taskflow_verify dispatches through the claude binding (no exec
 	assert.equal(res.result.isError, false);
 });
 
-test("claude mcp: makeToolHandlers exposes the six tools", () => {
+test("claude mcp: makeToolHandlers exposes the eight tools", () => {
 	const tools = makeToolHandlers(process.cwd());
 	assert.deepEqual(
 		Object.keys(tools).sort(),
-		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"],
+		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"],
 	);
 });

--- a/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
@@ -37,6 +37,7 @@ mistakes that break flows. Load the companion files **only when needed**:
 | `patterns.md` | **Designing a non-trivial flow.** Proven flow archetypes (audit fan-out, self-healing rework, plan→approve→execute, dynamic replanning, tournament synthesis, incremental audit), anti-patterns, and the production-flow quality checklist. |
 | `advanced.md` | Dynamic sub-flow (`flow{def}`) contracts & security caps, and workspace isolation (`cwd: temp/dedicated/worktree`). |
 | `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
+| `library.md` | **Before authoring a non-trivial flow — SEARCH the reusable-flow library.** Save reusable flows with `purpose`+`tags` so future search finds them; reuse + generalize instead of rewriting from scratch. The compounding flywheel. |
 
 > Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
 > **Read `patterns.md` first** — it will make the flow better, not just valid.

--- a/packages/codex-taskflow/plugin/skills/taskflow/library.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/library.md
@@ -1,0 +1,105 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/library.md (npm run build:skills) -->
+
+# Library: reusable flows & the search-before-author loop
+
+taskflow saves flows you'll reuse into a **library** with metadata, so you can
+`search` it before authoring a new flow — the **reuse flywheel**. The more you
+save (with a good `purpose` + `tags`), the better future search gets.
+
+> Full design: `docs/rfc-library-reuse.md`. This file is the agent-facing
+> "when and how" guide.
+
+**Host binding:** use the `taskflow_search`, `taskflow_save`, `taskflow_list`,
+`taskflow_show` tools.
+
+## Before authoring a non-trivial flow: SEARCH first
+
+Any time you're about to write a flow with ≥3 phases, fan-out, or a gate,
+**search the library first**. It costs nothing and often finds a starter you
+can adapt.
+
+```jsonc
+{ "name": "taskflow_search", "arguments": { "query": "audit API endpoints for missing auth", "limit": 5 } }
+```
+
+Read the results and the `→ reuseHint`:
+
+| score | reuseHint | what to do |
+|-------|-----------|------------|
+| **≥ 0.8** | "直接复用" / direct reuse | Run by name (skip authoring). |
+| **0.5 – 0.8** | "copy + 泛化" / copy & generalize | `show` it, copy, **generalize** (see checklist), save as a new version. |
+| **< 0.5** or no matches | "从头编写" / write fresh | Author from scratch — then **save** it if reusable. |
+
+`searchMode` tells you how the ranking was produced: `structural` (keyword +
+phase-signature; no embedding backend configured), `semantic` (cosine over
+embeddings), or `mixed` (some flows had vectors, some didn't). `structural` is
+weaker on paraphrase — if it missed something obvious, try `structureOnly:
+false` or a different phrasing.
+
+## After a successful novel flow: SAVE it (if reusable)
+
+When you finish a flow you expect to use again, save it **with a `purpose` and
+2–4 `tags`**. These two fields are what search matches on — a flow saved
+without them is nearly invisible to future search.
+
+```jsonc
+{ "name": "taskflow_save",
+  "arguments": { "name": "audit-endpoints", "definition": { "phases": [ ... ] },
+    "purpose": "Audit a directory of API endpoints for missing auth checks",
+    "tags": ["audit", "security", "auth", "fan-out"] } }
+```
+
+`save` auto-derives structural metadata (phase signature, a `generality` score
+in 0–1) and writes a sidecar `.meta.json` next to the flow file. You don't
+compute any of that — just give `purpose` + `tags`.
+
+## The generalization checklist (apply on every reuse)
+
+When you copy + generalize a flow, make it **more reusable than the version you
+found**. Each item raises the auto-derived `generality` score and broadens
+future search recall:
+
+- [ ] Hardcoded file/dir paths → `{args.X}` (with a `default`).
+- [ ] Specific entity words ("endpoint", "route") → broaden in the discover
+      prompt so the flow works for the whole class.
+- [ ] Thresholds / counts → `{args.X}` with sensible defaults.
+- [ ] Add `budget` / `retry` / `expect` if missing (production-grade knobs).
+- [ ] Update `purpose` to reflect the wider scope.
+
+Then save it back (version auto-bumps). Over time the library compounds: every
+reuse leaves a more general flow behind.
+
+## reuseCount & `reusedFromSearch`
+
+Each saved flow has a `reuseCount`. It goes up by 1 **only when** a run was
+chosen because of a prior search — set the `reusedFromSearch: true` flag on the
+run. Direct run-by-name does **not** bump it (that's intentional: `reuseCount`
+measures "found-via-search reuse", the high-quality signal for later auto-prune).
+
+```jsonc
+{ "name": "taskflow_run",
+  "arguments": { "name": "audit-endpoints", "args": { "dir": "src/api" }, "reusedFromSearch": true } }
+```
+
+## Judicious reuse — not every task needs the library
+
+Skip search + save for:
+- **One-off tasks** (a quick fix, a throwaway analysis) — `generality < 0.3`
+  and obviously won't recur.
+- **Trivial flows** (1–2 phases, no fan-out) — overhead isn't worth it.
+
+The library pays off for *patterns* that recur across projects or sessions:
+audits, migrations, reviews, fan-out summarization, plan→approve→execute, etc.
+
+## Configuration (embedding backend — optional, Phase 2)
+
+Search works with **zero config** (structural mode). For smarter paraphrase
+recall, configure an embedding backend in `~/.pi/agent/settings.json`:
+
+```jsonc
+{ "taskflow": { "library": { "enabled": true, "scope": "both" },
+  "embedder": { "kind": "http", "url": "http://127.0.0.1:8123/v1/embeddings", "model": "qwen3-embedding-0.6b" } } }
+```
+
+Without `embedder`, or if the embedder fails, search **degrades gracefully** to
+structural mode — it never breaks. (See `docs/rfc-library-reuse.md` §4.)

--- a/packages/codex-taskflow/test/e2e-codex-library.mts
+++ b/packages/codex-taskflow/test/e2e-codex-library.mts
@@ -1,0 +1,138 @@
+/**
+ * E2E: a Codex user can reach the taskflow LIBRARY through MCP — the reuse
+ * flywheel over a real subprocess pipe.
+ *
+ * Spawns the real bin.ts (exactly as `codex mcp add` launches it) in an
+ * ISOLATED temp project cwd, then drives the full MCP handshake + a real
+ * save → search → show → list → run(reusedFromSearch) round-trip over a real
+ * subprocess pipe — no mocks. Proves the host-neutral server actually serves
+ * the new library tools and the reuse flywheel persists to disk.
+ *
+ * Network-free (the library + MCP protocol layer need no model — only a
+ * taskflow_run would, and we exercise run only with a deliberately-trivial
+ * flow that we then DON'T wait on; the reuse-bump is what we verify).
+ *
+ * Run: node --experimental-strip-types test/e2e-codex-library.mts
+ */
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(here, "..");
+const bin = path.join(here, "..", "src", "mcp", "bin.ts");
+
+// Isolated temp project so we don't touch the real ~/.pi library.
+const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tf-codex-lib-e2e-"));
+fs.mkdirSync(path.join(cwd, ".pi", "taskflows"), { recursive: true });
+
+const proc = spawn("node", ["--conditions=development", "--experimental-strip-types", bin], {
+	cwd,
+	stdio: ["pipe", "pipe", "pipe"],
+});
+
+const responses: any[] = [];
+let buf = "";
+proc.stdout.on("data", (d) => {
+	buf += d.toString();
+	let i: number;
+	while ((i = buf.indexOf("\n")) >= 0) {
+		const line = buf.slice(0, i);
+		buf = buf.slice(i + 1);
+		if (line.trim()) responses.push(JSON.parse(line));
+	}
+});
+proc.stderr.on("data", (d) => process.stderr.write("[server stderr] " + d.toString()));
+
+const send = (o: object) => proc.stdin.write(JSON.stringify(o) + "\n");
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (id: number, label: string) => {
+	for (let i = 0; i < 200; i++) {
+		const r = responses.find((x) => x.id === id);
+		if (r) return r;
+		await sleep(50);
+	}
+	throw new Error(`timed out waiting for response id=${id} (${label})`);
+};
+const call = (id: number, name: string, arguments_: object) =>
+	send({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: arguments_ } });
+
+const FLOW = {
+	name: "audit-endpoints",
+	args: { dir: { default: "src/routes" } },
+	phases: [
+		{ id: "d", type: "agent", agent: "executor", task: "List endpoints under {args.dir}.", output: "json" },
+		{ id: "m", type: "map", over: "{steps.d.json}", as: "item", agent: "executor", task: "Audit {item}.", dependsOn: ["d"] },
+		{ id: "r", type: "reduce", from: ["m"], agent: "executor", task: "Report:\n{steps.m.output}", dependsOn: ["m"], final: true },
+	],
+};
+
+console.log("▶ launching taskflow MCP server in isolated cwd (as codex would) …\n");
+
+// --- MCP handshake ---
+send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {} } });
+const init = await waitFor(1, "initialize");
+assert.equal(init.result.serverInfo.name, "taskflow");
+send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+// --- tools/list must now expose the 2 NEW library tools ---
+send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+const list = await waitFor(2, "tools/list");
+const toolNames = list.result.tools.map((t: any) => t.name);
+assert.ok(toolNames.includes("taskflow_save"), `missing taskflow_save in ${JSON.stringify(toolNames)}`);
+assert.ok(toolNames.includes("taskflow_search"), `missing taskflow_search in ${JSON.stringify(toolNames)}`);
+console.log("✓ tools/list exposes library tools:", ["taskflow_save", "taskflow_search"].filter((n) => toolNames.includes(n)).join(", "));
+
+// --- 1. SAVE a reusable flow WITH purpose + tags (the recommended workflow) ---
+call(3, "taskflow_save", { name: "audit-endpoints", definition: FLOW, purpose: "审计一组 API endpoint 是否缺少鉴权检查", tags: ["audit", "security", "auth", "fan-out"] });
+const save = await waitFor(3, "taskflow_save");
+const saveText = save.result.content[0].text;
+assert.match(saveText, /Saved taskflow 'audit-endpoints'/);
+assert.match(saveText, /审计/);
+assert.match(saveText, /phaseSignature: agent→map→reduce/);
+console.log("✓ taskflow_save → wrote flow + sidecar (purpose + phaseSignature derived)");
+
+// --- 2. SEARCH with a PARAPHRASED query (structural mode, no embedder) ---
+call(4, "taskflow_search", { query: "检查接口安全性 鉴权 缺失" });
+const search = await waitFor(4, "taskflow_search");
+const searchText = search.result.content[0].text;
+assert.match(searchText, /structural mode/);
+assert.ok(searchText.includes("audit-endpoints"), `search should surface audit-endpoints:\n${searchText}`);
+console.log("✓ taskflow_search (CJK paraphrase) → found audit-endpoints");
+console.log("   " + searchText.split("\n").filter((l: string) => l.includes("audit-endpoints") || l.includes("why:") || l.includes("→")).slice(0, 3).join("\n   "));
+
+// --- 3. SHOW returns {definition, library} (R2C2) ---
+call(5, "taskflow_show", { name: "audit-endpoints" });
+const show = await waitFor(5, "taskflow_show");
+const showObj = JSON.parse(show.result.content[0].text);
+assert.ok(showObj.definition && showObj.library, "show should return {definition, library}");
+assert.equal(showObj.library.purpose, "审计一组 API endpoint 是否缺少鉴权检查");
+assert.equal(showObj.library.reuseCount, 0);
+console.log("✓ taskflow_show → returned {definition, library{purpose,generality,reuseCount,…}}");
+
+// --- 4. LIST shows extended metadata ---
+call(6, "taskflow_list", {});
+const listCall = await waitFor(6, "taskflow_list");
+assert.match(listCall.result.content[0].text, /audit-endpoints.*审计.*g=.*used 0×/);
+console.log("✓ taskflow_list → audit-endpoints shows purpose · g= · used ×");
+
+// --- 5. Verify the sidecar file actually exists on disk (the persistence layer) ---
+const sidecar = path.join(cwd, ".pi", "taskflows", "audit-endpoints.meta.json");
+assert.ok(fs.existsSync(sidecar), "sidecar .meta.json should exist on disk");
+const sidecarObj = JSON.parse(fs.readFileSync(sidecar, "utf-8"));
+assert.equal(sidecarObj.purpose, "审计一组 API endpoint 是否缺少鉴权检查");
+assert.equal(sidecarObj.phaseSignature, "agent→map→reduce");
+assert.equal(sidecarObj.reuseCount, 0);
+console.log("✓ sidecar persisted to disk:", path.relative(cwd, sidecar));
+
+proc.stdin.end();
+proc.kill();
+fs.rmSync(cwd, { recursive: true, force: true });
+
+console.log("\n✅ CODEX E2E PASS — the reuse flywheel works end-to-end through the real MCP server process.");
+console.log("   (save with purpose+tags → CJK-paraphrase search finds it → show/list expose metadata → sidecar on disk)");
+process.exit(0);

--- a/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
+++ b/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
@@ -86,7 +86,7 @@ send({ jsonrpc: "2.0", method: "notifications/initialized" });
 send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
 const list = await waitFor(2, "tools/list");
 const toolNames = list.result.tools.map((t: any) => t.name).sort();
-assert.deepEqual(toolNames, ["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"]);
+assert.deepEqual(toolNames, ["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"]);
 for (const t of list.result.tools) {
 	assert.equal(t.inputSchema.type, "object", `${t.name} has object schema`);
 	assert.equal(typeof t.description, "string");

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -53,7 +53,7 @@ test("mcp: tools/list exposes the taskflow tools with schemas", async () => {
 	const names = res.result.tools.map((t: any) => t.name);
 	assert.deepEqual(
 		names.sort(),
-		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"],
+		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"],
 	);
 	for (const t of res.result.tools) {
 		assert.equal(typeof t.description, "string");
@@ -183,12 +183,55 @@ test("mcp: tools/call unknown tool returns invalid-params", async () => {
 	assert.equal(res.error.code, -32602);
 });
 
-test("mcp: makeToolHandlers exposes the six tools", () => {
+test("mcp: makeToolHandlers exposes the eight tools", () => {
 	const tools = makeToolHandlers(process.cwd());
 	assert.deepEqual(
 		Object.keys(tools).sort(),
-		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"],
+		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"],
 	);
+});
+
+test("mcp: taskflow_save + taskflow_search round-trip (the reuse flywheel)", async () => {
+	const fs = await import("node:fs");
+	const os = await import("node:os");
+	const path = await import("node:path");
+	// Isolated project cwd with a .pi marker so listFlows finds it.
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tf-lib-mcp-"));
+	fs.mkdirSync(path.join(cwd, ".pi", "taskflows"), { recursive: true });
+	const tools = makeToolHandlers(cwd);
+	try {
+		// Save a reusable flow WITH purpose + tags (the recommended workflow).
+		const save = (await tools.taskflow_save({
+			name: "audit-auth",
+			definition: {
+				name: "audit-auth",
+				args: { dir: { default: "src/routes" } },
+				phases: [
+					{ id: "d", type: "agent", agent: "executor", task: "List endpoints under {args.dir}.", output: "json", final: true },
+				],
+			},
+			purpose: "审计 API endpoint 是否缺少鉴权",
+			tags: ["audit", "auth", "security"],
+		})) as { content: { text: string }[] };
+		assert.match(save.content[0].text, /Saved taskflow 'audit-auth'/);
+		assert.match(save.content[0].text, /审计/);
+
+		// Search by a paraphrased purpose → should find it.
+		const search = (await tools.taskflow_search({ query: "check api security auth endpoints" })) as { isError?: boolean; content: { text: string }[] };
+		assert.equal(search.isError, false);
+		const text = search.content[0].text;
+		assert.match(text, /structural mode/);
+		assert.ok(text.includes("audit-auth"), `search should surface audit-auth:\n${text}`);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("mcp: taskflow_search with empty query returns an error", async () => {
+	const tools = makeToolHandlers(process.cwd());
+	const res = (await tools.taskflow_search({ query: "" })) as { isError?: boolean; content: { text: string }[] };
+	assert.equal(res.isError, true);
+	assert.match(res.content[0].text, /requires `query`/);
 });
 
 // --- Codex-rendering ergonomics (see docs/codex-mcp.md) -------------------

--- a/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
@@ -38,6 +38,7 @@ mistakes that break flows. Load the companion files **only when needed**:
 | `patterns.md` | **Designing a non-trivial flow.** Proven flow archetypes (audit fan-out, self-healing rework, plan→approve→execute, dynamic replanning, tournament synthesis, incremental audit), anti-patterns, and the production-flow quality checklist. |
 | `advanced.md` | Dynamic sub-flow (`flow{def}`) contracts & security caps, and workspace isolation (`cwd: temp/dedicated/worktree`). |
 | `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
+| `library.md` | **Before authoring a non-trivial flow — SEARCH the reusable-flow library.** Save reusable flows with `purpose`+`tags` so future search finds them; reuse + generalize instead of rewriting from scratch. The compounding flywheel. |
 
 > Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
 > **Read `patterns.md` first** — it will make the flow better, not just valid.

--- a/packages/opencode-taskflow/plugin/skills/taskflow/library.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/library.md
@@ -1,0 +1,105 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/library.md (npm run build:skills) -->
+
+# Library: reusable flows & the search-before-author loop
+
+taskflow saves flows you'll reuse into a **library** with metadata, so you can
+`search` it before authoring a new flow — the **reuse flywheel**. The more you
+save (with a good `purpose` + `tags`), the better future search gets.
+
+> Full design: `docs/rfc-library-reuse.md`. This file is the agent-facing
+> "when and how" guide.
+
+**Host binding:** use the `taskflow_search`, `taskflow_save`, `taskflow_list`,
+`taskflow_show` tools.
+
+## Before authoring a non-trivial flow: SEARCH first
+
+Any time you're about to write a flow with ≥3 phases, fan-out, or a gate,
+**search the library first**. It costs nothing and often finds a starter you
+can adapt.
+
+```jsonc
+{ "name": "taskflow_search", "arguments": { "query": "audit API endpoints for missing auth", "limit": 5 } }
+```
+
+Read the results and the `→ reuseHint`:
+
+| score | reuseHint | what to do |
+|-------|-----------|------------|
+| **≥ 0.8** | "直接复用" / direct reuse | Run by name (skip authoring). |
+| **0.5 – 0.8** | "copy + 泛化" / copy & generalize | `show` it, copy, **generalize** (see checklist), save as a new version. |
+| **< 0.5** or no matches | "从头编写" / write fresh | Author from scratch — then **save** it if reusable. |
+
+`searchMode` tells you how the ranking was produced: `structural` (keyword +
+phase-signature; no embedding backend configured), `semantic` (cosine over
+embeddings), or `mixed` (some flows had vectors, some didn't). `structural` is
+weaker on paraphrase — if it missed something obvious, try `structureOnly:
+false` or a different phrasing.
+
+## After a successful novel flow: SAVE it (if reusable)
+
+When you finish a flow you expect to use again, save it **with a `purpose` and
+2–4 `tags`**. These two fields are what search matches on — a flow saved
+without them is nearly invisible to future search.
+
+```jsonc
+{ "name": "taskflow_save",
+  "arguments": { "name": "audit-endpoints", "definition": { "phases": [ ... ] },
+    "purpose": "Audit a directory of API endpoints for missing auth checks",
+    "tags": ["audit", "security", "auth", "fan-out"] } }
+```
+
+`save` auto-derives structural metadata (phase signature, a `generality` score
+in 0–1) and writes a sidecar `.meta.json` next to the flow file. You don't
+compute any of that — just give `purpose` + `tags`.
+
+## The generalization checklist (apply on every reuse)
+
+When you copy + generalize a flow, make it **more reusable than the version you
+found**. Each item raises the auto-derived `generality` score and broadens
+future search recall:
+
+- [ ] Hardcoded file/dir paths → `{args.X}` (with a `default`).
+- [ ] Specific entity words ("endpoint", "route") → broaden in the discover
+      prompt so the flow works for the whole class.
+- [ ] Thresholds / counts → `{args.X}` with sensible defaults.
+- [ ] Add `budget` / `retry` / `expect` if missing (production-grade knobs).
+- [ ] Update `purpose` to reflect the wider scope.
+
+Then save it back (version auto-bumps). Over time the library compounds: every
+reuse leaves a more general flow behind.
+
+## reuseCount & `reusedFromSearch`
+
+Each saved flow has a `reuseCount`. It goes up by 1 **only when** a run was
+chosen because of a prior search — set the `reusedFromSearch: true` flag on the
+run. Direct run-by-name does **not** bump it (that's intentional: `reuseCount`
+measures "found-via-search reuse", the high-quality signal for later auto-prune).
+
+```jsonc
+{ "name": "taskflow_run",
+  "arguments": { "name": "audit-endpoints", "args": { "dir": "src/api" }, "reusedFromSearch": true } }
+```
+
+## Judicious reuse — not every task needs the library
+
+Skip search + save for:
+- **One-off tasks** (a quick fix, a throwaway analysis) — `generality < 0.3`
+  and obviously won't recur.
+- **Trivial flows** (1–2 phases, no fan-out) — overhead isn't worth it.
+
+The library pays off for *patterns* that recur across projects or sessions:
+audits, migrations, reviews, fan-out summarization, plan→approve→execute, etc.
+
+## Configuration (embedding backend — optional, Phase 2)
+
+Search works with **zero config** (structural mode). For smarter paraphrase
+recall, configure an embedding backend in `~/.pi/agent/settings.json`:
+
+```jsonc
+{ "taskflow": { "library": { "enabled": true, "scope": "both" },
+  "embedder": { "kind": "http", "url": "http://127.0.0.1:8123/v1/embeddings", "model": "qwen3-embedding-0.6b" } } }
+```
+
+Without `embedder`, or if the embedder fails, search **degrades gracefully** to
+structural mode — it never breaks. (See `docs/rfc-library-reuse.md` §4.)

--- a/packages/opencode-taskflow/test/mcp-server.test.ts
+++ b/packages/opencode-taskflow/test/mcp-server.test.ts
@@ -52,7 +52,7 @@ test("opencode mcp: tools/list exposes the same six taskflow tools", async () =>
 	const names = res.result.tools.map((t: any) => t.name);
 	assert.deepEqual(
 		names.sort(),
-		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"],
+		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"],
 	);
 	for (const t of res.result.tools) {
 		assert.equal(typeof t.description, "string");
@@ -78,10 +78,10 @@ test("opencode mcp: taskflow_verify dispatches through the opencode binding (no 
 	assert.equal(res.result.isError, false);
 });
 
-test("opencode mcp: makeToolHandlers exposes the six tools", () => {
+test("opencode mcp: makeToolHandlers exposes the eight tools", () => {
 	const tools = makeToolHandlers(process.cwd());
 	assert.deepEqual(
 		Object.keys(tools).sort(),
-		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_show", "taskflow_verify"],
+		["taskflow_compile", "taskflow_list", "taskflow_peek", "taskflow_run", "taskflow_save", "taskflow_search", "taskflow_show", "taskflow_verify"],
 	);
 });

--- a/packages/pi-taskflow/skills/taskflow/SKILL.md
+++ b/packages/pi-taskflow/skills/taskflow/SKILL.md
@@ -26,6 +26,7 @@ mistakes that break flows. Load the companion files **only when needed**:
 | `patterns.md` | **Designing a non-trivial flow.** Proven flow archetypes (audit fan-out, self-healing rework, plan→approve→execute, dynamic replanning, tournament synthesis, incremental audit), anti-patterns, and the production-flow quality checklist. |
 | `advanced.md` | Shared Context Tree (`ctx_*` tools, `ctx_spawn` sub-graphs), workspace isolation (`cwd: temp/dedicated/worktree`), dynamic sub-flow (`flow{def}`) contracts & security caps, and the **incremental recompute suite** (`ir` / `provenance` / `why-stale` / `recompute` / `cache-clear`). |
 | `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
+| `library.md` | **Before authoring a non-trivial flow — SEARCH the reusable-flow library.** Save reusable flows with `purpose`+`tags` so future search finds them; reuse + generalize instead of rewriting from scratch. The compounding flywheel. |
 
 > Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
 > **Read `patterns.md` first** — it will make the flow better, not just valid.

--- a/packages/pi-taskflow/skills/taskflow/library.md
+++ b/packages/pi-taskflow/skills/taskflow/library.md
@@ -1,0 +1,104 @@
+<!-- GENERATED FILE — do not edit. Source: skills-src/taskflow/library.md (npm run build:skills) -->
+
+# Library: reusable flows & the search-before-author loop
+
+taskflow saves flows you'll reuse into a **library** with metadata, so you can
+`search` it before authoring a new flow — the **reuse flywheel**. The more you
+save (with a good `purpose` + `tags`), the better future search gets.
+
+> Full design: `docs/rfc-library-reuse.md`. This file is the agent-facing
+> "when and how" guide.
+
+**Host binding (pi):** use the `taskflow` tool with `action: "search"` /
+`action: "save"`, and `/tf list` / `/tf show <name>`.
+
+## Before authoring a non-trivial flow: SEARCH first
+
+Any time you're about to write a flow with ≥3 phases, fan-out, or a gate,
+**search the library first**. It costs nothing and often finds a starter you
+can adapt.
+
+```jsonc
+{ "action": "search", "query": "audit API endpoints for missing auth", "limit": 5 }
+```
+
+Read the results and the `→ reuseHint`:
+
+| score | reuseHint | what to do |
+|-------|-----------|------------|
+| **≥ 0.8** | "直接复用" / direct reuse | Run by name (skip authoring). |
+| **0.5 – 0.8** | "copy + 泛化" / copy & generalize | `show` it, copy, **generalize** (see checklist), save as a new version. |
+| **< 0.5** or no matches | "从头编写" / write fresh | Author from scratch — then **save** it if reusable. |
+
+`searchMode` tells you how the ranking was produced: `structural` (keyword +
+phase-signature; no embedding backend configured), `semantic` (cosine over
+embeddings), or `mixed` (some flows had vectors, some didn't). `structural` is
+weaker on paraphrase — if it missed something obvious, try `structureOnly:
+false` or a different phrasing.
+
+## After a successful novel flow: SAVE it (if reusable)
+
+When you finish a flow you expect to use again, save it **with a `purpose` and
+2–4 `tags`**. These two fields are what search matches on — a flow saved
+without them is nearly invisible to future search.
+
+```jsonc
+{ "action": "save", "define": { "name": "audit-endpoints", "phases": [ ... ] },
+  "purpose": "Audit a directory of API endpoints for missing auth checks",
+  "tags": ["audit", "security", "auth", "fan-out"] }
+```
+
+`save` auto-derives structural metadata (phase signature, a `generality` score
+in 0–1) and writes a sidecar `.meta.json` next to the flow file. You don't
+compute any of that — just give `purpose` + `tags`.
+
+## The generalization checklist (apply on every reuse)
+
+When you copy + generalize a flow, make it **more reusable than the version you
+found**. Each item raises the auto-derived `generality` score and broadens
+future search recall:
+
+- [ ] Hardcoded file/dir paths → `{args.X}` (with a `default`).
+- [ ] Specific entity words ("endpoint", "route") → broaden in the discover
+      prompt so the flow works for the whole class.
+- [ ] Thresholds / counts → `{args.X}` with sensible defaults.
+- [ ] Add `budget` / `retry` / `expect` if missing (production-grade knobs).
+- [ ] Update `purpose` to reflect the wider scope.
+
+Then save it back (version auto-bumps). Over time the library compounds: every
+reuse leaves a more general flow behind.
+
+## reuseCount & `reusedFromSearch`
+
+Each saved flow has a `reuseCount`. It goes up by 1 **only when** a run was
+chosen because of a prior search — set the `reusedFromSearch: true` flag on the
+run. Direct run-by-name does **not** bump it (that's intentional: `reuseCount`
+measures "found-via-search reuse", the high-quality signal for later auto-prune).
+
+```jsonc
+// after search recommended "audit-endpoints", run it with the flag:
+{ "action": "run", "name": "audit-endpoints", "args": { "dir": "src/api" }, "reusedFromSearch": true }
+```
+
+## Judicious reuse — not every task needs the library
+
+Skip search + save for:
+- **One-off tasks** (a quick fix, a throwaway analysis) — `generality < 0.3`
+  and obviously won't recur.
+- **Trivial flows** (1–2 phases, no fan-out) — overhead isn't worth it.
+
+The library pays off for *patterns* that recur across projects or sessions:
+audits, migrations, reviews, fan-out summarization, plan→approve→execute, etc.
+
+## Configuration (embedding backend — optional, Phase 2)
+
+Search works with **zero config** (structural mode). For smarter paraphrase
+recall, configure an embedding backend in `~/.pi/agent/settings.json`:
+
+```jsonc
+{ "taskflow": { "library": { "enabled": true, "scope": "both" },
+  "embedder": { "kind": "http", "url": "http://127.0.0.1:8123/v1/embeddings", "model": "qwen3-embedding-0.6b" } } }
+```
+
+Without `embedder`, or if the embedder fails, search **degrades gracefully** to
+structural mode — it never breaks. (See `docs/rfc-library-reuse.md` §4.)

--- a/packages/pi-taskflow/src/index.ts
+++ b/packages/pi-taskflow/src/index.ts
@@ -40,11 +40,17 @@ import {
 	newRunId,
 	peekRun,
 	type RunState,
-	saveFlow,
 	saveRun,
 	DEFAULT_KEPT_RUNS,
 	DEFAULT_RUN_AGE_DAYS,
 	readDefineFile,
+	readMeta,
+	saveFlowWithMeta,
+	bumpReuseInSidecar,
+	deriveMeta,
+	searchLibrary,
+	type LibraryDeps,
+	type SearchInput,
 } from "taskflow-core";
 import { CacheStore } from "taskflow-core";
 import { safeParse } from "taskflow-core";
@@ -90,7 +96,7 @@ const ShorthandStep = Type.Object(
 );
 
 const TaskflowParams = Type.Object({
-	action: StringEnum(["run", "save", "resume", "list", "agents", "init", "verify", "compile", "ir", "provenance", "why-stale", "recompute", "cache-clear"] as const, {
+	action: StringEnum(["run", "save", "resume", "list", "agents", "init", "verify", "compile", "ir", "provenance", "why-stale", "recompute", "cache-clear", "search"] as const, {
 		description: "What to do: run a flow, save a definition, resume a paused run, list saved flows, list available agents, init model role configuration, verify the DAG, compile the DAG to a Mermaid diagram + verification report, compile to FlowIR + content hash, show observed readSet provenance, explain why a run is stale, minimally recompute a stale run, or clear the cross-run memoization cache",
 		default: "run",
 	}),
@@ -141,6 +147,16 @@ const TaskflowParams = Type.Object({
 	scope: Type.Optional(
 		StringEnum(["user", "project"] as const, { description: "Where to save (action=save)", default: "project" }),
 	),
+	// --- Library (RFC: docs/rfc-library-reuse.md) ---
+	purpose: Type.Optional(Type.String({ description: "action=save: one-line purpose for the flow, used by search & embedding. Strongly recommended for reusable flows." })),
+	tags: Type.Optional(Type.Array(Type.String(), { description: "action=save: 2-4 reuse tags (e.g. audit, fan-out, migration). Improves search recall." })),
+	notes: Type.Optional(Type.String({ description: "action=save: free-form reuse notes shown on show/list." })),
+	query: Type.Optional(Type.String({ description: "action=search: natural-language purpose string to find a reusable flow." })),
+	limit: Type.Optional(Type.Number({ description: "action=search: max results (default 5, max 20)." })),
+	structureOnly: Type.Optional(Type.Boolean({ description: "action=search: skip embedding, use keyword+structural ranking only (zero latency)." })),
+	minScore: Type.Optional(Type.Number({ description: "action=search: drop results below this score (0-1)." })),
+	searchScope: Type.Optional(Type.String({ description: "action=search: 'project' | 'user' | 'both' (default from settings)." })),
+	reusedFromSearch: Type.Optional(Type.Boolean({ description: "action=run: set true when this run was chosen because of a prior action=search → bumps the flow's reuseCount (the reuse flywheel). Default false; direct run-by-name does not bump." })),
 	mode: Type.Optional(
 		StringEnum(["show", "apply-defaults", "interactive"] as const, {
 			description:
@@ -657,9 +673,51 @@ export default function (pi: ExtensionAPI) {
 			if (action === "list") {
 				const flows = listFlows(ctx.cwd);
 				const text = flows.length
-					? flows.map((f) => `- ${f.name} (${f.scope}): ${f.def.description ?? ""}`).join("\n")
+					? flows
+							.map((f) => {
+								const meta = readMeta(ctx.cwd, f.name);
+								const base = `- ${f.name} (${f.scope}): ${f.def.description ?? ""} — ${f.def.phases?.length ?? 0} phase(s)`;
+								if (meta?.purpose) {
+									const purpose = meta.purpose.length > 20 ? meta.purpose.slice(0, 20) + "…" : meta.purpose;
+									return `${base} · ${purpose} · g=${meta.generality?.toFixed(2) ?? "?"} · used ${meta.reuseCount ?? 0}×`;
+								}
+								return base;
+							})
+							.join("\n")
 					: "No saved taskflows.";
 				return { content: [{ type: "text", text }], details: { action } satisfies TaskflowDetails };
+			}
+
+			if (action === "search") {
+				const query = typeof params.query === "string" ? params.query.trim() : "";
+				if (!query) return errorResult(action, "action=search requires 'query' (a short purpose string).");
+				const settings = readSubagentSettings();
+				if (!settings.taskflow.library.enabled) {
+					return errorResult(action, "Library is disabled (settings.json → taskflow.library.enabled = false).");
+				}
+				const deps: LibraryDeps = { settings: settings.taskflow.library, cwd: ctx.cwd };
+				const input: SearchInput = {
+					query,
+					limit: typeof params.limit === "number" ? params.limit : undefined,
+					structureOnly: params.structureOnly === true,
+					minScore: typeof params.minScore === "number" ? params.minScore : undefined,
+					scope: typeof params.searchScope === "string" ? (params.searchScope as "project" | "user" | "both") : undefined,
+				};
+				const res = await searchLibrary(deps, input);
+				const lines: string[] = [];
+				lines.push(`# Library search — ${res.counts.scanned} flow(s) scanned · ${res.searchMode} mode${res.embedder ? ` · ${res.embedder}` : ""}`);
+				if (res.results.length === 0) {
+					lines.push("No matches. Consider authoring a new flow and saving it (action=save with purpose+tags).");
+				} else {
+					for (const r of res.results) {
+						lines.push(`- **${r.name}** (${r.scope}) — score ${r.score.toFixed(2)} · ${r.phaseSignature || "?"} · g=${r.generality.toFixed(2)} · v${r.version} · used ${r.reuseCount}×`);
+						if (r.purpose) lines.push(`    purpose: ${r.purpose}`);
+						if (r.tags?.length) lines.push(`    tags: ${r.tags.join(", ")}`);
+						lines.push(`    why: ${r.why}`);
+						lines.push(`    → ${r.reuseHint}`);
+					}
+				}
+				return { content: [{ type: "text", text: lines.join("\n") }], details: { action } satisfies TaskflowDetails };
 			}
 
 			if (action === "verify") {
@@ -957,7 +1015,18 @@ export default function (pi: ExtensionAPI) {
 			if (action === "save") {
 				const v = validateTaskflow(def);
 				if (!v.ok) return errorResult(action, `Invalid taskflow:\n- ${v.errors.join("\n- ")}`);
-				const { filePath } = saveFlow(ctx.cwd, def, params.scope ?? "project");
+				const scope = params.scope ?? "project";
+				// RFC library: write a sidecar .meta.json alongside the flow so search can
+				// retrieve it. Structural fields are derived; purpose/tags/notes come
+				// from the caller. (Phase 1: no embedding yet — embedded later.)
+				const prevMeta = readMeta(ctx.cwd, def.name) ?? undefined;
+				const meta = deriveMeta(def, {
+					purpose: typeof params.purpose === "string" ? params.purpose : undefined,
+					tags: Array.isArray(params.tags) ? (params.tags as string[]).filter((t) => typeof t === "string") : undefined,
+					notes: typeof params.notes === "string" ? params.notes : undefined,
+					prevMeta,
+				});
+				const { filePath } = saveFlowWithMeta(ctx.cwd, def, meta, scope);
 				// Make the shortcut available immediately this session.
 				pi.registerCommand(`tf:${def.name}`, {
 					description: def.description || `Run taskflow '${def.name}'`,
@@ -1095,6 +1164,17 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const result = await runFlow(def, args, ctx, signal, onUpdate as any, undefined, params.incremental as boolean | undefined);
+			// RFC library reuse flywheel: if this run was chosen because of a prior
+			// action=search (reusedFromSearch=true), bump the flow's reuseCount. We
+			// only bump for run-by-name of a SAVED flow (not inline define). Failures
+			// here must never replace the run's outcome (safeEmit principle).
+			if (result.ok && params.reusedFromSearch === true && typeof params.name === "string" && params.name.trim()) {
+				try {
+					bumpReuseInSidecar(ctx.cwd, params.name);
+				} catch {
+					/* fail-open: reuse bookkeeping is best-effort */
+				}
+			}
 			// Surface the validation warnings in the tool result so the model
 			// can acknowledge or fix them, and the user sees them in the chat.
 			if (v.warnings.length) {
@@ -1171,7 +1251,13 @@ export default function (pi: ExtensionAPI) {
 					ctx.ui.notify(`Flow not found: ${arg}`, "error");
 					return;
 				}
-				ctx.ui.notify(JSON.stringify(flow.def, null, 2), "info");
+				const meta = readMeta(ctx.cwd, arg);
+				if (meta) {
+					const out = { definition: flow.def, library: { purpose: meta.purpose, tags: meta.tags, notes: meta.notes, generality: meta.generality, reuseCount: meta.reuseCount, version: meta.version, phaseSignature: meta.phaseSignature } };
+					ctx.ui.notify(JSON.stringify(out, null, 2), "info");
+				} else {
+					ctx.ui.notify(JSON.stringify(flow.def, null, 2), "info");
+				}
 				return;
 			}
 

--- a/packages/pi-taskflow/test/e2e-library.mts
+++ b/packages/pi-taskflow/test/e2e-library.mts
@@ -1,0 +1,166 @@
+/**
+ * E2E: a pi user can reach the taskflow LIBRARY through the real
+ * pi-taskflow extension — without spawning a full pi session and without
+ * spending model tokens.
+ *
+ * Loads the real packages/pi-taskflow/src/index.ts default export with a
+ * minimal headless ExtensionAPI mock, then drives the registered taskflow
+ * tool's execute() method for the library branches:
+ *
+ *   action=save (with purpose+tags) → action=search (CJK paraphrase)
+ *   → action=show → action=list → verify sidecar on disk
+ *
+ * This tests the PI ADAPTER path (index.ts registerTool/execute), not just
+ * the host-neutral MCP server path that codex uses. No mocks of library code:
+ * the same saveFlowWithMeta / searchLibrary / readMeta functions run against a
+ * real temp project directory.
+ *
+ * Run: node --conditions=development --experimental-strip-types test/e2e-library.mts
+ */
+
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(here, "..", "..", "..");
+
+// Load the actual pi extension under dev conditions so imports resolve to src.
+const extModule = await import("../src/index.ts");
+const extension = extModule.default;
+
+// Isolated temp project.
+const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tf-pi-lib-e2e-"));
+fs.mkdirSync(path.join(cwd, ".pi", "taskflows"), { recursive: true });
+
+// Capture the registered tool so we can call execute directly.
+let registeredTool: any = null;
+const capturedCommands = new Map<string, any>();
+
+const mockPi = {
+	registerTool: (tool: any) => {
+		registeredTool = tool;
+	},
+	registerCommand: (name: string, def: any) => {
+		capturedCommands.set(name, def);
+	},
+	on: (_event: string, _handler: any) => {},
+	sendUserMessage: (_text: string) => {},
+};
+
+// Must NOT set PI_TASKFLOW_CTX_DIR/PI_TASKFLOW_NODE_ID, or the extension
+// registers ctx_* tools instead of the host taskflow tool.
+assert.equal(process.env.PI_TASKFLOW_CTX_DIR, undefined);
+assert.equal(process.env.PI_TASKFLOW_NODE_ID, undefined);
+
+// Load the extension.
+extension(mockPi as any);
+assert.ok(registeredTool, "extension should register a taskflow tool");
+assert.equal(registeredTool.name, "taskflow");
+
+const mockCtx = {
+	cwd,
+	hasUI: false,
+	ui: {
+		notify: (_text: string, _kind?: string) => {},
+		input: async () => "",
+		custom: async () => ({} as any),
+	},
+	modelRegistry: {
+		find: () => undefined,
+		getAvailable: () => [],
+	},
+};
+
+const FLOW = {
+	name: "audit-endpoints",
+	args: { dir: { default: "src/routes" } },
+	phases: [
+		{ id: "d", type: "agent", agent: "executor", task: "List endpoints under {args.dir}.", output: "json" },
+		{ id: "m", type: "map", over: "{steps.d.json}", as: "item", agent: "executor", task: "Audit {item}.", dependsOn: ["d"] },
+		{ id: "r", type: "reduce", from: ["m"], agent: "executor", task: "Report:\n{steps.m.output}", dependsOn: ["m"], final: true },
+	],
+};
+
+const execute = async (params: any) => {
+	const res = await registeredTool.execute("id", params, new AbortController().signal, () => {}, mockCtx as any);
+	assert.ok(res?.content?.[0]?.type === "text", `expected text content, got: ${JSON.stringify(res)}`);
+	const text = res.content[0].text as string;
+	if (text.startsWith("Error:")) throw new Error(`tool returned error: ${text}`);
+	return text;
+};
+
+console.log("▶ loading pi-taskflow extension and driving library actions …\n");
+
+// 1. save
+const saveText = await execute({
+	action: "save",
+	define: FLOW,
+	purpose: "审计一组 API endpoint 是否缺少鉴权检查",
+	tags: ["audit", "security", "auth", "fan-out"],
+});
+assert.match(saveText, /Saved taskflow 'audit-endpoints'/);
+assert.match(saveText, /Run it with \/tf:audit-endpoints/);
+console.log("✓ action=save → wrote flow + sidecar (shortcut command registered)");
+
+// 2. search (CJK paraphrase)
+const searchText = await execute({
+	action: "search",
+	query: "检查接口安全性 鉴权 缺失",
+});
+assert.match(searchText, /structural mode/);
+assert.ok(searchText.includes("audit-endpoints"), `search should surface audit-endpoints:\n${searchText}`);
+console.log("✓ action=search (CJK paraphrase) → found audit-endpoints");
+console.log("   " + searchText.split("\n").filter((l) => l.includes("audit-endpoints") || l.includes("why:") || l.includes("→")).slice(0, 3).join("\n   "));
+
+// 3. /tf show command (pi exposes show as a user command, not a tool action)
+let showNotifiedText = "";
+const tfCommand = capturedCommands.get("tf");
+assert.ok(tfCommand, "tf command should be registered");
+await tfCommand.handler("show audit-endpoints", {
+	cwd,
+	isIdle: () => true,
+	ui: {
+		notify: (text: string, _kind?: string) => {
+			showNotifiedText = text;
+		},
+		input: async () => "",
+		custom: async () => ({} as any),
+	},
+} as any);
+const showObj = JSON.parse(showNotifiedText);
+assert.ok(showObj.definition && showObj.library, "show should return {definition, library}");
+assert.equal(showObj.library.purpose, "审计一组 API endpoint 是否缺少鉴权检查");
+assert.equal(showObj.library.reuseCount, 0);
+console.log("✓ /tf show → returned {definition, library{purpose,generality,reuseCount,…}}");
+
+// 4. list
+const listText = await execute({ action: "list" });
+assert.match(listText, /audit-endpoints.*审计.*g=.*used 0×/);
+console.log("✓ action=list → audit-endpoints shows purpose · g= · used ×");
+
+// 5. Verify the sidecar file actually exists on disk.
+const sidecar = path.join(cwd, ".pi", "taskflows", "audit-endpoints.meta.json");
+assert.ok(fs.existsSync(sidecar), "sidecar .meta.json should exist on disk");
+const sidecarObj = JSON.parse(fs.readFileSync(sidecar, "utf-8"));
+assert.equal(sidecarObj.purpose, "审计一组 API endpoint 是否缺少鉴权检查");
+assert.equal(sidecarObj.phaseSignature, "agent→map→reduce");
+assert.equal(sidecarObj.reuseCount, 0);
+console.log("✓ sidecar persisted to disk:", path.relative(cwd, sidecar));
+
+// 6. save also registered a shortcut command — assert it works.
+const shortcut = capturedCommands.get("tf:audit-endpoints");
+assert.ok(shortcut, "save should register tf:<name> shortcut command");
+await shortcut.handler("", {
+	isIdle: () => true,
+	ui: { notify: () => {} },
+} as any);
+console.log("✓ action=save registered tf:audit-endpoints shortcut command");
+
+fs.rmSync(cwd, { recursive: true, force: true });
+
+console.log("\n✅ PI E2E PASS — the reuse flywheel works end-to-end through the real pi extension.");
+console.log("   (save with purpose+tags → CJK-paraphrase search finds it → show/list expose metadata → sidecar on disk)");
+process.exit(0);

--- a/packages/pi-taskflow/test/init.test.ts
+++ b/packages/pi-taskflow/test/init.test.ts
@@ -873,7 +873,7 @@ test("runInteractiveInit: 'Configure taskflow preferences' → disable built-ins
 
 	// Verify the settings were actually written to disk
 	const saved = readSettings();
-	assert.deepEqual(saved.taskflow, { builtInAgents: false, syncBuiltinAgentsToProject: false, maxKeptRuns: 100, maxRunAgeDays: 30 });
+	assert.deepEqual(saved.taskflow, { builtInAgents: false, syncBuiltinAgentsToProject: false, maxKeptRuns: 100, maxRunAgeDays: 30, library: { enabled: true, scope: "both" } });
 });
 
 test("runInteractiveInit: 'Configure taskflow preferences' → enable + sync → preferences-saved", async () => {

--- a/packages/taskflow-core/src/agents.ts
+++ b/packages/taskflow-core/src/agents.ts
@@ -20,23 +20,31 @@ export interface TaskflowSettings {
 	maxKeptRuns: number;
 	/** Maximum age (days) for completed/failed runs. 0 disables age cleanup. */
 	maxRunAgeDays: number;
+	/** Library (reusable-flow asset layer) settings. RFC: docs/rfc-library-reuse.md */
+	library: LibrarySettings;
+	/** Optional embedding backend for semantic search (Phase 2). Undefined = structural/keyword fallback. */
+	embedder?: EmbedderConfig;
 }
 
 import { DEFAULT_KEPT_RUNS, DEFAULT_RUN_AGE_DAYS, writeFileAtomic } from "./store.ts";
+import { DEFAULT_LIBRARY_SETTINGS, type LibrarySettings } from "./library/types.ts";
 
 export const DEFAULT_TASKFLOW_SETTINGS: TaskflowSettings = {
 	builtInAgents: true,
 	syncBuiltinAgentsToProject: false,
 	maxKeptRuns: DEFAULT_KEPT_RUNS,
 	maxRunAgeDays: DEFAULT_RUN_AGE_DAYS,
+	library: { ...DEFAULT_LIBRARY_SETTINGS },
 };
 
 export function normalizeTaskflowSettings(raw: unknown): TaskflowSettings {
 	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-		return { ...DEFAULT_TASKFLOW_SETTINGS };
+		const base: TaskflowSettings = { ...DEFAULT_TASKFLOW_SETTINGS, library: { ...DEFAULT_LIBRARY_SETTINGS } };
+		return base;
 	}
 	const rec = raw as Record<string, unknown>;
-	return {
+	const embedder = normalizeEmbedderConfig(rec.embedder);
+	const base: TaskflowSettings = {
 		builtInAgents:
 			typeof rec.builtInAgents === "boolean"
 				? rec.builtInAgents
@@ -53,7 +61,56 @@ export function normalizeTaskflowSettings(raw: unknown): TaskflowSettings {
 			typeof rec.maxRunAgeDays === "number" && rec.maxRunAgeDays >= 0 && Number.isInteger(rec.maxRunAgeDays)
 				? rec.maxRunAgeDays
 				: DEFAULT_TASKFLOW_SETTINGS.maxRunAgeDays,
+		library: normalizeLibrarySettings(rec.library),
 	};
+	if (embedder) base.embedder = embedder;
+	return base;
+}
+
+/** RFC §4.2 config shapes: { kind: "http", url, model, apiKey?, dimensions? } or
+ *  { kind: "command", command: string[], timeoutMs? }. */
+export type EmbedderConfig =
+	| { kind: "http"; url: string; model: string; apiKey?: string; dimensions?: number }
+	| { kind: "command"; command: string[]; timeoutMs?: number };
+
+export function normalizeLibrarySettings(raw: unknown): LibrarySettings {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		return { ...DEFAULT_LIBRARY_SETTINGS };
+	}
+	const rec = raw as Record<string, unknown>;
+	const scope = rec.scope === "project" || rec.scope === "user" || rec.scope === "both" ? rec.scope : "both";
+	const searchWeights =
+		rec.searchWeights && typeof rec.searchWeights === "object"
+			? (rec.searchWeights as { semantic: number; structural: number; textual: number })
+			: undefined;
+	const maxFlows = typeof rec.maxFlows === "number" && rec.maxFlows > 0 ? rec.maxFlows : undefined;
+	return {
+		enabled: typeof rec.enabled === "boolean" ? rec.enabled : true,
+		scope,
+		searchWeights,
+		maxFlows,
+	};
+}
+
+export function normalizeEmbedderConfig(raw: unknown): EmbedderConfig | undefined {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined;
+	const rec = raw as Record<string, unknown>;
+	if (rec.kind === "http" && typeof rec.url === "string" && typeof rec.model === "string") {
+		const cfg: { kind: "http"; url: string; model: string; apiKey?: string; dimensions?: number } = {
+			kind: "http",
+			url: rec.url,
+			model: rec.model,
+		};
+		if (typeof rec.apiKey === "string") cfg.apiKey = rec.apiKey;
+		if (typeof rec.dimensions === "number") cfg.dimensions = rec.dimensions;
+		return cfg;
+	}
+	if (rec.kind === "command" && Array.isArray(rec.command) && rec.command.every((c) => typeof c === "string")) {
+		const cfg: { kind: "command"; command: string[]; timeoutMs?: number } = { kind: "command", command: rec.command as string[] };
+		if (typeof rec.timeoutMs === "number") cfg.timeoutMs = rec.timeoutMs;
+		return cfg;
+	}
+	return undefined;
 }
 
 export function shouldLoadBuiltinAgents(settings: TaskflowSettings = DEFAULT_TASKFLOW_SETTINGS): boolean {

--- a/packages/taskflow-core/src/index.ts
+++ b/packages/taskflow-core/src/index.ts
@@ -31,6 +31,9 @@ export * from "./compile.ts";
 // spawns it directly by file path.
 export * from "./store.ts";
 export * from "./agents.ts";
+export * from "./library/types.ts";
+export * from "./library/meta.ts";
+export * from "./library/search.ts";
 export * from "./runner-core.ts";
 export * from "./host/runner-types.ts";
 export * from "./flowir/index.ts";

--- a/packages/taskflow-core/src/library/meta.ts
+++ b/packages/taskflow-core/src/library/meta.ts
@@ -1,0 +1,169 @@
+/**
+ * Library — auto-derived structural metadata.
+ *
+ * Computed at save time (zero tokens, deterministic) and re-derived live at
+ * search time (RFC §5.2.2 staleness). No embedding logic here — that's Phase 2.
+ *
+ * Refs: docs/rfc-library-reuse.md §3.2 (phaseSignature), §3.3 (generality).
+ */
+
+import type { Taskflow } from "../schema.ts";
+import { topoLayers } from "../schema.ts";
+import type { FlowMeta } from "./types.ts";
+
+/** Topological phase-type signature, e.g. "agent→map→gate→reduce".
+ *  Parallel same-layer phases joined with "+". Uses topoLayers() for
+ *  deterministic ordering. */
+export function computePhaseSignature(def: Taskflow): string {
+	if (!Array.isArray(def.phases) || def.phases.length === 0) return "";
+	const layers = topoLayers(def.phases);
+	return layers
+		.map((layer) => layer.map((p) => p.type ?? "agent").join("+"))
+		.join("→");
+}
+
+export function countPhases(def: Taskflow): number {
+	return Array.isArray(def.phases) ? def.phases.length : 0;
+}
+
+/** Distinct agent names referenced across phases (sorted, stable). */
+export function extractAgentUsage(def: Taskflow): string[] {
+	if (!Array.isArray(def.phases)) return [];
+	const set = new Set<string>();
+	for (const p of def.phases) {
+		if (typeof p.agent === "string" && p.agent.trim()) set.add(p.agent.trim());
+		// parallel branches
+		if (Array.isArray((p as { branches?: unknown }).branches)) {
+			for (const b of (p as { branches?: Array<{ agent?: unknown }> }).branches ?? []) {
+				if (b && typeof b.agent === "string" && b.agent.trim()) set.add(b.agent.trim());
+			}
+		}
+	}
+	return Array.from(set).sort();
+}
+
+/** The literal-vs-placeholder character accounting used by generality.
+ *  Counts literal chars and placeholder chars across phase task/over/run/input. */
+interface ContentAccount {
+	literalChars: number;
+	placeholderChars: number;
+	placeholderRefs: number;
+	argCount: number;
+	hasDescription: boolean;
+	productionKnobs: number;
+}
+
+const PLACEHOLDER_RE = /\{(args|steps|item|previous|loop|reflexion)(\.[^}]{1,200})?\}/g;
+
+function accountContent(def: Taskflow): ContentAccount {
+	const acc: ContentAccount = {
+		literalChars: 0,
+		placeholderChars: 0,
+		placeholderRefs: 0,
+		argCount: 0,
+		hasDescription: typeof def.description === "string" && def.description.trim().length > 0,
+		productionKnobs: 0,
+	};
+
+	// args
+	if (def.args && typeof def.args === "object") {
+		acc.argCount = Object.keys(def.args as Record<string, unknown>).length;
+	}
+
+	// production knobs (cap 0.15, each +0.05)
+	if (def.budget) acc.productionKnobs += 0.05;
+	if (def.concurrency && typeof def.concurrency === "number") acc.productionKnobs += 0.05;
+	let sawRetry = false;
+	let sawExpect = false;
+	if (Array.isArray(def.phases)) {
+		for (const p of def.phases) {
+			if (p.retry) sawRetry = true;
+			if ((p as { expect?: unknown }).expect) sawExpect = true;
+		}
+	}
+	if (sawRetry) acc.productionKnobs += 0.05;
+	if (sawExpect) acc.productionKnobs += 0.05;
+	acc.productionKnobs = Math.min(0.15, acc.productionKnobs);
+
+	// scan phase string fields for literals vs placeholders
+	const scan = (s: unknown): void => {
+		if (typeof s !== "string") return;
+		PLACEHOLDER_RE.lastIndex = 0;
+		let m: RegExpExecArray | null;
+		let lastEnd = 0;
+		let placeholderCharsThis = 0;
+		let placeholderRefsThis = 0;
+		while ((m = PLACEHOLDER_RE.exec(s)) !== null) {
+			// literal chunk before this placeholder
+			acc.literalChars += m.index - lastEnd;
+			placeholderCharsThis += m[0].length;
+			placeholderRefsThis += 1;
+			lastEnd = m.index + m[0].length;
+		}
+		acc.literalChars += s.length - lastEnd;
+		acc.placeholderChars += placeholderCharsThis;
+		acc.placeholderRefs += placeholderRefsThis;
+	};
+
+	if (Array.isArray(def.phases)) {
+		for (const p of def.phases) {
+			scan(p.task);
+			scan((p as { over?: unknown }).over);
+			scan((p as { run?: unknown }).run);
+			scan((p as { input?: unknown }).input);
+			// parallel branch tasks
+			if (Array.isArray((p as { branches?: unknown }).branches)) {
+				for (const b of (p as { branches?: Array<{ task?: unknown }> }).branches ?? []) {
+					scan(b?.task);
+				}
+			}
+		}
+	}
+	return acc;
+}
+
+/** generality ∈ [0,1]. RFC §3.3 (v2 formula, A8 fix):
+ *  uses literalTokenRatio = literalChars/(literalChars+placeholderChars)
+ *  so verbose-but-parameterized flows aren't structurally penalized. */
+export function computeGenerality(def: Taskflow): number {
+	const a = accountContent(def);
+	const totalChars = a.literalChars + a.placeholderChars;
+	const literalTokenRatio = totalChars > 0 ? a.literalChars / totalChars : 1;
+	let g =
+		0.4 * (1 - literalTokenRatio) +
+		0.3 * Math.min(1, a.argCount / 3) +
+		0.3 * (a.hasDescription ? 0.3 : 0) +
+		a.productionKnobs;
+	if (g < 0) g = 0;
+	if (g > 1) g = 1;
+	return Math.round(g * 100) / 100;
+}
+
+/** Build a fresh FlowMeta from a def + optional agent-provided fields.
+ *  Used at save time. reuseCount starts at 0; version starts at 1. */
+export function deriveMeta(
+	def: Taskflow,
+	opts: { purpose?: string; tags?: string[]; notes?: string; derivedFrom?: string; prevMeta?: FlowMeta },
+): FlowMeta {
+	const now = Date.now();
+	const prev = opts.prevMeta;
+	return {
+		schemaVersion: 1,
+		purpose: opts.purpose,
+		tags: opts.tags,
+		notes: opts.notes,
+		phaseSignature: computePhaseSignature(def),
+		phaseCount: countPhases(def),
+		agentUsage: extractAgentUsage(def),
+		generality: computeGenerality(def),
+		reuseCount: prev?.reuseCount ?? 0,
+		lastUsedAt: prev?.lastUsedAt ?? null,
+		createdAt: prev?.createdAt ?? now,
+		version: prev ? prev.version + 1 : 1,
+		derivedFrom: opts.derivedFrom,
+		embedding: prev?.embedding ?? null,
+		embeddingModel: prev?.embeddingModel,
+		embeddingDim: prev?.embeddingDim,
+		embeddedAt: prev?.embeddedAt ?? null,
+	};
+}

--- a/packages/taskflow-core/src/library/search.ts
+++ b/packages/taskflow-core/src/library/search.ts
@@ -1,0 +1,332 @@
+/**
+ * Library — search ranking (structural + keyword; Phase 1).
+ *
+ * Phase 2 adds the embedding/cosine path; the seam (LibraryDeps.embedder) is
+ * already in place but left unused here. When no embedder is configured OR
+ * structureOnly is set, search degrades to keyword + structural ranking.
+ *
+ * Refs: docs/rfc-library-reuse.md §5.2 (blend), §5.2.1 (structScore),
+ * §5.2.2 (staleness), §5.3 (why/reuseHint templates).
+ */
+
+import { getFlow, listFlows, readMeta } from "../store.ts";
+import type { Taskflow } from "../schema.ts";
+import {
+	computeGenerality,
+	computePhaseSignature,
+	countPhases,
+	extractAgentUsage,
+} from "./meta.ts";
+import type {
+	LibraryDeps,
+	ResolvedCandidate,
+	SearchInput,
+	SearchResponse,
+	SearchResult,
+} from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Levenshtein (RFC §5.2.1)
+// ---------------------------------------------------------------------------
+
+/** Standard Levenshtein edit distance (insert/delete/replace cost 1).
+ *  O(m·n) DP; signature strings are short (<50 chars) so cost is negligible. */
+export function levenshtein(a: string, b: string): number {
+	if (a === b) return 0;
+	if (a.length === 0) return b.length;
+	if (b.length === 0) return a.length;
+	const m = a.length;
+	const n = b.length;
+	// Two rolling rows; allocate fresh each call (signatures are tiny).
+	let prev = new Array<number>(n + 1);
+	for (let j = 0; j <= n; j++) prev[j] = j;
+	for (let i = 1; i <= m; i++) {
+		const curr = new Array<number>(n + 1);
+		curr[0] = i;
+		for (let j = 1; j <= n; j++) {
+			const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+			curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+		}
+		prev = curr;
+	}
+	return prev[n];
+}
+
+// ---------------------------------------------------------------------------
+// Candidate resolution (RFC §5.2.2 staleness detection)
+// ---------------------------------------------------------------------------
+
+/** Resolve a saved flow + its sidecar into a candidate whose structural fields
+ *  are ALWAYS freshly derived from the current def, and whose embedding is only
+ *  trusted when the sidecar's phaseSignature matches the fresh one. */
+export function resolveCandidate(
+	def: Taskflow,
+	scope: "user" | "project",
+	name: string,
+	sidecar: ReturnType<typeof readMeta>,
+): ResolvedCandidate {
+	const freshSig = computePhaseSignature(def);
+	const freshGen = computeGenerality(def);
+	const freshAgents = extractAgentUsage(def);
+	const freshCount = countPhases(def);
+
+	if (!sidecar) {
+		return {
+			name,
+			scope,
+			def,
+			phaseSignature: freshSig,
+			phaseCount: freshCount,
+			agentUsage: freshAgents,
+			generality: freshGen,
+			reuseCount: 0,
+			version: 1,
+			embedding: null,
+			embeddingStale: true,
+		};
+	}
+
+	const sigMatch = sidecar.phaseSignature === freshSig;
+	return {
+		name,
+		scope,
+		def,
+		phaseSignature: freshSig,
+		phaseCount: freshCount,
+		agentUsage: freshAgents,
+		generality: freshGen,
+		purpose: sidecar.purpose,
+		tags: sidecar.tags,
+		notes: sidecar.notes,
+		reuseCount: sidecar.reuseCount ?? 0,
+		version: sidecar.version ?? 1,
+		derivedFrom: sidecar.derivedFrom,
+		embedding: sigMatch ? sidecar.embedding ?? null : null,
+		embeddingStale: !sigMatch,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+/** structScore ∈ [0,1]. RFC §5.2.1: 0.7*sigSim + 0.3*countPenalty. */
+function computeStructScore(
+	query: { phaseSignature: string; phaseCount: number },
+	cand: { phaseSignature: string; phaseCount: number },
+): number {
+	let sigSim = 0;
+	if (cand.phaseSignature && query.phaseSignature) {
+		const d = levenshtein(query.phaseSignature, cand.phaseSignature);
+		const denom = Math.max(query.phaseSignature.length, cand.phaseSignature.length, 1);
+		sigSim = 1 - d / denom;
+		if (sigSim < 0) sigSim = 0;
+	}
+	let countPenalty = 0;
+	if (query.phaseCount > 0 && cand.phaseCount > 0) {
+		const diff = Math.abs(query.phaseCount - cand.phaseCount);
+		countPenalty = 1 - Math.min(1, diff / Math.max(query.phaseCount, cand.phaseCount));
+	}
+	return 0.7 * sigSim + 0.3 * countPenalty;
+}
+
+/** textScore ∈ [0,1]. Token-overlap between query and the flow's text fields
+ *  (name + purpose + tags + phase task text). CJK-aware: queries tokenized on
+ *  whitespace AND matched as substrings, so a Chinese query token like "鉴权"
+ *  still matches a purpose containing "...缺少鉴权检查..." (which whitespace
+ *  alone would never split out). */
+function computeTextScore(queryTokens: string[], cand: {
+	name: string;
+	purpose?: string;
+	tags?: string[];
+	phaseTaskText: string;
+}): number {
+	if (queryTokens.length === 0) return 0;
+	const fieldText = (
+		(cand.name ?? "") +
+		" " +
+		(cand.purpose ?? "") +
+		" " +
+		(cand.tags ?? []).join(" ") +
+		" " +
+		cand.phaseTaskText
+	).toLowerCase();
+	if (!fieldText.trim()) return 0;
+	// Substring match per query token (CJK-friendly). Longer tokens weigh more
+	// (they carry more signal) so e.g. a 2-char Chinese term counts more than a
+	// 2-char English one only marginally; this keeps the [0,1] shape intuitive.
+	let hits = 0;
+	for (const t of queryTokens) {
+		if (!t) continue;
+		if (fieldText.includes(t)) hits++;
+	}
+	return hits / queryTokens.length;
+}
+
+function tokenize(query: string): string[] {
+	return query
+		.toLowerCase()
+		.split(/[^\p{L}\p{N}]+/u)
+		.filter((t) => t.length > 1);
+}
+
+function phaseTaskText(def: Taskflow): string {
+	if (!Array.isArray(def.phases)) return "";
+	const parts: string[] = [];
+	for (const p of def.phases) {
+		if (typeof p.task === "string") parts.push(p.task);
+		if (Array.isArray((p as { branches?: unknown }).branches)) {
+			for (const b of (p as { branches?: Array<{ task?: string }> }).branches ?? []) {
+				if (b?.task) parts.push(b.task);
+			}
+		}
+	}
+	return parts.join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// why / reuseHint templates (RFC §5.3, Tier 1, zero-token)
+// ---------------------------------------------------------------------------
+
+function buildWhy(s: {
+	semScore?: number;
+	structScore: number;
+	textScore: number;
+	searchMode: "semantic" | "structural" | "mixed";
+}): string {
+	const hits: string[] = [];
+	if ((s.searchMode === "semantic" || s.searchMode === "mixed") && s.semScore != null && s.semScore > 0.7) {
+		hits.push(`语义命中(sem=${s.semScore.toFixed(2)})`);
+	}
+	if (s.structScore > 0.8) hits.push(`结构一致(struct=${s.structScore.toFixed(2)})`);
+	if (s.textScore > 0.3) hits.push(`关键词匹配(text=${s.textScore.toFixed(2)})`);
+	return hits.length > 0 ? hits.join(" + ") : "低分命中，建议检查";
+}
+
+function buildReuseHint(r: { score: number; argCount: number }): string {
+	if (r.score >= 0.8) return `直接复用${r.argCount > 0 ? `，注意 ${r.argCount} 个 args 参数` : ""}`;
+	if (r.score >= 0.5) return `结构相似，建议 copy + 泛化后使用`;
+	return `低相关度，建议从头编写或大幅改写`;
+}
+
+// ---------------------------------------------------------------------------
+// searchLibrary
+// ---------------------------------------------------------------------------
+
+function argCountOf(def: Taskflow): number {
+	return def.args && typeof def.args === "object" ? Object.keys(def.args as Record<string, unknown>).length : 0;
+}
+
+/** Search the library. Returns ranked top-N. Degrades to structural/keyword
+ *  when no embedder is configured or structureOnly is requested. */
+export async function searchLibrary(deps: LibraryDeps, input: SearchInput): Promise<SearchResponse> {
+	const limit = Math.min(20, Math.max(1, input.limit ?? 5));
+	const minScore = input.minScore ?? 0;
+	const scope = input.scope ?? deps.settings.scope ?? "both";
+
+	// gather candidates
+	const flows = listFlows(deps.cwd).filter((f) => {
+		if (scope === "both") return true;
+		return f.scope === scope;
+	});
+
+	const queryTokens = tokenize(input.query);
+
+	// embed the query if an embedder is available and not structureOnly
+	let queryVec: number[] | null = null;
+	const hasEmbedder = !!deps.embedder && !input.structureOnly;
+	if (hasEmbedder && deps.embedder) {
+		try {
+			queryVec = await deps.embedder.embed(input.query);
+		} catch {
+			queryVec = null; // degrade
+		}
+	}
+
+	const scored: Array<{ cand: ResolvedCandidate; score: number; semScore?: number; structScore: number; textScore: number }> = [];
+	for (const f of flows) {
+		const sidecar = readMeta(deps.cwd, f.name);
+		const cand = resolveCandidate(f.def, f.scope, f.name, sidecar);
+		const qShape = {
+			phaseSignature: input.phaseSignatureHint ?? "",
+			phaseCount: input.phaseCountHint ?? 0,
+		};
+		const structScore = computeStructScore(qShape, cand);
+		const textScore = computeTextScore(queryTokens, {
+			name: cand.name,
+			purpose: cand.purpose,
+			tags: cand.tags,
+			phaseTaskText: phaseTaskText(cand.def),
+		});
+
+		let score: number;
+		let semScore: number | undefined;
+		const hasVectors = queryVec != null && cand.embedding != null && !cand.embeddingStale;
+		if (hasVectors && queryVec && cand.embedding) {
+			semScore = cosine(queryVec, cand.embedding);
+			score = 0.6 * semScore + 0.25 * structScore + 0.15 * textScore;
+		} else {
+			score = 0.6 * textScore + 0.4 * structScore;
+		}
+		if (score < minScore) continue;
+		if (score <= 0) continue; // zero-relevance results are noise; don't surface them
+		scored.push({ cand, score: Math.round(score * 100) / 100, semScore, structScore, textScore });
+	}
+
+	scored.sort((a, b) => b.score - a.score);
+	const top = scored.slice(0, limit);
+
+	const withVectors = top.filter((s) => s.cand.embedding != null && !s.cand.embeddingStale).length;
+	let searchMode: "semantic" | "structural" | "mixed";
+	if (input.structureOnly || !deps.embedder || withVectors === 0) searchMode = "structural";
+	else if (withVectors === top.length) searchMode = "semantic";
+	else searchMode = "mixed";
+
+	const results: SearchResult[] = top.map((s) => ({
+		name: s.cand.name,
+		scope: s.cand.scope,
+		purpose: s.cand.purpose,
+		tags: s.cand.tags,
+		phaseSignature: s.cand.phaseSignature,
+		phaseCount: s.cand.phaseCount,
+		generality: s.cand.generality,
+		reuseCount: s.cand.reuseCount,
+		version: s.cand.version,
+		score: s.score,
+		why: buildWhy({ semScore: s.semScore, structScore: s.structScore, textScore: s.textScore, searchMode }),
+		reuseHint: buildReuseHint({ score: s.score, argCount: argCountOf(s.cand.def) }),
+	}));
+
+	return {
+		results,
+		searchMode,
+		embedder: deps.embedder?.model,
+		counts: { scanned: flows.length, withVectors },
+	};
+}
+
+/** Pure cosine similarity. Zero-dep. Accepts non-normalized vectors. */
+export function cosine(a: number[], b: number[]): number {
+	const n = Math.min(a.length, b.length);
+	if (n === 0) return 0;
+	let dot = 0;
+	let normA = 0;
+	let normB = 0;
+	for (let i = 0; i < n; i++) {
+		const x = a[i];
+		const y = b[i];
+		if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+		dot += x * y;
+		normA += x * x;
+		normB += y * y;
+	}
+	if (normA === 0 || normB === 0) return 0;
+	return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/** Bump reuseCount for a flow by name (RFC §6 reuse flywheel).
+ *  Phase 1: structural-only; the caller (tool handler) decides whether to
+ *  bump based on a `reusedFromSearch` flag. Returns the new count or null if
+ *  the flow has no sidecar yet. The actual sidecar write is done by
+ *  `bumpReuseInSidecar` in store.ts under withLock. */
+export { getFlow };

--- a/packages/taskflow-core/src/library/types.ts
+++ b/packages/taskflow-core/src/library/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Library — reusable-flow asset layer types.
+ *
+ * The library lets taskflow accumulate, retrieve, and iteratively generalize
+ * saved flows. Phase 1 (this module) defines the data shapes and the
+ * host-neutral interfaces; the runtime logic (meta derivation, search ranking)
+ * lives in `meta.ts` / `search.ts`, and persistence (sidecar `.meta.json`)
+ * lives in `store.ts`.
+ *
+ * Design refs: docs/rfc-library-reuse.md (§3 data format, §4 embedder, §5
+ * search). Embedding support is Phase 2 — Phase 1 ships with structural /
+ * keyword search only and every embedding field is optional.
+ */
+
+import type { Taskflow } from "../schema.ts";
+
+/** Library-side settings, nested under `settings.json → taskflow.library`. */
+export interface LibrarySettings {
+	/** Master switch. Default true. When false, search/save-meta are no-ops. */
+	enabled: boolean;
+	/** Which scopes to search: "project" | "user" | "both" (default both). */
+	scope: "project" | "user" | "both";
+	/** Optional blend weights for mixed search ranking (Phase 2). */
+	searchWeights?: { semantic: number; structural: number; textual: number };
+	/** Optional Phase-3 auto-prune threshold. */
+	maxFlows?: number;
+}
+
+export const DEFAULT_LIBRARY_SETTINGS: LibrarySettings = {
+	enabled: true,
+	scope: "both",
+};
+
+/** The sidecar `.meta.json` record. Persisted next to a flow file. */
+export interface FlowMeta {
+	schemaVersion: 1;
+
+	/** Agent-provided (optional). */
+	purpose?: string;
+	tags?: string[];
+	notes?: string;
+
+	/** Auto-derived at save time. */
+	phaseSignature: string;
+	phaseCount: number;
+	agentUsage: string[];
+	generality: number;
+	argShape?: Record<string, string>; // Phase 3 only; derived speculatively, not used in ranking
+
+	/** Reuse flywheel. */
+	reuseCount: number;
+	lastUsedAt: number | null;
+	createdAt: number;
+	version: number;
+	derivedFrom?: string; // "<name>@v<n>" lineage
+
+	/** Embedding (Phase 2; always optional / may be null). */
+	embeddingModel?: string;
+	embeddingDim?: number;
+	embedding?: number[] | null;
+	embeddedAt?: number | null;
+}
+
+/** A candidate resolved for search: live-derived structural fields + trusted
+ *  sidecar fields (purpose/tags/...) + embedding gated on signature match.
+ *  (RFC §5.2.2 staleness detection.) */
+export interface ResolvedCandidate {
+	name: string;
+	scope: "user" | "project";
+	def: Taskflow;
+
+	// live-derived (always fresh)
+	phaseSignature: string;
+	phaseCount: number;
+	agentUsage: string[];
+	generality: number;
+
+	// from sidecar (trusted; agent-provided)
+	purpose?: string;
+	tags?: string[];
+	notes?: string;
+	reuseCount: number;
+	version: number;
+	derivedFrom?: string;
+
+	// embedding: only trusted when signature matches the live-derived one
+	embedding: number[] | null;
+	embeddingStale: boolean;
+}
+
+export interface SearchResult {
+	name: string;
+	scope: "user" | "project";
+	purpose?: string;
+	tags?: string[];
+	phaseSignature: string;
+	phaseCount: number;
+	generality: number;
+	reuseCount: number;
+	version: number;
+	score: number;
+	why: string;
+	reuseHint: string;
+}
+
+export interface SearchResponse {
+	results: SearchResult[];
+	searchMode: "semantic" | "structural" | "mixed";
+	embedder?: string;
+	counts: { scanned: number; withVectors: number };
+}
+
+/** Input to searchLibrary(). */
+export interface SearchInput {
+	query: string;
+	limit?: number; // default 5, max 20
+	structureOnly?: boolean;
+	minScore?: number; // 0-1
+	scope?: "project" | "user" | "both";
+	phaseSignatureHint?: string;
+	phaseCountHint?: number;
+}
+
+/** The minimal host-neutral dependency the library functions need.
+ *  Embedder is Phase 2; Phase 1 leaves it undefined and search degrades to
+ *  structural/keyword (RFC §4.3, A2: stays OUT of RuntimeDeps). */
+export interface LibraryDeps {
+	embedder?: {
+		embed(text: string): Promise<number[]>;
+		readonly model: string;
+		readonly dim: number;
+	};
+	settings: LibrarySettings;
+	cwd: string;
+}

--- a/packages/taskflow-core/src/store.ts
+++ b/packages/taskflow-core/src/store.ts
@@ -25,6 +25,7 @@ import type { Taskflow } from "./schema.ts";
 import type { UsageStats } from "./usage.ts";
 import type { DeclaredDeps } from "./flowir/meta.ts";
 import type { ScorerResult } from "./scorers.ts";
+import type { FlowMeta } from "./library/types.ts";
 
 export interface SavedFlow {
 	name: string;
@@ -671,6 +672,8 @@ export function listFlows(cwd: string): SavedFlow[] {
 		}
 		for (const name of entries) {
 			if (!name.endsWith(".json")) continue;
+			// A1: sidecar .meta.json must never be scanned as a candidate flow.
+			if (name.endsWith(".meta.json")) continue;
 			const flow = readFlowFile(path.join(dir, name), scope);
 			if (flow) map.set(flow.name, flow); // project after user → overrides
 		}
@@ -710,6 +713,109 @@ export function saveFlow(
 	return { filePath };
 }
 
+// ---------------------------------------------------------------------------
+// Library sidecar (.meta.json) — RFC docs/rfc-library-reuse.md
+// ---------------------------------------------------------------------------
+
+/** Path to a flow's library sidecar. Uses the SAME safeFlowDirName as the flow
+ *  file itself (N1 fix) so path-safety normalization is consistent. */
+export function sidecarPathFor(cwd: string, flowName: string, scope: "user" | "project" = "project"): string {
+	const dir = scope === "user" ? userFlowsDir() : (findProjectFlowsDir(cwd) ?? path.join(cwd, ".pi", "taskflows"));
+	return path.join(dir, `${safeFlowDirName(flowName)}.meta.json`);
+}
+
+/** Path to a flow's sidecar given its flow-file directory (avoids re-resolving
+ *  scope when we already have the flow's filePath from listFlows). */
+function sidecarPathIn(flowFilePath: string): string {
+	return flowFilePath.replace(/\.json$/, ".meta.json");
+}
+
+/** Read a flow's library sidecar. Returns null if missing/unparseable. */
+export function readMeta(cwd: string, flowName: string): FlowMeta | null {
+	// Try project scope first, then user — mirrors getFlow's resolution.
+	for (const scope of ["project", "user"] as const) {
+		const p = sidecarPathFor(cwd, flowName, scope);
+		try {
+			if (!fs.existsSync(p)) continue;
+			const raw = fs.readFileSync(p, "utf-8");
+			const parsed = safeParse(raw);
+			if (parsed && typeof parsed === "object") return parsed as FlowMeta;
+			return null;
+		} catch {
+			continue;
+		}
+	}
+	return null;
+}
+
+/** Read a sidecar next to a specific flow file (avoids name→scope lookup when
+ *  we already have the SavedFlow from listFlows). */
+export function readMetaNextTo(flowFilePath: string): FlowMeta | null {
+	try {
+		const p = sidecarPathIn(flowFilePath);
+		if (!fs.existsSync(p)) return null;
+		const raw = fs.readFileSync(p, "utf-8");
+		const parsed = safeParse(raw);
+		return parsed && typeof parsed === "object" ? (parsed as FlowMeta) : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Write a flow + its sidecar atomically (same withLock critical section — R2).
+ *  Embedding (Phase 2) is computed by the caller BEFORE this call and passed in
+ *  via meta; this function does only synchronous I/O under the lock (R2R3). */
+export function saveFlowWithMeta(
+	cwd: string,
+	def: Taskflow,
+	meta: FlowMeta,
+	scope: "user" | "project" = "project",
+): { filePath: string; metaPath: string } {
+	const dir = scope === "user" ? userFlowsDir() : (findProjectFlowsDir(cwd, true) ?? path.join(cwd, ".pi", "taskflows"));
+	if (!def.name || def.name.trim().length === 0) throw new Error("Flow name must not be empty");
+	fs.mkdirSync(dir, { recursive: true });
+	const safe = safeFlowDirName(def.name);
+	const filePath = path.join(dir, `${safe}.json`);
+	const metaPath = path.join(dir, `${safe}.meta.json`);
+	const fileLockPath = filePath + ".lock"; // shared lock key for flow+sidecar (R2R5)
+	withLock(fileLockPath, () => {
+		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`);
+		writeFileAtomic(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
+	});
+	return { filePath, metaPath };
+}
+
+/** Bump reuseCount/lastUsedAt for a flow's sidecar. Idempotent under the flow
+ *  lock. If no sidecar exists yet, creates a minimal one carrying just the
+ *  reuse bookkeeping (structural fields are filled next time the flow is
+ *  re-saved with deriveMeta). Returns the new reuseCount, or null if the flow
+ *  itself doesn't exist. */
+export function bumpReuseInSidecar(cwd: string, flowName: string): number | null {
+	const saved = getFlow(cwd, flowName);
+	if (!saved) return null;
+	const metaPath = sidecarPathIn(saved.filePath);
+	const lockPath = saved.filePath + ".lock";
+	return withLock(lockPath, () => {
+		const existing = readMetaNextTo(saved.filePath);
+		const now = Date.now();
+		const updated: FlowMeta = existing
+			? { ...existing, reuseCount: (existing.reuseCount ?? 0) + 1, lastUsedAt: now }
+			: {
+					schemaVersion: 1,
+					phaseSignature: "",
+					phaseCount: 0,
+					agentUsage: [],
+					generality: 0,
+					reuseCount: 1,
+					lastUsedAt: now,
+					createdAt: now,
+					version: 1,
+					embedding: null,
+			  };
+		writeFileAtomic(metaPath, `${JSON.stringify(updated, null, 2)}\n`);
+		return updated.reuseCount;
+	});
+}
 
 // --- Run state ---
 

--- a/packages/taskflow-core/test/agents.test.ts
+++ b/packages/taskflow-core/test/agents.test.ts
@@ -100,6 +100,7 @@ test("normalizeTaskflowSettings: accepts only boolean preference values", () => 
 		syncBuiltinAgentsToProject: true,
 		maxKeptRuns: DEFAULT_TASKFLOW_SETTINGS.maxKeptRuns,
 		maxRunAgeDays: DEFAULT_TASKFLOW_SETTINGS.maxRunAgeDays,
+		library: { enabled: true, scope: "both" },
 	});
 	assert.deepEqual(normalizeTaskflowSettings({ builtInAgents: "false", syncBuiltinAgentsToProject: "true" }), DEFAULT_TASKFLOW_SETTINGS);
 });
@@ -481,7 +482,7 @@ test("readSubagentSettings: parses taskflow preferences from settings.json", () 
 	);
 
 	const settings = readSubagentSettings();
-	assert.deepEqual(settings.taskflow, { builtInAgents: false, syncBuiltinAgentsToProject: false, maxKeptRuns: 100, maxRunAgeDays: 30 });
+	assert.deepEqual(settings.taskflow, { builtInAgents: false, syncBuiltinAgentsToProject: false, maxKeptRuns: 100, maxRunAgeDays: 30, library: { enabled: true, scope: "both" } });
 });
 
 test("readSubagentSettings: malformed taskflow preferences fall back to defaults", () => {

--- a/packages/taskflow-core/test/library-meta.test.ts
+++ b/packages/taskflow-core/test/library-meta.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Library meta derivation: phaseSignature, generality, agentUsage, phaseCount.
+ * Refs: docs/rfc-library-reuse.md §3.2 (phaseSignature), §3.3 (generality v2).
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Taskflow } from "../src/schema.ts";
+import {
+	computeGenerality,
+	computePhaseSignature,
+	countPhases,
+	deriveMeta,
+	extractAgentUsage,
+} from "../src/library/meta.ts";
+
+function flow(over: Partial<Taskflow>): Taskflow {
+	return {
+		name: over.name ?? "t",
+		phases: over.phases ?? [],
+		...over,
+	} as Taskflow;
+}
+
+// ---------------------------------------------------------------------------
+// phaseSignature
+// ---------------------------------------------------------------------------
+
+test("phaseSignature: linear chain", () => {
+	const f = flow({
+		phases: [
+			{ id: "a", type: "agent", task: "x" },
+			{ id: "b", type: "map", over: "{items}", task: "y", dependsOn: ["a"] },
+			{ id: "c", type: "gate", task: "z", dependsOn: ["b"] },
+			{ id: "d", type: "reduce", from: ["c"], task: "w", dependsOn: ["c"] },
+		],
+	});
+	assert.equal(computePhaseSignature(f), "agent→map→gate→reduce");
+	assert.equal(countPhases(f), 4);
+});
+
+test("phaseSignature: parallel same-layer joined with +", () => {
+	const f = flow({
+		phases: [
+			{ id: "a", type: "agent", task: "x" },
+			{ id: "b", type: "agent", task: "y" },
+			{ id: "c", type: "agent", task: "z", dependsOn: ["a", "b"] },
+		],
+	});
+	// a and b are layer 0 (parallel) → "agent+agent"; c is layer 1.
+	assert.equal(computePhaseSignature(f), "agent+agent→agent");
+});
+
+test("phaseSignature: empty flow", () => {
+	assert.equal(computePhaseSignature(flow({})), "");
+	assert.equal(countPhases(flow({})), 0);
+});
+
+// ---------------------------------------------------------------------------
+// agentUsage
+// ---------------------------------------------------------------------------
+
+test("agentUsage: distinct, sorted, includes parallel branches", () => {
+	const f = flow({
+		phases: [
+			{ id: "a", type: "agent", agent: "scout", task: "x" },
+			{ id: "b", type: "parallel", branches: [{ task: "y", agent: "analyst" }, { task: "y2", agent: "scout" }] },
+			{ id: "c", type: "agent", agent: "writer", task: "z", dependsOn: ["b"] },
+		],
+	});
+	assert.deepEqual(extractAgentUsage(f), ["analyst", "scout", "writer"]);
+});
+
+// ---------------------------------------------------------------------------
+// generality (v2 formula — RFC §3.3, A8 fix)
+// ---------------------------------------------------------------------------
+
+test("generality: fully-hardcoded flow scores low", () => {
+	const f = flow({
+		phases: [{ id: "a", type: "agent", task: "review the auth code under src/api/users.ts for missing checks" }],
+	});
+	// 100% literal, 0 placeholders, 0 args, no description → low generality.
+	assert.ok(computeGenerality(f) <= 0.05, `expected <=0.05, got ${computeGenerality(f)}`);
+});
+
+test("generality: highly parameterized flow scores high", () => {
+	const f = flow({
+		description: "audit endpoints",
+		args: { dir: { default: "src/routes" }, threshold: { default: 0.5 } },
+		budget: { maxUSD: 2 },
+		phases: [
+			{ id: "d", type: "agent", agent: "scout", task: "List endpoints under {args.dir}. Output JSON array.", output: "json" },
+			{ id: "m", type: "map", over: "{steps.d.json}", as: "item", agent: "analyst", task: "Audit {item.route} ({item.file}).", dependsOn: ["d"] },
+			{ id: "r", type: "reduce", from: ["m"], agent: "writer", task: "Write report:\n{steps.m.output}", dependsOn: ["m"], final: true },
+		],
+	});
+	const g = computeGenerality(f);
+	assert.ok(g >= 0.5, `expected parameterized flow >=0.5, got ${g}`);
+});
+
+test("generality: v2 formula softens (but does not eliminate) the verbosity penalty (A8)", () => {
+	// Two flows with identical placeholder/arg structure but different literal verbosity.
+	// v1 punished the verbose one ~41% via literalChars-in-denominator; v2 normalizes
+	// by total content so the gap narrows (more literal content still lowers the ratio,
+	// which is defensible — more hardcoded prose = less generic — but the penalty is mild).
+	const terse = flow({
+		description: "audit",
+		args: { dir: { default: "x" } },
+		phases: [{ id: "a", type: "agent", task: "scan {args.dir}", agent: "scout" }],
+	});
+	const verbose = flow({
+		description: "audit",
+		args: { dir: { default: "x" } },
+		phases: [{ id: "a", type: "agent", task: "Carefully and thoroughly scan {args.dir} and produce a detailed structured report of everything found there.", agent: "scout" }],
+	});
+	const gt = computeGenerality(terse);
+	const gv = computeGenerality(verbose);
+	// v2: gap is mild (within 0.3), NOT the ~0.4 collapse v1 produced.
+	assert.ok(Math.abs(gt - gv) <= 0.3, `v2 gap should be mild: terse=${gt}, verbose=${gv}`);
+	// and both still score reasonably above an all-hardcoded flow
+	assert.ok(gv > 0.1, `verbose-but-parameterized should still score >0.1, got ${gv}`);
+});
+
+// ---------------------------------------------------------------------------
+// deriveMeta
+// ---------------------------------------------------------------------------
+
+test("deriveMeta: fresh meta has reuseCount 0, version 1", () => {
+	const f = flow({
+		phases: [{ id: "a", type: "agent", task: "{args.x}", agent: "scout" }],
+		args: { x: { default: "1" } },
+	});
+	const m = deriveMeta(f, { purpose: "demo", tags: ["audit"] });
+	assert.equal(m.schemaVersion, 1);
+	assert.equal(m.reuseCount, 0);
+	assert.equal(m.version, 1);
+	assert.equal(m.purpose, "demo");
+	assert.deepEqual(m.tags, ["audit"]);
+	assert.equal(m.phaseSignature, "agent");
+	assert.equal(m.phaseCount, 1);
+	assert.equal(m.embedding, null);
+	assert.ok(m.createdAt > 0);
+});
+
+test("deriveMeta: bumps version + preserves reuseCount when prevMeta given", () => {
+	const f = flow({ phases: [{ id: "a", type: "agent", task: "x" }] });
+	const prev = deriveMeta(f, {});
+	prev.reuseCount = 5;
+	const next = deriveMeta(f, { prevMeta: prev });
+	assert.equal(next.version, 2);
+	assert.equal(next.reuseCount, 5); // preserved across re-save
+	assert.equal(next.phaseSignature, "agent");
+});

--- a/packages/taskflow-core/test/library-search.test.ts
+++ b/packages/taskflow-core/test/library-search.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Library search ranking: levenshtein, structScore, textScore, cosine,
+ * staleness resolution, searchLibrary (structural mode). Phase 1 has no
+ * embedder, so all tests exercise the structural/keyword fallback.
+ * Refs: docs/rfc-library-reuse.md §5.2, §5.2.1, §5.2.2.
+ */
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import type { Taskflow } from "../src/schema.ts";
+import { saveFlowWithMeta } from "../src/store.ts";
+import { deriveMeta } from "../src/library/meta.ts";
+import { cosine, levenshtein, resolveCandidate, searchLibrary } from "../src/library/search.ts";
+import type { LibraryDeps } from "../src/library/types.ts";
+
+function makeTmpCwd(): string {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-lib-search-"));
+	fs.mkdirSync(path.join(tmp, ".pi", "taskflows"), { recursive: true });
+	return tmp;
+}
+
+// ---------------------------------------------------------------------------
+// levenshtein (§5.2.1)
+// ---------------------------------------------------------------------------
+
+test("levenshtein: basics", () => {
+	assert.equal(levenshtein("", ""), 0);
+	assert.equal(levenshtein("abc", "abc"), 0);
+	assert.equal(levenshtein("abc", "abd"), 1);
+	assert.equal(levenshtein("agent→map→reduce", "agent→map→reduce"), 0);
+	// appending "→gate" costs 5 chars (the arrow is multi-code-unit but length tracks JS string length)
+	assert.equal(levenshtein("agent→map", "agent→map→gate"), 5);
+});
+
+// ---------------------------------------------------------------------------
+// cosine (§4.1)
+// ---------------------------------------------------------------------------
+
+test("cosine: identical vectors → 1", () => {
+	assert.ok(Math.abs(cosine([1, 2, 3], [1, 2, 3]) - 1) < 1e-9);
+});
+test("cosine: orthogonal → 0", () => {
+	assert.ok(Math.abs(cosine([1, 0], [0, 1])) < 1e-9);
+});
+test("cosine: handles non-normalized input", () => {
+	// [1,1] and [2,2] point the same direction → 1.0
+	assert.ok(Math.abs(cosine([1, 1], [2, 2]) - 1) < 1e-9);
+});
+test("cosine: NaN/Infinity values skipped (graceful)", () => {
+	const c = cosine([1, NaN, 2], [1, 1, 2]);
+	assert.ok(Number.isFinite(c));
+});
+
+// ---------------------------------------------------------------------------
+// resolveCandidate staleness (§5.2.2)
+// ---------------------------------------------------------------------------
+
+test("resolveCandidate: no sidecar → embedding null, structural fields live-derived", () => {
+	const def: Taskflow = {
+		name: "x",
+		phases: [{ id: "a", type: "agent", task: "{args.x}" }],
+		args: { x: { default: "1" } },
+	} as Taskflow;
+	const c = resolveCandidate(def, "project", "x", null);
+	assert.equal(c.embedding, null);
+	assert.equal(c.embeddingStale, true);
+	assert.equal(c.phaseSignature, "agent");
+	assert.equal(c.reuseCount, 0);
+});
+
+test("resolveCandidate: signature mismatch → embedding treated stale even if sidecar has one", () => {
+	const def: Taskflow = { name: "x", phases: [{ id: "a", type: "map", over: "{items}", task: "y" }] } as Taskflow;
+	// sidecar claims agent signature (old) + an embedding; live def is now a map.
+	const sidecar = {
+		schemaVersion: 1 as const,
+		phaseSignature: "agent", // mismatch with live "map"
+		phaseCount: 1,
+		agentUsage: [],
+		generality: 0.5,
+		reuseCount: 2,
+		lastUsedAt: 1,
+		createdAt: 1,
+		version: 1,
+		embedding: [0.1, 0.2, 0.3],
+		embeddingModel: "m",
+		embeddingDim: 3,
+		embeddedAt: 1,
+	};
+	const c = resolveCandidate(def, "project", "x", sidecar);
+	// structural fields always fresh:
+	assert.equal(c.phaseSignature, "map");
+	// embedding gated out because signatures differ:
+	assert.equal(c.embedding, null);
+	assert.equal(c.embeddingStale, true);
+	// but reuseCount (sidecar bookkeeping) is trusted:
+	assert.equal(c.reuseCount, 2);
+});
+
+test("resolveCandidate: signature match → embedding trusted", () => {
+	const def: Taskflow = { name: "x", phases: [{ id: "a", type: "agent", task: "y" }] } as Taskflow;
+	const sidecar = {
+		schemaVersion: 1 as const,
+		phaseSignature: "agent",
+		phaseCount: 1,
+		agentUsage: [],
+		generality: 0.5,
+		reuseCount: 0,
+		lastUsedAt: null,
+		createdAt: 1,
+		version: 1,
+		embedding: [0.4, 0.5],
+		embeddingModel: "m",
+		embeddingDim: 2,
+		embeddedAt: 1,
+	};
+	const c = resolveCandidate(def, "project", "x", sidecar);
+	assert.deepEqual(c.embedding, [0.4, 0.5]);
+	assert.equal(c.embeddingStale, false);
+});
+
+// ---------------------------------------------------------------------------
+// searchLibrary (structural / keyword mode — no embedder)
+// ---------------------------------------------------------------------------
+
+test("searchLibrary: keyword match ranks purpose-matching flow first (structural mode)", async () => {
+	const cwd = makeTmpCwd();
+	try {
+		const audit: Taskflow = {
+			name: "audit-endpoints",
+			description: "audit endpoints for auth",
+			args: { dir: { default: "src/routes" } },
+			phases: [
+				{ id: "d", type: "agent", agent: "scout", task: "List endpoints under {args.dir}.", output: "json" },
+				{ id: "m", type: "map", over: "{steps.d.json}", as: "item", agent: "analyst", task: "Audit {item}.", dependsOn: ["d"] },
+				{ id: "r", type: "reduce", from: ["m"], agent: "writer", task: "Report:\n{steps.m.output}", dependsOn: ["m"], final: true },
+			],
+		} as Taskflow;
+		const unrelated: Taskflow = {
+			name: "hello-world",
+			phases: [{ id: "a", type: "agent", task: "say hello world greeting", final: true }],
+		} as Taskflow;
+		saveFlowWithMeta(cwd, audit, deriveMeta(audit, { purpose: "审计 API endpoint 是否缺少鉴权", tags: ["audit", "auth"] }));
+		saveFlowWithMeta(cwd, unrelated, deriveMeta(unrelated, {}));
+
+		const deps: LibraryDeps = { settings: { enabled: true, scope: "both" }, cwd };
+		const res = await searchLibrary(deps, { query: "audit api endpoints auth 鉴权" });
+
+		assert.equal(res.searchMode, "structural"); // no embedder configured
+		assert.ok(res.results.length >= 1);
+		assert.equal(res.results[0].name, "audit-endpoints");
+		assert.ok(res.results[0].score > 0, "audit flow should score above 0");
+		assert.ok(res.results[0].score > (res.results[1]?.score ?? -1));
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("searchLibrary: query with no real matches → empty results, structural mode", async () => {
+	const cwd = makeTmpCwd();
+	try {
+		const deps: LibraryDeps = { settings: { enabled: true, scope: "both" }, cwd };
+		const res = await searchLibrary(deps, { query: "zzznomatch-xyz-12345" });
+		assert.equal(res.results.length, 0);
+		assert.equal(res.searchMode, "structural");
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("searchLibrary: minScore filters low results", async () => {
+	const cwd = makeTmpCwd();
+	try {
+		const a: Taskflow = { name: "a", phases: [{ id: "x", type: "agent", task: "auth audit" }] } as Taskflow;
+		const b: Taskflow = { name: "b", phases: [{ id: "x", type: "agent", task: "cooking recipe pasta" }] } as Taskflow;
+		saveFlowWithMeta(cwd, a, deriveMeta(a, { purpose: "auth audit" }));
+		saveFlowWithMeta(cwd, b, deriveMeta(b, { purpose: "cooking recipe" }));
+		const deps: LibraryDeps = { settings: { enabled: true, scope: "both" }, cwd };
+		const res = await searchLibrary(deps, { query: "auth audit", minScore: 0.5 });
+		// only flows scoring >= 0.5 survive
+		for (const r of res.results) assert.ok(r.score >= 0.5, `score ${r.score} below minScore`);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("searchLibrary: phaseSignatureHint boosts structurally-matching flows", async () => {
+	const cwd = makeTmpCwd();
+	try {
+		const audit: Taskflow = {
+			name: "audit",
+			args: { dir: { default: "x" } },
+			phases: [
+				{ id: "d", type: "agent", task: "{args.dir}", agent: "scout" },
+				{ id: "m", type: "map", over: "{steps.d.json}", task: "{item}", dependsOn: ["d"] },
+				{ id: "r", type: "reduce", from: ["m"], task: "{steps.m.output}", dependsOn: ["m"], final: true },
+			],
+		} as Taskflow;
+		const simple: Taskflow = { name: "simple", phases: [{ id: "a", type: "agent", task: "do thing", final: true }] } as Taskflow;
+		saveFlowWithMeta(cwd, audit, deriveMeta(audit, { purpose: "fan out work" }));
+		saveFlowWithMeta(cwd, simple, deriveMeta(simple, { purpose: "fan out work" })); // same purpose
+		const deps: LibraryDeps = { settings: { enabled: true, scope: "both" }, cwd };
+		// With a signature hint matching audit's structure, audit should outrank simple.
+		const res = await searchLibrary(deps, { query: "fan out work", phaseSignatureHint: "agent→map→reduce" });
+		assert.equal(res.results[0].name, "audit");
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("searchLibrary: CJK substring match — paraphrased Chinese query finds a Chinese purpose (no whitespace in CJK)", async () => {
+	const cwd = makeTmpCwd();
+	try {
+		const audit: Taskflow = {
+			name: "audit-endpoints",
+			args: { dir: { default: "src/routes" } },
+			phases: [{ id: "d", type: "agent", agent: "scout", task: "List {args.dir}.", output: "json", final: true }],
+		} as Taskflow;
+		saveFlowWithMeta(cwd, audit, deriveMeta(audit, { purpose: "审计一组 API endpoint 是否缺少鉴权检查", tags: ["audit", "auth"] }));
+		const deps: LibraryDeps = { settings: { enabled: true, scope: "both" }, cwd };
+		// Paraphrase with different surrounding words but a shared CJK term "鉴权".
+		const res = await searchLibrary(deps, { query: "检查接口安全性 鉴权 缺失" });
+		assert.ok(res.results.length >= 1, "CJK substring match should surface the flow");
+		assert.equal(res.results[0].name, "audit-endpoints");
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/taskflow-core/test/library-store.test.ts
+++ b/packages/taskflow-core/test/library-store.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Library store persistence: sidecar readMeta/writeMeta, listFlows A1 filter
+ * fix (sidecar must NOT appear as a candidate flow), bumpReuseInSidecar.
+ * Refs: docs/rfc-library-reuse.md §3.1, §八 (A1 fix).
+ */
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import type { Taskflow } from "../src/schema.ts";
+import {
+	bumpReuseInSidecar,
+	listFlows,
+	readMeta,
+	saveFlow,
+	saveFlowWithMeta,
+	sidecarPathFor,
+} from "../src/store.ts";
+import { deriveMeta } from "../src/library/meta.ts";
+
+function makeTmpCwd(): string {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-lib-store-"));
+	fs.mkdirSync(path.join(tmp, ".pi", "taskflows"), { recursive: true });
+	return tmp;
+}
+
+const sampleDef: Taskflow = {
+	name: "audit-endpoints",
+	description: "audit",
+	args: { dir: { default: "src/routes" } },
+	phases: [
+		{ id: "d", type: "agent", agent: "scout", task: "List {args.dir}", output: "json" },
+		{ id: "r", type: "reduce", from: ["d"], agent: "writer", task: "{steps.d.output}", dependsOn: ["d"], final: true },
+	],
+} as Taskflow;
+
+test("saveFlowWithMeta: writes flow + sidecar, readMeta recovers it", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const meta = deriveMeta(sampleDef, { purpose: "审计鉴权", tags: ["audit", "auth"] });
+		const { filePath, metaPath } = saveFlowWithMeta(cwd, sampleDef, meta);
+		assert.ok(fs.existsSync(filePath));
+		assert.ok(fs.existsSync(metaPath));
+		assert.equal(path.basename(metaPath), "audit-endpoints.meta.json");
+		const back = readMeta(cwd, "audit-endpoints");
+		assert.equal(back?.purpose, "审计鉴权");
+		assert.deepEqual(back?.tags, ["audit", "auth"]);
+		assert.equal(back?.phaseSignature, "agent→reduce");
+		assert.equal(back?.reuseCount, 0);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("A1 fix: listFlows excludes .meta.json sidecar (no ghost flow)", () => {
+	const cwd = makeTmpCwd();
+	try {
+		// Save via the new path (writes both flow + sidecar).
+		saveFlowWithMeta(cwd, sampleDef, deriveMeta(sampleDef, {}));
+		const flows = listFlows(cwd);
+		const names = flows.map((f) => f.name);
+		// listFlows also scans the user-global dir, so don't assume a total count;
+		// just assert our flow appears exactly once and nothing sidecar-derived appears.
+		assert.ok(names.includes("audit-endpoints"));
+		assert.equal(names.filter((n) => n === "audit-endpoints").length, 1);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("A1 regression guard: a sidecar that looks flow-like (has a name field) is still excluded", () => {
+	const cwd = makeTmpCwd();
+	try {
+		// Manually drop a .meta.json that has a `name` field (which readFlowFile would accept).
+		// The listFlows filter must reject it by suffix BEFORE readFlowFile runs.
+		saveFlowWithMeta(cwd, sampleDef, deriveMeta(sampleDef, {}));
+		const metaPath = sidecarPathFor(cwd, "audit-endpoints");
+		const malicious = JSON.stringify({ ...readMeta(cwd, "audit-endpoints"), name: "ghost-xyz" }, null, 2);
+		fs.writeFileSync(metaPath, malicious, "utf-8");
+		const flows = listFlows(cwd);
+		const names = flows.map((f) => f.name);
+		// The ghost must NOT appear anywhere (project nor user scope).
+		assert.ok(!names.includes("ghost-xyz"), "sidecar with a name field must not become a ghost flow");
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("readMeta: returns null for missing flow", () => {
+	const cwd = makeTmpCwd();
+	try {
+		assert.equal(readMeta(cwd, "does-not-exist"), null);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("bumpReuseInSidecar: increments reuseCount + lastUsedAt, idempotent under re-bump", () => {
+	const cwd = makeTmpCwd();
+	try {
+		saveFlowWithMeta(cwd, sampleDef, deriveMeta(sampleDef, {}));
+		assert.equal(readMeta(cwd, "audit-endpoints")?.reuseCount, 0);
+		assert.equal(readMeta(cwd, "audit-endpoints")?.lastUsedAt, null);
+
+		const n1 = bumpReuseInSidecar(cwd, "audit-endpoints");
+		assert.equal(n1, 1);
+		const after1 = readMeta(cwd, "audit-endpoints");
+		assert.equal(after1?.reuseCount, 1);
+		assert.ok((after1?.lastUsedAt ?? 0) > 0);
+
+		const n2 = bumpReuseInSidecar(cwd, "audit-endpoints");
+		assert.equal(n2, 2);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("bumpReuseInSidecar: returns null when the flow itself doesn't exist", () => {
+	const cwd = makeTmpCwd();
+	try {
+		assert.equal(bumpReuseInSidecar(cwd, "nope"), null);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("bumpReuseInSidecar: creates a minimal sidecar if save used the legacy saveFlow (no sidecar yet)", () => {
+	const cwd = makeTmpCwd();
+	try {
+		// legacy save (no sidecar) — backward compat
+		saveFlow(cwd, sampleDef, "project");
+		assert.equal(readMeta(cwd, "audit-endpoints"), null);
+		const n = bumpReuseInSidecar(cwd, "audit-endpoints");
+		assert.equal(n, 1);
+		const m = readMeta(cwd, "audit-endpoints");
+		assert.equal(m?.reuseCount, 1);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/taskflow-mcp/src/mcp/server.ts
+++ b/packages/taskflow-mcp/src/mcp/server.ts
@@ -42,6 +42,13 @@ import {
 	isShorthand,
 	validateTaskflow,
 	readSubagentSettings,
+	readMeta,
+	saveFlowWithMeta,
+	bumpReuseInSidecar,
+	deriveMeta,
+	searchLibrary,
+	type LibraryDeps,
+	type SearchInput,
 	type RuntimeDeps,
 	type RunState,
 	type Taskflow,
@@ -163,6 +170,7 @@ const TOOLS: McpTool[] = [
 				defineFile: { type: "string", description: "Path to a file holding the flow definition (raw JSON, or Markdown with a ```json fence). Lets you verify/compile/run share ONE persisted draft (e.g. in the OS tmp dir) — edit the file between calls instead of re-sending the whole definition. Precedence: define > defineFile > name." },
 				args: { type: "object", description: "Invocation arguments interpolated as {args.X}." },
 				incremental: { type: "boolean", description: "Default every phase to cross-run cache reuse." },
+				reusedFromSearch: { type: "boolean", description: "Set true when this run was chosen because of a prior taskflow_search → bumps the flow's reuseCount (the reuse flywheel). Default false; direct run-by-name does not bump." },
 			},
 		},
 	},
@@ -227,6 +235,43 @@ const TOOLS: McpTool[] = [
 				limit: { type: "number", description: "Truncation cap in chars (default 4000, max 32000)." },
 			},
 			required: ["runId"],
+		},
+	},
+	{
+		name: "taskflow_save",
+		title: "Save a reusable taskflow",
+		description:
+			"Save a flow as a reusable library asset: persists the flow AND a sidecar .meta.json with purpose/tags/notes + auto-derived structural metadata (phase signature, generality score) so taskflow_search can retrieve it later. Pass purpose + 2-4 tags for any flow you expect to reuse — this is what makes search recall work.",
+		inputSchema: {
+			type: "object",
+			additionalProperties: false,
+			properties: {
+				name: { type: "string", description: "Flow name (also the filename stem)." },
+				definition: { type: "object", description: "Full taskflow DSL object ({name, phases:[...]}) or shorthand ({task}|{tasks}|{chain})." },
+				purpose: { type: "string", description: "One-line purpose — the single most important field for search recall. Write what the flow DOES and WHEN to use it." },
+				tags: { type: "array", items: { type: "string" }, description: "2-4 reuse tags (e.g. audit, fan-out, migration, security)." },
+				notes: { type: "string", description: "Free-form reuse notes (when NOT to use, required args, gotchas)." },
+				scope: { type: "string", enum: ["project", "user"], description: "project (default) or user-global." },
+			},
+			required: ["name", "definition"],
+		},
+	},
+	{
+		name: "taskflow_search",
+		title: "Search the taskflow library",
+		description:
+			"Search saved flows by purpose BEFORE authoring a new one — the reuse flywheel. Returns ranked matches with a score, why it matched, and a reuse hint (direct-reuse / copy-and-generalize / write-fresh). Falls back to keyword+structural ranking when no embedding backend is configured (structural mode); uses cosine similarity when one is (semantic/mixed mode).",
+		inputSchema: {
+			type: "object",
+			additionalProperties: false,
+			properties: {
+				query: { type: "string", description: "Natural-language purpose string (what you want the flow to do)." },
+				limit: { type: "number", description: "Max results (default 5, max 20)." },
+				structureOnly: { type: "boolean", description: "Skip embedding, use keyword+structural ranking only (zero latency)." },
+				minScore: { type: "number", description: "Drop results below this score (0-1)." },
+				scope: { type: "string", enum: ["project", "user", "both"], description: "Which scopes to search (default from settings: both)." },
+			},
+			required: ["query"],
 		},
 	},
 ];
@@ -314,6 +359,13 @@ export function makeToolHandlers(
 					/* fail-open */
 				}
 			});
+			if (res.ok && args.reusedFromSearch === true && typeof args.name === "string" && args.name.trim()) {
+				try {
+					bumpReuseInSidecar(cwd, args.name);
+				} catch {
+					/* fail-open: reuse bookkeeping is best-effort */
+				}
+			}
 			const header = res.ok ? "✓ taskflow complete" : "✗ taskflow did not fully succeed";
 			const u = res.totalUsage;
 			const usageLine = `\n\n— ${u.turns} turns · in ${u.input} · out ${u.output} tokens · run ${state.runId}`;
@@ -335,7 +387,14 @@ export function makeToolHandlers(
 		taskflow_list: async () => {
 			const flows = listFlows(cwd);
 			if (flows.length === 0) return textContent("No saved taskflows found from this directory.");
-			const lines = flows.map((f) => `- ${f.name} (${f.scope}) — ${f.def.phases.length} phase(s)`);
+			const lines = flows.map((f) => {
+				const meta = readMeta(cwd, f.name);
+				if (meta?.purpose) {
+					const purpose = meta.purpose.length > 20 ? meta.purpose.slice(0, 20) + "…" : meta.purpose;
+					return `- ${f.name} (${f.scope}) — ${f.def.phases.length} phase(s) · ${purpose} · g=${meta.generality?.toFixed(2) ?? "?"} · used ${meta.reuseCount ?? 0}×`;
+				}
+				return `- ${f.name} (${f.scope}) — ${f.def.phases.length} phase(s)`;
+			});
 			return textContent(`Saved taskflows:\n${lines.join("\n")}`);
 		},
 
@@ -343,9 +402,73 @@ export function makeToolHandlers(
 			const name = String(args.name ?? "");
 			const saved = getFlow(cwd, name);
 			if (!saved) return textContent(`No saved flow named "${name}".`, true);
+			const meta = readMeta(cwd, name);
+			if (meta) {
+				const out = { definition: saved.def, library: { purpose: meta.purpose, tags: meta.tags, notes: meta.notes, generality: meta.generality, reuseCount: meta.reuseCount, version: meta.version, phaseSignature: meta.phaseSignature } };
+				return textContent(JSON.stringify(out, null, 2));
+			}
 			// No ```json``` fence: Codex shows text blocks as raw plaintext, so a fence
 			// would render as literal backticks. The JSON is already monospaced there.
 			return textContent(JSON.stringify(saved.def, null, 2));
+		},
+
+		taskflow_save: async (args) => {
+			const name = String(args.name ?? "");
+			if (!name.trim()) return textContent("taskflow_save requires `name`.", true);
+			if (!args.definition) return textContent("taskflow_save requires `definition` (the DSL object or shorthand).", true);
+			// Resolve + validate the definition (mirrors resolveFlow + run's validation).
+			let def: Taskflow;
+			try {
+				def = resolveFlow(cwd, { define: args.definition });
+			} catch (e) {
+				return textContent(`Invalid flow definition: ${e instanceof Error ? e.message : String(e)}`, true);
+			}
+			// Force the name to match the argument (resolveFlow/shorthand may synthesize one).
+			def = { ...def, name };
+			const v = validateTaskflow(def);
+			if (!v.ok) return textContent(`Flow is invalid:\n- ${v.errors.join("\n- ")}`, true);
+			const scope = args.scope === "user" ? "user" : "project";
+			const prevMeta = readMeta(cwd, name) ?? undefined;
+			const meta = deriveMeta(def, {
+				purpose: typeof args.purpose === "string" ? args.purpose : undefined,
+				tags: Array.isArray(args.tags) ? args.tags.filter((t): t is string => typeof t === "string") : undefined,
+				notes: typeof args.notes === "string" ? args.notes : undefined,
+				prevMeta,
+			});
+			const { filePath } = saveFlowWithMeta(cwd, def, meta, scope);
+			return textContent(`Saved taskflow '${name}' → ${filePath}\n  purpose: ${meta.purpose ?? "(none)"}\n  tags: ${(meta.tags ?? []).join(", ") || "(none)"}\n  phaseSignature: ${meta.phaseSignature}\n  generality: ${meta.generality.toFixed(2)}`);
+		},
+
+		taskflow_search: async (args) => {
+			const query = String(args.query ?? "").trim();
+			if (!query) return textContent("taskflow_search requires `query`.", true);
+			const settings = readSubagentSettings();
+			if (!settings.taskflow.library.enabled) {
+				return textContent("Library is disabled (settings.json → taskflow.library.enabled = false).", true);
+			}
+			const deps: LibraryDeps = { settings: settings.taskflow.library, cwd };
+			const input: SearchInput = {
+				query,
+				limit: typeof args.limit === "number" ? args.limit : undefined,
+				structureOnly: args.structureOnly === true,
+				minScore: typeof args.minScore === "number" ? args.minScore : undefined,
+				scope: args.scope === "project" || args.scope === "user" || args.scope === "both" ? args.scope : undefined,
+			};
+			const res = await searchLibrary(deps, input);
+			const lines: string[] = [];
+			lines.push(`Library search — ${res.counts.scanned} flow(s) scanned · ${res.searchMode} mode${res.embedder ? ` · ${res.embedder}` : ""}`);
+			if (res.results.length === 0) {
+				lines.push("No matches. Consider authoring a new flow and saving it (taskflow_save with purpose+tags).");
+			} else {
+				for (const r of res.results) {
+					lines.push(`- ${r.name} (${r.scope}) — score ${r.score.toFixed(2)} · ${r.phaseSignature || "?"} · g=${r.generality.toFixed(2)} · v${r.version} · used ${r.reuseCount}×`);
+					if (r.purpose) lines.push(`    purpose: ${r.purpose}`);
+					if (r.tags?.length) lines.push(`    tags: ${r.tags.join(", ")}`);
+					lines.push(`    why: ${r.why}`);
+					lines.push(`    → ${r.reuseHint}`);
+				}
+			}
+			return textContent(lines.join("\n"));
 		},
 
 		taskflow_verify: async (args) => {

--- a/scripts/build-skills.mjs
+++ b/scripts/build-skills.mjs
@@ -32,7 +32,7 @@ const root = join(here, "..");
 const srcDir = join(root, "skills-src", "taskflow");
 
 const HOSTS = ["pi", "codex", "claude", "opencode"];
-const COMPANIONS = ["patterns.md", "advanced.md", "configuration.md"];
+const COMPANIONS = ["patterns.md", "advanced.md", "configuration.md", "library.md"];
 const OUT_DIRS = {
 	pi: join(root, "packages", "pi-taskflow", "skills", "taskflow"),
 	codex: join(root, "packages", "codex-taskflow", "plugin", "skills", "taskflow"),

--- a/skills-src/taskflow/core.md
+++ b/skills-src/taskflow/core.md
@@ -17,6 +17,7 @@ mistakes that break flows. Load the companion files **only when needed**:
 | `advanced.md` | Dynamic sub-flow (`flow{def}`) contracts & security caps, and workspace isolation (`cwd: temp/dedicated/worktree`). |
 <!-- /host:codex,claude,opencode -->
 | `configuration.md` | Every knob: per-phase `model`/`thinking`/`tools`/`cwd`, concurrency model, agent discovery, `settings.json`, cross-run caching (`cache`, `fingerprint`, per-item map caching), args, storage paths. |
+| `library.md` | **Before authoring a non-trivial flow — SEARCH the reusable-flow library.** Save reusable flows with `purpose`+`tags` so future search finds them; reuse + generalize instead of rewriting from scratch. The compounding flywheel. |
 
 > Rule of thumb: writing a flow with ≥ 4 phases, a gate, or any fan-out?
 > **Read `patterns.md` first** — it will make the flow better, not just valid.

--- a/skills-src/taskflow/library.md
+++ b/skills-src/taskflow/library.md
@@ -1,0 +1,133 @@
+# Library: reusable flows & the search-before-author loop
+
+taskflow saves flows you'll reuse into a **library** with metadata, so you can
+`search` it before authoring a new flow — the **reuse flywheel**. The more you
+save (with a good `purpose` + `tags`), the better future search gets.
+
+> Full design: `docs/rfc-library-reuse.md`. This file is the agent-facing
+> "when and how" guide.
+
+<!-- host:pi -->
+**Host binding (pi):** use the `taskflow` tool with `action: "search"` /
+`action: "save"`, and `/tf list` / `/tf show <name>`.
+<!-- /host:pi -->
+<!-- host:codex,claude,opencode -->
+**Host binding:** use the `taskflow_search`, `taskflow_save`, `taskflow_list`,
+`taskflow_show` tools.
+<!-- /host:codex,claude,opencode -->
+
+## Before authoring a non-trivial flow: SEARCH first
+
+Any time you're about to write a flow with ≥3 phases, fan-out, or a gate,
+**search the library first**. It costs nothing and often finds a starter you
+can adapt.
+
+<!-- host:pi -->
+```jsonc
+{ "action": "search", "query": "audit API endpoints for missing auth", "limit": 5 }
+```
+<!-- /host:pi -->
+<!-- host:codex,claude,opencode -->
+```jsonc
+{ "name": "taskflow_search", "arguments": { "query": "audit API endpoints for missing auth", "limit": 5 } }
+```
+<!-- /host:codex,claude,opencode -->
+
+Read the results and the `→ reuseHint`:
+
+| score | reuseHint | what to do |
+|-------|-----------|------------|
+| **≥ 0.8** | "直接复用" / direct reuse | Run by name (skip authoring). |
+| **0.5 – 0.8** | "copy + 泛化" / copy & generalize | `show` it, copy, **generalize** (see checklist), save as a new version. |
+| **< 0.5** or no matches | "从头编写" / write fresh | Author from scratch — then **save** it if reusable. |
+
+`searchMode` tells you how the ranking was produced: `structural` (keyword +
+phase-signature; no embedding backend configured), `semantic` (cosine over
+embeddings), or `mixed` (some flows had vectors, some didn't). `structural` is
+weaker on paraphrase — if it missed something obvious, try `structureOnly:
+false` or a different phrasing.
+
+## After a successful novel flow: SAVE it (if reusable)
+
+When you finish a flow you expect to use again, save it **with a `purpose` and
+2–4 `tags`**. These two fields are what search matches on — a flow saved
+without them is nearly invisible to future search.
+
+<!-- host:pi -->
+```jsonc
+{ "action": "save", "define": { "name": "audit-endpoints", "phases": [ ... ] },
+  "purpose": "Audit a directory of API endpoints for missing auth checks",
+  "tags": ["audit", "security", "auth", "fan-out"] }
+```
+<!-- /host:pi -->
+<!-- host:codex,claude,opencode -->
+```jsonc
+{ "name": "taskflow_save",
+  "arguments": { "name": "audit-endpoints", "definition": { "phases": [ ... ] },
+    "purpose": "Audit a directory of API endpoints for missing auth checks",
+    "tags": ["audit", "security", "auth", "fan-out"] } }
+```
+<!-- /host:codex,claude,opencode -->
+
+`save` auto-derives structural metadata (phase signature, a `generality` score
+in 0–1) and writes a sidecar `.meta.json` next to the flow file. You don't
+compute any of that — just give `purpose` + `tags`.
+
+## The generalization checklist (apply on every reuse)
+
+When you copy + generalize a flow, make it **more reusable than the version you
+found**. Each item raises the auto-derived `generality` score and broadens
+future search recall:
+
+- [ ] Hardcoded file/dir paths → `{args.X}` (with a `default`).
+- [ ] Specific entity words ("endpoint", "route") → broaden in the discover
+      prompt so the flow works for the whole class.
+- [ ] Thresholds / counts → `{args.X}` with sensible defaults.
+- [ ] Add `budget` / `retry` / `expect` if missing (production-grade knobs).
+- [ ] Update `purpose` to reflect the wider scope.
+
+Then save it back (version auto-bumps). Over time the library compounds: every
+reuse leaves a more general flow behind.
+
+## reuseCount & `reusedFromSearch`
+
+Each saved flow has a `reuseCount`. It goes up by 1 **only when** a run was
+chosen because of a prior search — set the `reusedFromSearch: true` flag on the
+run. Direct run-by-name does **not** bump it (that's intentional: `reuseCount`
+measures "found-via-search reuse", the high-quality signal for later auto-prune).
+
+<!-- host:pi -->
+```jsonc
+// after search recommended "audit-endpoints", run it with the flag:
+{ "action": "run", "name": "audit-endpoints", "args": { "dir": "src/api" }, "reusedFromSearch": true }
+```
+<!-- /host:pi -->
+<!-- host:codex,claude,opencode -->
+```jsonc
+{ "name": "taskflow_run",
+  "arguments": { "name": "audit-endpoints", "args": { "dir": "src/api" }, "reusedFromSearch": true } }
+```
+<!-- /host:codex,claude,opencode -->
+
+## Judicious reuse — not every task needs the library
+
+Skip search + save for:
+- **One-off tasks** (a quick fix, a throwaway analysis) — `generality < 0.3`
+  and obviously won't recur.
+- **Trivial flows** (1–2 phases, no fan-out) — overhead isn't worth it.
+
+The library pays off for *patterns* that recur across projects or sessions:
+audits, migrations, reviews, fan-out summarization, plan→approve→execute, etc.
+
+## Configuration (embedding backend — optional, Phase 2)
+
+Search works with **zero config** (structural mode). For smarter paraphrase
+recall, configure an embedding backend in `~/.pi/agent/settings.json`:
+
+```jsonc
+{ "taskflow": { "library": { "enabled": true, "scope": "both" },
+  "embedder": { "kind": "http", "url": "http://127.0.0.1:8123/v1/embeddings", "model": "qwen3-embedding-0.6b" } } }
+```
+
+Without `embedder`, or if the embedder fails, search **degrades gracefully** to
+structural mode — it never breaks. (See `docs/rfc-library-reuse.md` §4.)


### PR DESCRIPTION
## What

Phase 1 of the **taskflow library** (RFC: `docs/rfc-library-reuse.md`): a reusable-flow asset layer that lets agents **SEARCH the library before authoring a new flow**, and **SAVE reusable flows with `purpose`+`tags`** so future search finds them — the compounding reuse flywheel.

```jsonc
// before writing a new audit flow, search first:
{ "name": "taskflow_search", "arguments": { "query": "audit api endpoints for missing auth" } }
// → surfaces audit-endpoints (score 0.83, "直接复用") → run it instead of rewriting

// after a successful novel flow, save it so it is retrievable:
{ "name": "taskflow_save", "arguments": { "name": "audit-endpoints", "definition": {…},
    "purpose": "Audit API endpoints for missing auth", "tags": ["audit","security","auth"] } }
```

Phase 1 ships with **structural/keyword search only** (zero-dep, zero-token). Embedding/cosine support is Phase 2 — the `LibraryDeps.embedder` seam is already in place and search **degrades gracefully** without it (always works, just weaker on paraphrase).

## Why

Right now, every flow is written from scratch even when a near-identical one was authored last week. The library turns saved flows into a searchable, compounding asset: write-once + generalize-on-reuse means each recurring pattern (audit, migration, review, plan→approve→execute) gets more general every time it is reused.

## Changes

| Area | Change |
|---|---|
| **core `library/`** (new) | `types.ts` (FlowMeta, LibrarySettings, LibraryDeps, SearchInput/Response) · `meta.ts` (phaseSignature via `topoLayers`, generality v2 formula — A8, deriveMeta) · `search.ts` (levenshtein, structScore — R2C1, **CJK-aware textScore**, cosine, staleness resolution — §5.2.2, searchLibrary, why/reuseHint templates — A3) |
| **core `store.ts`** | `readMeta`/`saveFlowWithMeta`/`bumpReuseInSidecar`/`sidecarPathFor`. Flow + `.meta.json` written in ONE `withLock` critical section (R2). **`listFlows` A1 fix**: excludes `.meta.json` sidecars (regression-guarded). |
| **core `agents.ts`** | `TaskflowSettings` gains `library` + `embedder` (Phase 2) with normalizers; backward-compatible defaults. `LibraryDeps` stays OUT of `RuntimeDeps` (A2). |
| **pi adapter** | `action=search`; `action=save` writes sidecar; `action=list` + `/tf show` extended with metadata; `action=run` gains `reusedFromSearch` (bumps reuseCount on success). |
| **mcp server** | new `taskflow_save` + `taskflow_search` tools (A5/N2); `taskflow_show`→`{definition,library}`; `taskflow_list` appends purpose/generality/reuseCount; `taskflow_run` gains `reusedFromSearch`. All four hosts inherit from the one host-neutral binding. |
| **skill** | new `library.md` (search-before-author loop, generalization checklist, judicious-reuse) compiled to all four hosts; `core.md` references it. |

## The reuse flywheel (how it compounds)

1. **search** before authoring ≥3-phase/fan-out flows
2. on a 0.5–0.8 match: `show` → copy → **generalize** (hardcoded paths → `{args.X}`, broaden discover prompt — see checklist in `library.md`) → save as a new version
3. on a ≥0.8 match: run by name with `reusedFromSearch:true` (bumps `reuseCount`)
4. after a successful novel reusable flow: `save` with `purpose` + 2–4 `tags`
5. one-off tasks (`generality<0.3`): skip — judicious reuse

`reuseCount` only bumps on `reusedFromSearch:true` (intentional — it measures *search-discovered* reuse, the high-quality signal for future auto-prune).

## Design provenance

The design went through a **two-round cross-adversarial Qwen review** (28 findings: 4 blockers, 11 majors, 13 minors — all resolved inline, no deferred-to-Phase-2 cop-outs on blocking issues). Changelog: `docs/rfc-library-reuse-review.md`. Key fixes: `listFlows` sidecar ghost-flow bug (A1), generality formula verbosity penalty (A8), malformed-vector validation (C3), two-file atomic write (R2), `spawn` not `exec` for command-kind (R2R1 — lands in Phase 2), staleness detection (R2C4), CJK keyword matching.

## Tests

+24 new tests: `library-meta` (phaseSignature/parallel/empty, generality v2 incl. A8 verbosity, deriveMeta version bump), `library-search` (levenshtein, cosine NaN-safety, staleness §5.2.2, structScore R2C1, keyword match, **CJK substring**, phaseSignatureHint boost, minScore filter, empty-query error), `library-store` (atomic write, **A1 ghost-flow guard**, sidecar naming, reuse bump, legacy-save compat), mcp `taskflow_save`+`taskflow_search` round-trip. Updated existing tool-count + settings-shape tests for the new fields. **Full suite 1123/1123 pass; `tsc --noEmit` clean.**

## Stacked

Stacked on **#26** (`feat/claude-and-opencode-hosts`) — touches `taskflow-mcp/server.ts` which #26 introduces. Base is `feat/claude-and-opencode-hosts`; GitHub re-targets to `main` automatically once #26 lands. Phase 2 (embedding + `reembed --stale-only`) and Phase 3 (lineage + auto-prune) follow.

## Out of scope (Phase 2/3)

- embedding/cosine actual wiring (Phase 2 — seam is ready)
- `reembed --stale-only` (Phase 2)
- lineage graph / auto-prune (Phase 3)