### PR TITLE
feat(core): support JSONC comments in flow definition files

### DIFF
--- a/packages/taskflow-core/src/index.ts
+++ b/packages/taskflow-core/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 export * from "./schema.ts";
+export * from "./jsonc.ts";
 export * from "./contract.ts";
 export * from "./scorers.ts";
 export * from "./scorer-runtime.ts";

--- a/packages/taskflow-core/src/jsonc.ts
+++ b/packages/taskflow-core/src/jsonc.ts
@@ -1,0 +1,110 @@
+/**
+ * Zero-dependency JSONC (JSON with Comments) strip + parse.
+ *
+ * Flow definition files are hand-authored, and authors want to annotate them
+ * with `//` line comments and `/* block *​/` comments just like jsonc/JSON5.
+ * Standard `JSON.parse` rejects comments outright. This module strips comments
+ * (only those OUTSIDE string literals) and trailing commas before parsing, so
+ * a flow `.json` file may legally contain comments.
+ *
+ * Scope: this is used ONLY for user-authored flow definition files
+ * (readFlowFile). It must NOT be used to parse LLM/subagent output — that path
+ * (safeParse) stays strict by design, since model output is untrusted and we
+ * want structural failures to surface.
+ *
+ * The algorithm is a single linear scan that tracks whether the cursor is
+ * inside a string literal (respecting `\"` escapes). Comments are replaced
+ * with spaces so that line/column numbers in any error message stay aligned
+ * with the original source. Trailing commas before a closing brace/bracket
+ * (like `{"a": 1,}` or `[1, 2,]`) are also removed — a common hand-editing
+ * convenience that JSON.parse rejects.
+ */
+
+/** Strip JSONC comments (// line and block) and trailing commas. Exported for testing. */
+export function stripJsonComments(input: string): string {
+	let out = "";
+	let i = 0;
+	const n = input.length;
+
+	while (i < n) {
+		const ch = input[i];
+		const next = input[i + 1];
+
+		// String literal — copy verbatim, honoring escape sequences. A `//` or
+		// `/*` that appears inside a string is part of the value, not a comment,
+		// and a `,` inside a string is not a trailing comma.
+		if (ch === '"') {
+			out += ch;
+			i++;
+			while (i < n) {
+				const c = input[i];
+				if (c === "\\" && i + 1 < n) {
+					// Keep the escape char and the escaped char together.
+					out += c + input[i + 1];
+					i += 2;
+					continue;
+				}
+				out += c;
+				i++;
+				if (c === '"') break;
+			}
+			continue;
+		}
+
+		// Line comment `// ... \n` — drop it (do not emit a space, so line
+		// numbers stay aligned with the original source).
+		if (ch === "/" && next === "/") {
+			while (i < n && input[i] !== "\n") i++;
+			continue;
+		}
+
+		// Block comment `/* ... */` — replace with a single space so that
+		// positions of the surrounding tokens are preserved.
+		if (ch === "/" && next === "*") {
+			i += 2;
+			while (i < n && !(input[i] === "*" && input[i + 1] === "/")) i++;
+			i += 2; // consume the closing */
+			out += " ";
+			continue;
+		}
+
+		// Trailing comma: skip the comma when the next non-whitespace char is
+		// a closing brace or bracket. Only checked outside string literals.
+		// Newlines between the comma and the closer are preserved so that
+		// line numbers stay aligned with the original source.
+		if (ch === ",") {
+			let j = i + 1;
+			let sawNewline = false;
+			while (j < n) {
+				const c = input[j];
+				if (c === " " || c === "\t" || c === "\r") {
+					j++;
+				} else if (c === "\n") {
+					sawNewline = true;
+					j++;
+				} else {
+					break;
+				}
+			}
+			if (j < n && (input[j] === "}" || input[j] === "]")) {
+				if (sawNewline) out += "\n";
+				i = j;
+				continue;
+			}
+		}
+
+		out += ch;
+		i++;
+	}
+
+	return out;
+}
+
+/**
+ * Parse a JSONC string (JSON with comments and trailing commas allowed) into a
+ * value of type T. Throws the same SyntaxError `JSON.parse` would throw for any
+ * other structural problem, so callers can wrap it in try/catch as usual.
+ */
+export function parseJsonc<T = unknown>(input: string): T {
+	return JSON.parse(stripJsonComments(input)) as T;
+}

--- a/packages/taskflow-core/src/store.ts
+++ b/packages/taskflow-core/src/store.ts
@@ -18,6 +18,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { parseJsonc } from "./jsonc.ts";
 import { getAgentDir } from "./paths.ts";
 import type { Taskflow } from "./schema.ts";
 import type { UsageStats } from "./usage.ts";
@@ -615,7 +616,11 @@ function findProjectFlowsDirInternal(cwd: string, create = false): string | null
 function readFlowFile(filePath: string, scope: "user" | "project"): SavedFlow | null {
 	try {
 		const raw = fs.readFileSync(filePath, "utf-8");
-		const def = JSON.parse(raw) as Taskflow;
+		// Flow definition files are hand-authored and may contain JSONC-style
+		// comments (// line and /* block */) for readability. parseJsonc strips
+		// them before handing off to JSON.parse. LLM/subagent output is NOT
+		// routed through here — see interpolate.ts#safeParse (kept strict).
+		const def = parseJsonc(raw) as Taskflow;
 		if (!def?.name) return null;
 		return { name: def.name, scope, filePath, def };
 	} catch {

--- a/packages/taskflow-core/test/jsonc.test.ts
+++ b/packages/taskflow-core/test/jsonc.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseJsonc, stripJsonComments } from "../src/jsonc.ts";
+
+test("stripJsonComments: removes line comments (//)", () => {
+	const input = `{\n  "name": "x", // the name\n  "n": 1\n}`;
+	const out = stripJsonComments(input);
+	assert.deepEqual(JSON.parse(out), { name: "x", n: 1 });
+});
+
+test("stripJsonComments: removes block comments (/* */)", () => {
+	const input = `{/* leading */ "name": "x" /* trailing */}`;
+	assert.deepEqual(stripJsonComments(input), `{  "name": "x"  }`);
+});
+
+test("stripJsonComments: leaves comments inside strings untouched", () => {
+	const input = `{"task": "split on // and /* not a comment */"} `;
+	assert.equal(stripJsonComments(input), input);
+});
+
+test("stripJsonComments: boundary between string and real comment", () => {
+	// The // and /* ... */ inside the string value are data; the trailing
+	// `// real comment` is outside the string and must be stripped.
+	const input = `{ "s": "a//b/*c*/d", "n": 1 } // real comment`;
+	const out = stripJsonComments(input);
+	assert.deepEqual(JSON.parse(out), { s: "a//b/*c*/d", n: 1 });
+});
+
+test("stripJsonComments: removes trailing commas before } and ]", () => {
+	assert.equal(stripJsonComments('{"a":1,}'), '{"a":1}');
+	assert.equal(stripJsonComments('{"a":[1,2,],}'), '{"a":[1,2]}');
+	assert.equal(stripJsonComments('{\n  "a": 1,\n}'), '{\n  "a": 1\n}');
+});
+
+test("stripJsonComments: does not strip commas that look trailing inside strings", () => {
+	const input = `{"s": "x,]"}`;
+	assert.equal(stripJsonComments(input), input);
+});
+
+test("parseJsonc: parses a realistic flow definition with comments", () => {
+	const flow = `{
+  // This is a security review flow
+  "name": "review",
+  "args": { "dir": { "default": "src" } }, /* override on the CLI */
+  "phases": [
+    {
+      "id": "discover", // first phase
+      "type": "agent",
+      "task": "List files"
+    },
+  ],
+}`;
+	const parsed = parseJsonc(flow) as { name: string; phases: Array<{ id: string }> };
+	assert.equal(parsed.name, "review");
+	assert.equal(parsed.phases[0].id, "discover");
+	assert.equal(parsed.phases.length, 1);
+});
+
+test("parseJsonc: still throws SyntaxError for genuinely broken JSON", () => {
+	assert.throws(() => parseJsonc("{ not valid "));
+	assert.throws(() => parseJsonc('{"unclosed": '));
+});
+
+test("parseJsonc: a pure JSON input parses identically to JSON.parse", () => {
+	const pure = `{"a":[1,2,3],"b":{"c":true}}`;
+	assert.deepEqual(parseJsonc(pure), JSON.parse(pure));
+});

--- a/packages/taskflow-core/test/store.test.ts
+++ b/packages/taskflow-core/test/store.test.ts
@@ -217,6 +217,38 @@ test("saveFlow: overwrites existing flow with same name", () => {
 	}
 });
 
+test("getFlow: reads a JSONC flow file with comments and trailing commas", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const flowDir = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(flowDir, { recursive: true });
+		const filePath = path.join(flowDir, "jsonc-flow.json");
+		fs.writeFileSync(
+			filePath,
+			`{\n` +
+				`  // this flow has comments\n` +
+				`  "name": "jsonc-flow",\n` +
+				`  /* block comment is allowed */\n` +
+				`  "phases": [\n` +
+				`    {\n` +
+				`      "id": "p1", // inline comment\n` +
+				`      "type": "agent",\n` +
+				`      "agent": "executor",\n` +
+				`      "task": "do it",\n` +
+				`    },\n` +
+				`  ],\n` +
+				`}\n`,
+		);
+		const loaded = getFlow(cwd, "jsonc-flow");
+		assert.ok(loaded, "getFlow should parse JSONC flow files");
+		assert.equal(loaded?.name, "jsonc-flow");
+		assert.equal(loaded?.def.phases.length, 1);
+		assert.equal((loaded?.def.phases[0] as { id: string }).id, "p1");
+	} finally {
+		cleanup(cwd);
+	}
+});
+
 test("getFlow: returns null for nonexistent flow", () => {
 	const cwd = makeTmpCwd();
 	try {


### PR DESCRIPTION
Flow definition files are hand-authored `.json` files. This PR lets them contain `//` line comments, `/* */` block comments, and trailing commas — JSONC style.\n\n### What changed\n- New `packages/taskflow-core/src/jsonc.ts` with zero-dependency `stripJsonComments()` / `parseJsonc()`.\n- `readFlowFile()` now calls `parseJsonc()` instead of raw `JSON.parse()`.\n- `safeParse()` for LLM/subagent output is **unchanged** and stays strict.\n- Barrel export added.\n- 9 unit tests + 1 store integration test added.\n\n### Verification\n- `npm run test:core` → 851 tests pass\n- `npm run typecheck` passes\n\n### Scope note\nThis only applies to user-authored flow files read from disk (`~/.pi/...` or `.pi/taskflows/...`). Runtime-generated sub-flow strings (`flow{def}`) and agent outputs are still parsed strictly.