### PR TITLE
docs(website): advanced-features batch — scorers, incremental recompute, agents, host guides, i18n parity

### DIFF
--- a/website/content/docs/en/concepts/phases.mdx
+++ b/website/content/docs/en/concepts/phases.mdx
@@ -1,5 +1,5 @@
 ---
-title: Phase Types
+title: Phases
 description: The ten building blocks of a taskflow, and how to choose between them.
 ---
 

--- a/website/content/docs/en/concepts/shared-context-tree.mdx
+++ b/website/content/docs/en/concepts/shared-context-tree.mdx
@@ -1,0 +1,339 @@
+---
+title: Shared Context Tree
+description: How isolated subagents cooperate without breaking context isolation.
+---
+
+Imagine a security audit flow: ten parallel subagents review ten different files, but all need the same architecture diagram the first agent already read. Without coordination, each agent reads the diagram independently—ten times the tokens, ten times the cost. Or imagine a parent agent that needs to steer its children mid-flight: "skip module X, we found a critical bug there." Without an upward channel, the parent can only watch and hope.
+
+taskflow solves both problems with the Shared Context Tree.
+
+## Two problems, one substrate
+
+The Shared Context Tree is the IPC layer that lets isolated subagent processes cooperate while preserving the context isolation guarantee (intermediate transcripts never enter your conversation). It solves two distinct problems:
+
+**Horizontal coordination** (the blackboard): sibling subagents share findings with each other. The first agent to read an expensive document publishes a summary; the next nine read the summary instead of the original.
+
+**Vertical supervision** (the tree): child subagents report upward to their parent, and parents can spawn new children dynamically. A parent reviews its children's work and decides whether to escalate, retry, or move on.
+
+```txt title="The two channels"
+Horizontal (blackboard)          Vertical (supervision)
+                                 
+Agent A ——writes——┐              Agent Parent
+                  │                   │
+Agent B ——reads——─┤              ┌────┴────┐
+                  │              │         │
+Agent C ——reads——─┘           Child 1   Child 2
+                                │         │
+                              report    report
+                                │         │
+                                └────┬────┘
+                                     ▼
+                                   Parent
+```
+
+Both channels live in the same on-disk directory, guarded by the same atomic-write and file-lock primitives as the run store. Both are opt-in and bounded.
+
+## The four tools
+
+When a phase opts into shared context, its subagent receives four tools:
+
+```json title="Opting in per-phase"
+{
+  "id": "review-each",
+  "type": "map",
+  "shareContext": true,
+  "over": "{steps.discover.json.files}",
+  "as": "file",
+  "agent": "security-reviewer",
+  "task": "Review {file.path} for vulnerabilities."
+}
+```
+
+The subagent can now call:
+
+- **`ctx_write(key, value)`** — publish a finding to the shared blackboard.
+- **`ctx_read(key?)`** — read findings from the blackboard (optionally a single key).
+- **`ctx_report(summary, structured?)`** — send a summary upward to the parent.
+- **`ctx_spawn(assignments[])`** — queue child tasks the runtime picks up after this agent finishes.
+
+<Steps>
+  <Step title="Publish a finding">
+    The first reviewer reads the architecture diagram and publishes a summary:
+    
+    ```json title="ctx_write call"
+    {
+      "key": "architecture-summary",
+      "value": {
+        "pattern": "microservices",
+        "critical_paths": ["/auth", "/payment"],
+        "trust_boundaries": ["api-gateway", "service-mesh"]
+      }
+    }
+    ```
+  </Step>
+  
+  <Step title="Read findings">
+    The next nine reviewers read the summary instead of re-reading the diagram:
+    
+    ```json title="ctx_read call"
+    {
+      "key": "architecture-summary"
+    }
+    ```
+    
+    Each saves the tokens the first agent spent on the full read.
+  </Step>
+  
+  <Step title="Report upward">
+    When a reviewer finishes, it reports its verdict:
+    
+    ```json title="ctx_report call"
+    {
+      "summary": "Found 2 critical issues in /auth/oauth.ts",
+      "structured": {
+        "severity": "critical",
+        "issues": ["CSRF-token-leak", "SQL-injection"]
+      }
+    }
+    ```
+  </Step>
+  
+  <Step title="Spawn children">
+    A reviewer discovers a submodule that needs deeper inspection and queues child tasks:
+    
+    ```json title="ctx_spawn call"
+    {
+      "assignments": [
+        {
+          "task": "Deep-audit /auth/oauth.ts for token handling",
+          "agent": "security-reviewer"
+        },
+        {
+          "task": "Check /auth/session.ts for session fixation",
+          "agent": "security-reviewer"
+        }
+      ]
+    }
+    ```
+    
+    The runtime picks up these assignments after the parent agent finishes and runs them as child nodes in the supervision tree.
+  </Step>
+</Steps>
+
+## Who sees what
+
+The blackboard is not a free-for-all. Visibility is scoped to prevent reading half-written work:
+
+**A node sees:**
+
+- Its **own** findings, always (even while still running).
+- The findings of its **ancestors** (parent, grandparent, etc.).
+- The findings of **completed siblings** — never a sibling that is still running.
+
+That last rule is load-bearing. You never read a half-written blackboard. A sibling's findings become visible only once it has reported completion (`status: "done"` or `"failed"`), so you see a finished result, not a work-in-progress.
+
+```txt title="Visibility in a fan-out"
+Parent (done)
+  ├─ writes: "architecture-summary"
+  │
+  └─ Children (parallel map):
+      ├─ child-1 (running) → sees: parent's findings + own findings
+      ├─ child-2 (done)    → sees: parent's findings + own findings + child-2's findings
+      └─ child-3 (running) → sees: parent's findings + own findings
+                             (child-2 is visible because it is done)
+```
+
+**Key conflicts:** when two nodes write the same key, nearer scope wins. A node's own findings override its ancestors', and ancestors override completed siblings. This matches the intuition that a node trusts its own notes most.
+
+## On-disk layout
+
+The Shared Context Tree lives in a per-run directory under `<runs-root>/ctx/<run-id>/`:
+
+```txt title="Directory structure"
+<ctxDir>/
+├── tree.json                  the node tree (who spawned whom + status)
+├── tree.json.lock             lock guarding tree.json RMW cycles
+├── findings/
+│   ├── <nodeId>.json          findings written by one node (last-write-wins per key)
+│   └── <nodeId>.json.lock     per-node lock (siblings never contend)
+├── reports/
+│   └── <nodeId>.json          a node's upward report ({summary, structured?})
+└── pending/
+    └── <nodeId>-<seq>.json    a ctx_spawn intent the runtime will pick up
+```
+
+**Why per-node findings files** (not one shared `findings.json`): sibling subagents run concurrently. Giving each node its own file means concurrent writers never contend on the same lock—a node only locks its own file. A reader unions the relevant nodes' files (its ancestors plus completed siblings). This is the same "shard by writer" trick the run index uses to avoid a global write bottleneck.
+
+**Atomic writes and locks:** every file operation uses `writeFileAtomic` (write to temp, then `renameSync`) and `withLock` (file-based lock with stale-lock steal), the same primitives as `store.ts`. The tree inherits the project's "all file ops are atomic" invariant for free.
+
+## Limits and safety
+
+The Shared Context Tree is opt-in precisely because it punches a hole in context isolation. To keep that hole small, every channel is capped:
+
+| Channel | Limit | Rationale |
+|---------|-------|-----------|
+| Single finding value | 256 KB | Prevent a runaway tool call from filling the disk |
+| Single report summary | 256 KB | Same |
+| Report structured payload | 256 KB | Same |
+| Keys per node | 256 | Bound the size of one node's blackboard |
+| Spawn assignments per call | 16 | Prevent unbounded fan-out |
+| Spawn task prompt | 64 KB | Cap the size of a dynamically queued task |
+| Spawn subflow payload | 256 KB | Cap the size of an inline sub-DAG |
+| Key charset | `[A-Za-z0-9._-]` (≤128 chars) | Prevent path traversal and collisions |
+
+**What happens when you hit a limit:** the tool call throws an error that the subagent sees as a tool failure. The agent can retry with a smaller value, skip the write, or fail the phase—the runtime does not crash.
+
+**What is cleaned up:** the entire `<ctxDir>` is scoped to one run. When the run is cleaned up (per your retention policy), the context tree goes with it. Nothing leaks across runs or sessions.
+
+## Enabling shared context
+
+You can opt in at two levels:
+
+### Per-phase: `shareContext`
+
+Enable shared context for a single phase:
+
+```json title="Per-phase opt-in"
+{
+  "id": "review-each",
+  "type": "map",
+  "shareContext": true,
+  "over": "{steps.discover.json.files}",
+  "as": "file",
+  "agent": "security-reviewer",
+  "task": "Review {file.path}."
+}
+```
+
+### Flow-wide: `contextSharing`
+
+Enable shared context for every phase in the flow:
+
+```json title="Flow-wide opt-in"
+{
+  "name": "security-audit",
+  "contextSharing": true,
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "task": "..." },
+    { "id": "review-each", "type": "map", "over": "...", "task": "..." },
+    { "id": "summarize", "type": "agent", "agent": "auditor", "task": "..." }
+  ]
+}
+```
+
+**Precedence:** `shareContext` takes precedence over `contextSharing`. If you set `contextSharing: true` on the flow but `shareContext: false` on one phase, that phase is excluded. This lets you enable sharing globally and carve out exceptions.
+
+<Callout type="warn">
+  Shared context is a tradeoff. You gain efficiency and cooperation at the cost of phases no longer being fully independent. Leave it off until you have a concrete reason to turn it on—a shared expensive read, or a parent that needs to steer its children.
+</Callout>
+
+## Concrete use cases
+
+### Deduplicating expensive reads
+
+Ten parallel reviewers all need the same 50-page architecture document. The first reviewer reads it and publishes a 2-page summary to the blackboard. The next nine read the summary instead of the original, saving ~48 pages of context per agent.
+
+```json title="Dedup pattern"
+{
+  "id": "review-each",
+  "type": "map",
+  "shareContext": true,
+  "over": "{steps.list-files.json}",
+  "as": "file",
+  "agent": "reviewer",
+  "task": "If ctx_read('architecture-summary') is empty, read ARCHITECTURE.md and ctx_write('architecture-summary', <2-page summary>). Then review {file.path} using the summary."
+}
+```
+
+### Parent steering children
+
+A parent agent reviews its children's work and decides mid-flight to skip a module:
+
+```json title="Steering pattern"
+{
+  "id": "parent",
+  "type": "agent",
+  "shareContext": true,
+  "agent": "coordinator",
+  "task": "Review the initial scan. If /auth is broken, ctx_write('skip-auth', true) so your children skip it."
+}
+```
+
+Children check the blackboard before starting work:
+
+```json title="Child checks parent's finding"
+{
+  "id": "children",
+  "type": "map",
+  "shareContext": true,
+  "dependsOn": ["parent"],
+  "over": "{steps.list-modules.json}",
+  "as": "module",
+  "agent": "auditor",
+  "task": "If ctx_read('skip-auth') and {module.path} starts with '/auth', skip. Otherwise audit {module.path}."
+}
+```
+
+### Dynamic fan-out with ctx_spawn
+
+A reviewer discovers a submodule that needs deeper inspection and spawns child tasks dynamically:
+
+```json title="Dynamic spawn pattern"
+{
+  "id": "reviewer",
+  "type": "agent",
+  "shareContext": true,
+  "agent": "security-reviewer",
+  "task": "Review /auth. If you find submodules that need deep-audit, ctx_spawn them as child tasks."
+}
+```
+
+The runtime picks up the spawn intents after the reviewer finishes and runs them as child nodes in the supervision tree. Each child inherits the parent's context (it sees the parent's findings) and can itself spawn grandchildren.
+
+### Aggregating reports
+
+A parent collects structured reports from its children and decides whether to escalate:
+
+```json title="Aggregation pattern"
+{
+  "id": "parent",
+  "type": "reduce",
+  "shareContext": true,
+  "dependsOn": ["children"],
+  "agent": "coordinator",
+  "task": "Read ctx_report() from each child. If any report has severity='critical', escalate to the user. Otherwise summarize."
+}
+```
+
+## Resume safety
+
+The Shared Context Tree is resume-safe. When a run resumes:
+
+- **Tree nodes are upserted** by `nodeId`, so a re-run does not duplicate tree entries (which would double-count ancestor findings).
+- **`dedicated` workspaces** (if you use worktree isolation alongside shared context) reuse the same directory path per `(runId, phaseId)`.
+- **Findings persist** across resume, so a phase that already published findings does not need to re-publish them.
+
+This means you can resume a long-running flow without losing the cooperation state its phases built up.
+
+## The contract, restated
+
+The Shared Context Tree has two load-bearing guarantees:
+
+1. **Opt-in and bounded.** Shared context is disabled by default. When enabled, every channel is capped so cooperation cannot run away.
+2. **Atomic and isolated.** Every write is atomic and locked. Siblings never contend on the same lock. Nothing leaks across runs.
+
+Together they mean you can coordinate complex multi-agent workflows without sacrificing the safety and predictability that context isolation provides.
+
+## Next
+
+<Cards>
+  <Card title="Context Isolation" href="/en/docs/concepts/context-isolation">
+    The default behavior shared context builds on.
+  </Card>
+  <Card title="Phase Types" href="/en/docs/concepts/phases">
+    How the ten phase types use shared context.
+  </Card>
+  <Card title="Resume" href="/en/docs/concepts/resume">
+    How shared context survives across sessions.
+  </Card>
+</Cards>

--- a/website/content/docs/en/concepts/workspace-isolation.mdx
+++ b/website/content/docs/en/concepts/workspace-isolation.mdx
@@ -1,0 +1,281 @@
+---
+title: Workspace Isolation
+description: How taskflow gives each phase its own working directory — and cleans up afterwards.
+---
+
+Most phases run in the directory where you launched the flow. That is fine when the subagent is reading code, but it becomes a liability the moment a phase writes files, runs a build, or makes git commits. Two parallel branches editing the same `src/index.ts` will clobber each other. A failed experiment leaves artifacts in your tree that the next phase has to work around. A `script` phase that runs `npm install` pollutes your `node_modules` with packages only one subagent needed.
+
+Workspace isolation solves all of this with one field on the phase definition: `cwd`.
+
+## The three reserved keywords
+
+Set a phase's `cwd` to one of three reserved keywords and the runtime allocates an isolated working directory for it before execution, then tears it down afterwards. Leave `cwd` as a literal path (or omit it entirely) and the phase runs in the default directory as before — isolation is opt-in.
+
+```txt title="The three workspace modes"
+cwd: "temp"        →  /tmp/pi-tf-ws-<phase>-XXXXXX   (removed after phase)
+cwd: "dedicated"   →  <runs>/ws/<runId>/<phaseId>    (kept for inspection)
+cwd: "worktree"    →  git worktree on throwaway branch (removed after phase)
+```
+
+Each mode trades isolation against persistence. The right choice depends on whether the phase's side effects should survive the run.
+
+### `temp` — ephemeral scratch space
+
+A `temp` workspace is an OS-level temporary directory created via `fs.mkdtempSync` under the system's `os.tmpdir()`. The prefix `pi-tf-ws-<phaseId>-` makes the directory identifiable in `/tmp` listings; the random suffix guarantees uniqueness across concurrent phases.
+
+```json title="A phase that drafts code without touching your tree"
+{
+  "id": "draft-patch",
+  "type": "agent",
+  "cwd": "temp",
+  "task": "Write a patch for the issue described below.\n{steps.analyze.output}"
+}
+```
+
+**Cleanup:** The directory is recursively deleted when the phase finishes — on success or failure. The deletion is best-effort and contained: the runtime refuses to remove anything outside the OS tmpdir, so a future bug in path construction can never delete your project.
+
+**When to use:** Drafting experiments, code generation, intermediate file transforms, anything that produces files you do not need after the phase completes. If the phase's value is its text output (captured by the runtime), not its filesystem artifacts, `temp` is the right choice.
+
+### `dedicated` — persistent per-phase directory
+
+A `dedicated` workspace is a directory under the run's state tree at `<runsRoot>/ws/<runId>/<phaseId>`. It is created with `mkdirSync({ recursive: true })` and — critically — **never deleted** by the runtime.
+
+```json title="A phase whose artifacts you want to inspect afterwards"
+{
+  "id": "generate-report",
+  "type": "agent",
+  "cwd": "dedicated",
+  "task": "Generate a full HTML report from the audit data.\n{steps.audit.json}"
+}
+```
+
+**Cleanup:** None. The directory persists alongside the run state. It is cleaned up only when the run itself is pruned by the retention policy (`maxKeptRuns` / `maxRunAgeDays`).
+
+**Resume behavior:** The path is deterministic per `(runId, phaseId)`. If you resume a failed run, the same directory is reused — existing artifacts from the prior attempt are still there. This is by design: a `dedicated` workspace is the one mode where the runtime assumes you want to inspect or accumulate artifacts across attempts.
+
+**When to use:** Phases that produce files you want to review after the run (reports, generated code, test fixtures). Also useful for phases whose downstream siblings need to read artifacts from disk rather than through the interpolation system.
+
+### `worktree` — a real git worktree on a throwaway branch
+
+A `worktree` workspace is a genuine `git worktree add -b <branch> <dir> HEAD` invocation. The branch is named `tf/<runId>/<phaseId>-<timestamp>` (base-36 timestamp for compactness) and the working directory is allocated under the OS tmpdir, then populated by git with a full checkout of `HEAD`.
+
+```json title="A phase that makes isolated git commits"
+{
+  "id": "apply-migration",
+  "type": "agent",
+  "cwd": "worktree",
+  "task": "Apply the database migration plan from the previous step. Commit each migration file separately."
+}
+```
+
+**Cleanup:** On phase completion, the runtime runs `git worktree remove --force <dir>` (with a 30-second timeout), then `rmrf`s the directory as defense-in-depth, then `git branch -D <branch>` (with a 10-second timeout). Every step is best-effort: a leftover worktree or branch is harmless and does not fail the phase.
+
+**The fail-open fallback:** A worktree requires the phase's base directory to be inside a git work tree. When it is not — the base directory has no `.git`, or `git rev-parse --is-inside-work-tree` fails — the runtime degrades gracefully to a `temp` workspace. The phase still runs in an isolated directory; it just loses git semantics. A warning is attached to the phase's `warnings` array:
+
+```txt title="Warning on a degraded worktree"
+workspace:temp — worktree requested but base cwd is not a git work tree; used a temp dir instead
+```
+
+The same fallback applies if `git worktree add` itself fails (e.g. a conflicting branch name, a detached HEAD, or a 60-second timeout). The runtime cleans up the failed allocation and retries with `temp`.
+
+**When to use:** Phases that need to make git commits, run diffs, apply patches, or operate on a copy of the repository that can be discarded without affecting the main working tree. A tournament with N variants, each making independent commits, is the canonical use case.
+
+## How the runtime integrates
+
+The lifecycle is straightforward:
+
+```txt title="Workspace lifecycle in the runtime"
+1. phase.cwd is a keyword?
+   NO  → run phase in deps.cwd (default path). Done.
+   YES ↓
+2. allocateWorkspace(keyword, {baseCwd, runId, phaseId, runsRoot})
+   → Workspace { dir, kind, teardown, branch?, note? }
+3. Override deps.cwd → ws.dir for the phase's subagent(s)
+4. Execute the phase
+5. Attach workspace diagnostics to PhaseState.warnings (if degraded)
+6. ws.teardown() in a finally block (best-effort)
+```
+
+The teardown runs in a `finally` block, so it fires whether the phase succeeds, fails, or is aborted. The teardown itself is wrapped in `try/catch` — a cleanup error never replaces the phase's real outcome (the "safe emit" invariant from the project's error-handling conventions).
+
+## Fail-open, always
+
+Every workspace mode degrades rather than fails. The full degradation ladder:
+
+| Failure | Degradation |
+|---|---|
+| `temp`: `mkdtempSync` throws | Falls back to `baseCwd` (the run's default directory) with a warning |
+| `dedicated`: `mkdirSync` throws | Falls back to `baseCwd` with a warning |
+| `worktree`: base is not a git repo | Falls back to `temp` (still isolated, no git) |
+| `worktree`: temp dir allocation fails | Falls back to `temp` retry, then `baseCwd` |
+| `worktree`: `git worktree add` fails | Falls back to `temp` (with git stderr in the warning) |
+| Any teardown error | Silently swallowed; best-effort cleanup |
+
+In every case, the phase still runs. The runtime attaches a `note` to the workspace handle that surfaces as a `PhaseState.warnings` entry, so the degradation is visible in `/tf peek` but never blocks the run.
+
+```txt title="Example warning from a degraded workspace"
+workspace — dedicated workspace alloc failed: EACCES: permission denied
+```
+
+<Callout type="info">
+  The fail-open design is deliberate: a workspace is an isolation enhancement, not a correctness requirement. A phase that runs in the base directory instead of an isolated one may leave artifacts behind, but it still produces a correct result. The alternative — failing the phase because `/tmp` is full — would be strictly worse.
+</Callout>
+
+## Resume safety
+
+Resume (the cross-session replay system documented in [Resume](/en/docs/concepts/resume)) interacts with workspaces in specific ways:
+
+- **`temp`** and **`worktree`** are re-allocated from scratch on every run. If a phase is resumed (its input changed, or you forced a re-run), a fresh directory is created. The old temp/worktree directory was already torn down when the prior attempt finished.
+- **`dedicated`** is deterministic: the path `<runs>/ws/<runId>/<phaseId>` is the same across resume attempts. If the prior attempt left files behind, they are still there when the re-run starts. This is intentional — a `dedicated` workspace is the accumulation mode.
+- A phase that was cached (input hash unchanged, result restored) never triggers workspace allocation at all. The cached result is reused without re-running the subagent, so no directory is created or touched.
+
+<Callout type="warn">
+  A `dedicated` workspace accumulates across resume attempts. If a phase writes `output.json` on attempt 1, then fails and is re-run on attempt 2, the file from attempt 1 is still in the directory when attempt 2 starts. Design `dedicated` phases to be idempotent or to check for existing artifacts.
+</Callout>
+
+## Path containment
+
+The runtime enforces containment at two levels:
+
+1. **`dedicated` dirs are rooted under the run state.** The path `<runsRoot>/ws/<runId>/<phaseId>` is constructed from sanitized segments — phase ids are run through `safeSegment()`, which strips anything outside `[A-Za-z0-9._-]`, collapses leading dots, and caps at 100 characters. A phase id like `../../etc` becomes `______etc`.
+
+2. **`temp` and `worktree` deletion is root-restricted.** The `rmrf` helper refuses to delete anything outside the OS tmpdir and the run's own `ws/` tree. Even if a future bug produced a wrong path, the containment check prevents deletion of project files.
+
+3. **Dynamic sub-flows cannot use workspace keywords at all.** A generated sub-flow (one authored by an LLM via `flow { def }` or `ctx_spawn`) is rejected by validation if any phase sets `cwd` to `temp`, `dedicated`, or `worktree`. LLM-authored plans must not allocate isolated directories or create git worktrees that mutate the repository. Only author-written flows may use workspace isolation.
+
+## Choosing the right mode
+
+```txt title="Decision tree"
+Does the phase write files you need after it finishes?
+  YES → dedicated
+  NO  ↓
+Does the phase need git (commits, diffs, branches)?
+  YES → worktree
+  NO  → temp
+```
+
+| Mode | Isolated | Persistent | Git | Cleanup | Resume |
+|---|---|---|---|---|---|
+| `temp` | ✓ | ✗ | ✗ | Removed on finish | Re-allocated |
+| `dedicated` | ✓ | ✓ | ✗ | Kept until run pruned | Same dir reused |
+| `worktree` | ✓ | ✗ | ✓ | Worktree + branch removed | Re-allocated |
+
+## Examples
+
+### Parallel experiments without conflicts
+
+Two phases that each generate a full implementation, running in parallel. Without isolation they would write to the same files:
+
+```json title="Parallel isolated drafts"
+{
+  "name": "compare-approaches",
+  "phases": [
+    {
+      "id": "approach-a",
+      "type": "agent",
+      "cwd": "temp",
+      "task": "Implement the feature using approach A."
+    },
+    {
+      "id": "approach-b",
+      "type": "agent",
+      "cwd": "temp",
+      "task": "Implement the feature using approach B."
+    },
+    {
+      "id": "judge",
+      "type": "agent",
+      "task": "Compare:\nA: {steps.approach-a.output}\nB: {steps.approach-b.output}",
+      "dependsOn": ["approach-a", "approach-b"],
+      "final": true
+    }
+  ]
+}
+```
+
+Each draft runs in its own temp directory. Neither can see or overwrite the other's files.
+
+### A tournament with git commits
+
+Each variant makes independent commits on its own branch, then the judge picks the best:
+
+```json title="Tournament with worktree isolation"
+{
+  "name": "refactor-tournament",
+  "phases": [
+    {
+      "id": "variant-1",
+      "type": "agent",
+      "cwd": "worktree",
+      "task": "Refactor the auth module using strategy pattern. Commit each file change."
+    },
+    {
+      "id": "variant-2",
+      "type": "agent",
+      "cwd": "worktree",
+      "task": "Refactor the auth module using middleware chain. Commit each file change."
+    },
+    {
+      "id": "judge",
+      "type": "gate",
+      "task": "Review both refactor approaches. Output VERDICT: PASS for the better one with justification.",
+      "dependsOn": ["variant-1", "variant-2"],
+      "final": true
+    }
+  ]
+}
+```
+
+Each variant gets its own worktree on a throwaway branch (`tf/<runId>/variant-1-<ts>` and `tf/<runId>/variant-2-<ts>`). Commits are real git commits, fully isolated from the main tree. Both worktrees and branches are cleaned up when their phases finish.
+
+### An audit that leaves artifacts for review
+
+```json title="Dedicated workspace for inspectable output"
+{
+  "name": "security-audit",
+  "phases": [
+    {
+      "id": "scan",
+      "type": "agent",
+      "cwd": "dedicated",
+      "task": "Scan the codebase for vulnerabilities. Write a findings.json file with all issues found."
+    },
+    {
+      "id": "report",
+      "type": "agent",
+      "task": "Read the scan results:\n{steps.scan.output}\nWrite a human-readable summary.",
+      "dependsOn": ["scan"],
+      "final": true
+    }
+  ]
+}
+```
+
+The `scan` phase's `dedicated` workspace keeps `findings.json` on disk after the run completes. You can inspect it with `/tf peek` or find it directly under the run's `ws/` directory.
+
+## Warnings and diagnostics
+
+When a workspace degrades or encounters an issue, the runtime attaches a warning to the phase state. These are visible in `/tf peek <runId>` and in the persisted run record:
+
+```txt title="Workspace warning examples"
+workspace:temp at /tmp/pi-tf-ws-draft-patch-a1b2c3/
+workspace:temp — worktree requested but base cwd is not a git work tree; used a temp dir instead
+workspace — dedicated workspace alloc failed: EACCES: permission denied
+workspace:worktree at /tmp/pi-tf-wt-apply-migration-x4y5z6/ (branch: tf/abc123/apply-migration-m3k2j1)
+```
+
+A warning that says `workspace:<kind> at <path>` is informational — the workspace was allocated successfully. A warning with `—` after the kind indicates degradation.
+
+## Next
+
+<Cards>
+  <Card title="Context Isolation" href="/en/docs/concepts/context-isolation">
+    Workspace isolation handles the filesystem; context isolation handles the transcript.
+  </Card>
+  <Card title="Resume" href="/en/docs/concepts/resume">
+    How cached phases skip workspace allocation entirely.
+  </Card>
+  <Card title="Phase Types" href="/en/docs/concepts/phases">
+    The `script` phase type and when workspace isolation matters most.
+  </Card>
+</Cards>

--- a/website/content/docs/en/guides/agents-and-model-roles.mdx
+++ b/website/content/docs/en/guides/agents-and-model-roles.mdx
@@ -1,0 +1,487 @@
+---
+title: Agents and Model Roles
+description: How taskflow discovers agents from three layers, maps them to six model roles, and resolves the right agent for each phase.
+---
+
+Every phase in a taskflow runs as a subagent — an isolated LLM process with its own context window, system prompt, and tool set. That isolation is what keeps intermediate transcripts out of your conversation: only the final phase output comes back.
+
+But which agent runs which phase? And which model does that agent use? taskflow answers both questions with a layered discovery system and a role-based model mapping. You can use the 18 built-in agents as-is, override them with project-specific versions, or write entirely custom agents — all without changing a single flow definition.
+
+This guide covers the full picture: how agents are discovered, what the built-in agents do, how model roles work, and how to customize everything.
+
+## Agent discovery
+
+taskflow loads agents from three layers, in order:
+
+<Steps>
+  <Step>
+    **Built-in agents.** Eighteen agents ship with the taskflow package. They cover the full software development lifecycle: planning, execution, review, security, testing, and recovery. These agents are always available unless explicitly disabled.
+  </Step>
+  <Step>
+    **User agents.** Agents in `~/.pi/agent/agents/` (or the directory set by `TASKFLOW_AGENT_DIR` or `PI_CODING_AGENT_DIR`). These are your personal agents, shared across all your projects.
+  </Step>
+  <Step>
+    **Project agents.** Agents in `.pi/agents/` at the root of your project (or any parent directory). taskflow walks up the directory tree from the current working directory to find the nearest `.pi/agents/` folder. These are project-specific agents, versioned with your codebase.
+  </Step>
+</Steps>
+
+The layers override each other by name. If you have a project agent called `executor` and a built-in agent also called `executor`, the project version wins. This lets you customize behavior without forking the entire agent set.
+
+<Callout type="info">
+  Agent names use hyphens, not underscores: `executor-code` is correct, `executor_code` is not. The runtime validates this and will warn you if you use underscores.
+</Callout>
+
+### The `agentScope` field
+
+Not every flow needs all three layers. The `agentScope` field on a taskflow controls which layers are active:
+
+| Scope | What's loaded | Use case |
+|---|---|---|
+| `"user"` (default) | Built-in + user agents | Personal workflows that don't depend on project-specific agents. |
+| `"project"` | Built-in + project agents | Team workflows where project agents override user preferences. |
+| `"both"` | Built-in + user + project agents | Full resolution: project overrides user overrides built-in. |
+
+Set `agentScope` at the top level of your taskflow:
+
+```json title="project-scoped.json"
+{
+  "name": "project-review",
+  "agentScope": "project",
+  "phases": [...]
+}
+```
+
+<Callout type="tip">
+  If you're building a flow that will run on a teammate's machine, use `agentScope: "project"` so it doesn't depend on their personal `~/.pi/agent/agents/` directory.
+</Callout>
+
+## The 18 built-in agents
+
+taskflow ships with 18 agents organized into four categories. Each agent is defined as a markdown file with YAML frontmatter specifying its name, description, tools, model role, and thinking level.
+
+### Planning and analysis
+
+These agents analyze requirements, create plans, and challenge assumptions before code is written.
+
+| Agent | Role | Thinking | Purpose |
+|---|---|---|---|
+| `analyst` | `{{thinker}}` | high | Analyze requirements, surface ambiguity, identify hidden constraints. Read-only. |
+| `critic` | `{{thinker}}` | xhigh | Challenge plans and conclusions, find contradictions before commitment. Read-only. |
+| `planner` | `{{strong}}` | high | Create concrete implementation plans with file-level detail. Read-only. |
+| `plan-arbiter` | `{{arbiter}}` | high | Review and challenge plans before execution begins. Read-only. |
+
+The `analyst` runs first in complex pipelines to clarify requirements. The `planner` turns those requirements into actionable plans. The `critic` and `plan-arbiter` act as quality gates — they push back on weak plans before expensive execution begins.
+
+### Execution
+
+These agents write code. They differ in scope and complexity.
+
+| Agent | Role | Thinking | Purpose |
+|---|---|---|---|
+| `executor` | `{{fast}}` | high | Default executor for 1–4 files with a clear plan. |
+| `executor-fast` | `{{fast}}` | off | Trivial changes: ≤2 files, ≤50 lines, no architecture decisions. |
+| `executor-code` | `{{strong}}` | high | Complex multi-file changes: ≥5 files, cross-module, structural refactors. |
+| `executor-ui` | `{{vision}}` | high | UI/frontend changes: components, styling, layout, responsive design. |
+
+The default `executor` handles most work. Use `executor-fast` for mechanical cleanups, `executor-code` for structural refactors, and `executor-ui` when you need vision capabilities to understand design intent.
+
+### Review and quality
+
+These agents review code, assess risk, and verify outcomes. None of them edit files.
+
+| Agent | Role | Thinking | Purpose |
+|---|---|---|---|
+| `reviewer` | `{{strong}}` | high | General code review: quality, architecture, test coverage. |
+| `risk-reviewer` | `{{reasoner}}` | high | Backend/infrastructure risk: data integrity, concurrency, migrations. |
+| `security-reviewer` | `{{reasoner}}` | high | Security vulnerabilities: auth, injection, secrets, trust boundaries. |
+| `final-arbiter` | `{{arbiter}}` | xhigh | Resolve conflicts when multiple reviewers disagree. Tiebreaker. |
+
+The `reviewer` handles general quality. The `risk-reviewer` and `security-reviewer` specialize in high-stakes domains and defer to each other at domain boundaries. The `final-arbiter` breaks ties when reviews conflict.
+
+### Support
+
+These agents handle auxiliary tasks: testing, documentation, exploration, and recovery.
+
+| Agent | Role | Thinking | Purpose |
+|---|---|---|---|
+| `test-engineer` | `{{fast}}` | high | Design and implement test strategies, detect flaky patterns. |
+| `verifier` | `{{fast}}` | off | Run validation commands, reproduce failures, check logs. Read-only. |
+| `scout` | `{{fast}}` | off | Fast codebase exploration, return structured findings for other agents. |
+| `doc-writer` | `{{fast}}` | off | Author and edit documentation files (READMEs, guides, changelogs). |
+| `visual-explorer` | `{{vision}}` | high | Analyze Figma designs, extract colors, tokens, and component specs. |
+| `recover` | `{{fast}}` | low | Resume work after context compaction, pick up from handoff files. |
+
+The `scout` does quick recon so other agents don't have to re-read everything. The `test-engineer` and `verifier` handle validation. The `visual-explorer` parses design files. The `recover` agent picks up work after a context window reset.
+
+## Model roles
+
+Each built-in agent specifies a model role in its frontmatter — not a concrete model ID, but a role name wrapped in double braces: `{{fast}}`, `{{strong}}`, `{{thinker}}`, `{{arbiter}}`, `{{vision}}`, or `{{reasoner}}`.
+
+This indirection exists because different users have different models available. A role is a semantic contract ("this agent needs fast, cheap inference") that gets resolved to a concrete model based on your configuration.
+
+### The six roles
+
+| Role | Semantic contract | Default model | Used by |
+|---|---|---|---|
+| `{{fast}}` | Cheap and quick, high-volume low-stakes | `openrouter/deepseek/deepseek-v4-flash` | `executor`, `executor-fast`, `scout`, `verifier`, `doc-writer`, `test-engineer`, `recover` |
+| `{{strong}}` | Balanced capability, moderate complexity | `openrouter/xiaomi/mimo-v2.5-pro` | `planner`, `reviewer`, `executor-code` |
+| `{{thinker}}` | Deep reasoning, high thinking budget | `openrouter/deepseek/deepseek-v4-pro` | `analyst`, `critic` |
+| `{{arbiter}}` | High-stakes judgment, tie-breaking | `openrouter/qwen/qwen3.7-max` | `plan-arbiter`, `final-arbiter` |
+| `{{vision}}` | Multimodal, image understanding | `minimax/MiniMax-M3` | `executor-ui`, `visual-explorer` |
+| `{{reasoner}}` | Cautious reasoning, security-sensitive | `z-ai/glm-5.1` | `risk-reviewer`, `security-reviewer` |
+
+The defaults work well out of the box. But you might want to swap them — for example, if you have a Claude Pro subscription and want to use `anthropic/claude-3.5-sonnet` for `{{strong}}` instead of the default.
+
+### How roles are resolved
+
+When a phase spawns a subagent, the runtime checks the agent's `model` field. If it matches the pattern `{{roleName}}`, the runtime looks up that role in your settings and substitutes the concrete model ID. If no mapping exists, the model field is left empty and the host's default model is used.
+
+```text
+Agent frontmatter:  model: "{{strong}}"
+                       ↓
+settings.json:      modelRoles: { "strong": "anthropic/claude-3.5-sonnet" }
+                       ↓
+Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
+```
+
+An agent with a literal model ID (no braces) bypasses role resolution entirely. This is useful for custom agents that must always use a specific model.
+
+## Configuring with `/tf init`
+
+The `/tf init` command walks you through role configuration interactively. It reads your current settings, shows you the available models from your provider's registry, and writes your choices back atomically.
+
+<Callout type="tip">
+  Run `/tf init` the first time you install taskflow. The recommended defaults work well for most users, but you may want to swap the `vision` role to a different multimodal model or the `arbiter` role to a stronger reasoning model.
+</Callout>
+
+### The action menu
+
+When you run `/tf init`, you see an action menu:
+
+1. **Use recommended defaults** — Apply the default models from the table above.
+2. **Configure each role** — Walk through all six roles one by one.
+3. **Edit one role** — Change a single role without touching the others.
+4. **Configure taskflow preferences** — Adjust built-in agent settings.
+5. **Show current roles** — Display your current configuration without changes.
+
+For each role, the picker shows available models from your registry with capability tags (`image ✓` for multimodal, `reasoning ✓` for reasoning-capable models), plus markers for your current choice and the recommended default.
+
+### Custom model identifiers
+
+You can also type a custom model identifier in `provider/model-id` format. The runtime validates it against your model registry and warns you if the model doesn't exist — a typo here would silently break every flow that uses the role.
+
+### Where settings are stored
+
+All configuration is saved to `~/.pi/agent/settings.json` (or the path set by `TASKFLOW_AGENT_DIR` / `PI_CODING_AGENT_DIR`):
+
+```json title="settings.json"
+{
+  "modelRoles": {
+    "fast": "openrouter/deepseek/deepseek-v4-flash",
+    "strong": "openrouter/xiaomi/mimo-v2.5-pro",
+    "thinker": "openrouter/deepseek/deepseek-v4-pro",
+    "arbiter": "openrouter/qwen/qwen3.7-max",
+    "vision": "minimax/MiniMax-M3",
+    "reasoner": "z-ai/glm-5.1"
+  },
+  "taskflow": {
+    "builtInAgents": true,
+    "syncBuiltinAgentsToProject": false,
+    "maxKeptRuns": 100,
+    "maxRunAgeDays": 30
+  }
+}
+```
+
+### Taskflow preferences
+
+The "Configure taskflow preferences" option in `/tf init` adjusts four settings:
+
+| Setting | Default | Description |
+|---|---|---|
+| `builtInAgents` | `true` | Enable or disable the 18 built-in agents. Disable this if you only want your own agents. |
+| `syncBuiltinAgentsToProject` | `false` | Copy built-in agents into your project's `.pi/agents/` on session start, so native Pi `@agent` syntax can discover them too. |
+| `maxKeptRuns` | `100` | Maximum completed/failed runs to keep. Set to `0` to disable count-based cleanup. |
+| `maxRunAgeDays` | `30` | Maximum age (days) for completed/failed runs. Set to `0` to disable age-based cleanup. |
+
+<Callout type="info">
+  Cleanup runs automatically, throttled to once per minute. It only removes terminal (completed or failed) runs — active runs are never touched.
+</Callout>
+
+## Custom agents
+
+You can create custom agents by writing markdown files with YAML frontmatter. Custom agents live in user scope (`~/.pi/agent/agents/`) or project scope (`.pi/agents/`).
+
+### Agent file format
+
+Every agent file has three parts: YAML frontmatter between `---` delimiters, a blank line, and the system prompt body.
+
+```markdown title="~/.pi/agent/agents/code-reviewer.md"
+---
+name: code-reviewer
+description: Review code for quality and best practices
+tools: read, grep, find, ls, bash
+model: "{{strong}}"
+thinking: high
+---
+
+You are a code reviewer focused on quality and best practices.
+
+Review the provided code for:
+- Code style and consistency
+- Performance implications
+- Error handling
+- Test coverage
+
+Be specific and actionable. Don't just say "this could be better" — explain why and how.
+```
+
+### Frontmatter fields
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Unique identifier, used to reference the agent in flows. Use hyphens. |
+| `description` | Yes | Brief description shown in agent listings and picker UIs. |
+| `tools` | No | Comma-separated tool list: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`. Defaults to all tools if omitted. |
+| `model` | No | Model ID or role reference (e.g., `openai/gpt-4o` or `"{{strong}}"`). Falls back to the host's default model. |
+| `thinking` | No | Thinking level: `off`, `low`, `high`, `xhigh`. Falls back to the `globalThinking` setting. |
+
+<Callout type="info">
+  A malformed agent file never breaks discovery. The runtime catches parse errors and skips the bad file with a warning, so the rest of your agents load normally.
+</Callout>
+
+### Overriding built-in agents
+
+To override a built-in agent, create a custom agent with the same name in your user or project agents directory. The layer order determines which version wins:
+
+```markdown title=".pi/agents/executor.md"
+---
+name: executor
+description: Custom executor with project-specific conventions
+tools: read, grep, find, ls, bash, edit, write
+model: "{{strong}}"
+thinking: high
+---
+
+You are the executor agent for the Acme Corp codebase.
+
+Always follow these project-specific rules:
+- Use TypeScript strict mode
+- Prefer functional patterns over classes
+- Write tests for all public functions
+- Run `pnpm typecheck` before committing
+```
+
+This project-level `executor` replaces the built-in `executor` for any flow run in this project. A user-level override in `~/.pi/agent/agents/executor.md` would apply across all your projects.
+
+<Callout type="warn">
+  Overrides are matched by exact name. `my-executor` does not override `executor`. If you want a variant, give it a different name and reference it explicitly in your flows.
+</Callout>
+
+## Agent resolution in flows
+
+When a phase runs, the runtime resolves its agent through a specific process:
+
+<Steps>
+  <Step>
+    **Check the phase's `agent` field.** If the phase specifies an agent name, look it up in the discovery result.
+  </Step>
+  <Step>
+    **Warn on unknown agents.** If the named agent doesn't exist in the discovery result, log a warning (once per unknown agent per run) and fall back to the default agent.
+  </Step>
+  <Step>
+    **Fall back to the default agent.** The default is the first agent in the discovery result — typically the first built-in agent alphabetically, unless user or project agents override it. If no agents exist at all, the name `"default"` is used.
+  </Step>
+</Steps>
+
+### Specifying agents in phases
+
+Most phases specify an agent explicitly:
+
+```json title="phase-with-agent.json"
+{
+  "id": "review",
+  "type": "agent",
+  "agent": "reviewer",
+  "task": "Review the code changes for quality issues."
+}
+```
+
+You can omit the `agent` field. The phase will use the default agent:
+
+```json title="phase-without-agent.json"
+{
+  "id": "review",
+  "type": "agent",
+  "task": "Review the code changes for quality issues."
+}
+```
+
+<Callout type="info">
+  The default agent depends on your `agentScope` and which agents exist in each layer. For predictable behavior across different environments, specify agents explicitly.
+</Callout>
+
+### Phase-level overrides
+
+Phases can override an agent's model, thinking level, and tool access without modifying the agent file:
+
+```json title="phase-with-overrides.json"
+{
+  "id": "deep-review",
+  "type": "agent",
+  "agent": "reviewer",
+  "model": "anthropic/claude-3.5-sonnet",
+  "thinking": "xhigh",
+  "tools": ["read", "grep"],
+  "task": "Deep review of the authentication module."
+}
+```
+
+These overrides apply only to this phase invocation. The agent's frontmatter settings are still used for other phases that don't override them.
+
+| Override | Effect |
+|---|---|
+| `model` | Replace the agent's model for this phase. Accepts a role (`"{{strong}}"`) or a literal model ID. |
+| `thinking` | Override the thinking level: `off`, `low`, `high`, `xhigh`. |
+| `tools` | Restrict the tool set. Useful for read-only phases that should not modify files. |
+
+### Branches and sub-phases
+
+Phase types with multiple branches (`parallel`, `tournament`) let each branch specify its own agent:
+
+```json title="parallel-with-per-branch-agents.json"
+{
+  "id": "review-all",
+  "type": "parallel",
+  "branches": [
+    {
+      "agent": "security-reviewer",
+      "task": "Review for security vulnerabilities."
+    },
+    {
+      "agent": "risk-reviewer",
+      "task": "Review for data integrity risks."
+    },
+    {
+      "agent": "reviewer",
+      "task": "Review for general code quality."
+    }
+  ]
+}
+```
+
+Branches that don't specify an agent inherit the parent phase's agent. Tournament phases also support a `judgeAgent` field for the judge step, which defaults to the phase's main agent.
+
+### Inheritance in sub-flows
+
+When a `flow` phase spawns an inline sub-flow, inner phases that don't specify their own agent inherit the parent phase's `defaultAgent` (or `agent` field). This means a single agent assignment at the parent level cascades to every child phase that doesn't override it.
+
+## Practical examples
+
+### Multi-stage review pipeline
+
+Different agents handle different review concerns, and a final arbiter synthesizes the results:
+
+```json title="multi-stage-review.json"
+{
+  "name": "review-pipeline",
+  "phases": [
+    {
+      "id": "plan",
+      "type": "agent",
+      "agent": "planner",
+      "task": "Analyze the code changes and create a review plan."
+    },
+    {
+      "id": "security-review",
+      "type": "agent",
+      "agent": "security-reviewer",
+      "dependsOn": ["plan"],
+      "task": "Review for security issues based on this plan: {steps.plan.output}"
+    },
+    {
+      "id": "quality-review",
+      "type": "agent",
+      "agent": "reviewer",
+      "dependsOn": ["plan"],
+      "task": "Review for code quality: {steps.plan.output}"
+    },
+    {
+      "id": "synthesis",
+      "type": "agent",
+      "agent": "final-arbiter",
+      "dependsOn": ["security-review", "quality-review"],
+      "task": "Synthesize these reviews and resolve any conflicts:\n\nSecurity: {steps.security-review.output}\n\nQuality: {steps.quality-review.output}",
+      "final": true
+    }
+  ]
+}
+```
+
+### Custom domain agent
+
+Create a specialized agent for your domain, then reference it in flows:
+
+```markdown title=".pi/agents/api-designer.md"
+---
+name: api-designer
+description: Design RESTful APIs following OpenAPI 3.0 spec
+tools: read, grep, find, ls, write
+model: "{{strong}}"
+thinking: high
+---
+
+You are an API designer specializing in RESTful APIs.
+
+Follow these principles:
+- Use nouns for resource names, verbs for actions
+- Return appropriate HTTP status codes
+- Include pagination for list endpoints
+- Version APIs in the URL path (e.g., /v1/users)
+- Write OpenAPI 3.0 specs in YAML format
+```
+
+```json title="api-design-flow.json"
+{
+  "id": "design-api",
+  "type": "agent",
+  "agent": "api-designer",
+  "output": "text",
+  "task": "Design a REST API for a task management system with projects, tasks, and users."
+}
+```
+
+### Project-scoped team workflow
+
+Use `agentScope: "project"` so every team member gets the same agent behavior:
+
+```json title="team-review.json"
+{
+  "name": "team-review",
+  "agentScope": "project",
+  "phases": [
+    {
+      "id": "review",
+      "type": "agent",
+      "agent": "team-reviewer",
+      "task": "Review the code using team standards documented in .pi/agents/team-reviewer.md."
+    }
+  ]
+}
+```
+
+With a project agent in `.pi/agents/team-reviewer.md` that encodes your team's specific review criteria. This flow runs the same way for everyone on the team, regardless of their personal agent directory.
+
+## Next
+
+<Cards>
+  <Card title="Phase Types" href="/en/docs/syntax/phase-types">
+    Learn about all 10 phase types and when to use each one.
+  </Card>
+  <Card title="Tournament Selection" href="/en/docs/guides/tournament">
+    Spawn competing variants and let a judge pick the best result.
+  </Card>
+  <Card title="Dynamic Planning" href="/en/docs/guides/dynamic-planning">
+    Generate sub-flows at runtime and validate them before execution.
+  </Card>
+</Cards>

--- a/website/content/docs/en/guides/background-runs.mdx
+++ b/website/content/docs/en/guides/background-runs.mdx
@@ -1,0 +1,304 @@
+---
+title: Background Runs
+description: Kick off long-running flows as detached child processes and poll for results.
+---
+
+Some flows take minutes. Some take hours. Neither should hold your conversation hostage.
+
+When you set `detach: true` on a taskflow call, the runtime spawns the entire DAG as an independent child process and returns immediately with a `runId`. Your context window stays free. The flow runs to completion in the background, persisting its state after each phase. You check on it later — or never, if you only care about the side effects.
+
+This page covers when to detach, how to poll, what happens to approval gates, and the crash-safety guarantees that keep background runs debuggable.
+
+## When to detach
+
+A normal taskflow call blocks your conversation until the final phase returns. That is the right default for most work — you asked for a result, you want it now. But three situations favor detaching:
+
+**The flow is long.** A multi-hour audit, a large `map` over hundreds of files, a `loop` that converges slowly. Blocking your conversation for that duration wastes the interactive session.
+
+**The flow is fire-and-forget.** A nightly batch, a CI pipeline, a webhook-triggered reindex. You care about the terminal state, not the live transcript.
+
+**You want to overlap work.** Kick off a slow flow, continue the current conversation, check back later. The parent session is never blocked.
+
+<Callout type="info">
+  Detaching is a runtime concern, not a flow-definition concern. The same JSON flow can run inline or detached — the `detach` flag lives on the tool call, not in the flow definition.
+</Callout>
+
+## Starting a background run
+
+### On Pi
+
+Pass `detach: true` to the `taskflow` tool. The model can do this automatically when it judges the flow is long-running, or you can be explicit:
+
+<Callout type="tip">
+  Try: *"Run the audit flow in the background — I'll check on it later."*
+</Callout>
+
+Or via the command:
+
+```bash title="Start a detached run"
+/tf run audit dir=src --detach
+```
+
+The response is immediate:
+
+```
+Taskflow 'audit' started in background (pid: 42871). Run id: 2026-07-06T14-32-01-audit
+```
+
+That `runId` is your handle. The `pid` is the OS process id of the detached child — useful if you need to inspect or signal it directly.
+
+### On Codex, Claude Code, OpenCode
+
+The MCP server exposes the same `detach` parameter on the `taskflow_run` tool. The mechanics are identical: the server spawns a child process and returns the `runId` in the tool result.
+
+```json title="MCP tool call"
+{
+  "action": "run",
+  "name": "audit",
+  "args": { "dir": "src" },
+  "detach": true
+}
+```
+
+## What happens under the hood
+
+<Steps>
+  <Step>
+    **Serialize context.** The host writes a small JSON file to a temp directory. It contains the `runId`, the flow definition name, the resolved args, the working directory, and the path to the host's runner module (so the child can spawn subagents).
+  </Step>
+  <Step>
+    **Spawn the child.** The host calls `child_process.spawn` with `detached: true` and `child.unref()`. The child is a standalone Node process running the `detached-runner` script. It receives the context file path as `argv[2]`.
+  </Step>
+  <Step>
+    **Return immediately.** The host persists the initial run state (with `detached: true` and the child's `pid`), then returns the `runId` to the caller. The parent conversation is free.
+  </Step>
+  <Step>
+    **The child runs the DAG.** The detached runner reads the context file, re-discovers agents, dynamically imports the host's runner module, and calls `executeTaskflow`. Each phase runs exactly as it would inline — subagent calls, caching, retry, persistence.
+  </Step>
+  <Step>
+    **Persist terminal state.** When the flow completes (or fails), the child persists the final `RunState` to disk and exits. The parent can poll the store at any time to see the result.
+  </Step>
+</Steps>
+
+The child process is genuinely independent. It has its own event loop, its own stderr, and its own lifecycle. Killing the parent does not kill the child — that is by design. The child was spawned with `detached: true` specifically so it survives the parent session.
+
+## Polling and monitoring
+
+A detached run persists its state to disk after every phase. You can check on it from any session in the same project.
+
+### Browse run history
+
+```bash title="List all runs, including in-progress detached runs"
+/tf runs
+```
+
+Detached runs show their `pid` and `detached: true` flag. In-progress runs show `status: running`. Completed runs show their terminal state.
+
+### Peek at a phase
+
+```bash title="Inspect a phase's output from a detached run"
+/tf peek <runId> <phaseId>
+```
+
+This is the same `peek` command you use for any run. It pulls the phase's persisted output into your context — useful for debugging a gate that blocked or a map that partially failed.
+
+<Callout type="warn">
+  `peek` is for debugging only. By design it pulls intermediate output into your context — that's the one exception to taskflow's isolation guarantee, and it's opt-in.
+</Callout>
+
+### Resume a failed run
+
+If a detached run fails (a transient error exhausted its retries, a gate blocked, a subagent crashed), you can resume it from where it stopped:
+
+```bash title="Resume a failed detached run"
+/tf resume <runId>
+```
+
+Resume runs inline by default. If you want the resumed run to also be detached, pass `--detach` again.
+
+## Approval phases in detached mode
+
+Approval phases are human-in-the-loop gates. They pause the flow and wait for a decision. In a detached run, there is no interactive approver — the child process has no TTY, no UI, no way to ask a human.
+
+<Callout type="warn">
+  **Approval phases auto-reject in detached mode.** The gate records a `BLOCK` verdict with the reason `"(auto-rejected: no interactive approver available)"`. The run halts at that phase, just as if a human had rejected it.
+</Callout>
+
+This is a safety boundary, not a limitation. Approval gates exist to prevent unreviewed work from shipping. Silently bypassing them in a non-interactive context would defeat their purpose. If your flow has approval phases and you want it to run unattended, replace them with `gate` phases (which are deterministic and don't require human input) or remove them entirely.
+
+The auto-rejection is recorded in the run state. When you poll the run, you'll see:
+
+```json
+{
+  "id": "approve-deploy",
+  "status": "done",
+  "output": "(auto-rejected: no interactive approver available)",
+  "approval": { "decision": "reject", "auto": true },
+  "gate": { "verdict": "block", "reason": "(auto-rejected: no interactive approver available)" }
+}
+```
+
+The phase itself is `done` (it executed), but the gate it carries is `block`, which halts downstream phases.
+
+## Crash safety
+
+Background runs can fail in ways that inline runs cannot: the child process can crash, the runner module can fail to load, the OS can kill the process. taskflow handles each failure mode explicitly so the run is never silently stuck.
+
+### Top-level crash guard
+
+The detached runner wraps its entire execution in a top-level `try/catch`. If an unhandled exception reaches the top level, the catch block persists `status: "failed"` to the run state before exiting. The run is never left in `status: "running"` after the child process dies.
+
+### Runner module failure
+
+The detached runner dynamically imports the host's runner module (e.g., `piSubagentRunner` from `pi-taskflow`). If the import fails — bad path, missing export, compile error — the runner writes a synthetic `__detach__` phase with the import error and exits with code 1:
+
+```json
+{
+  "id": "__detach__",
+  "status": "failed",
+  "error": "Runner module failed to load: 'pi-taskflow/dist/runner.js' (export 'piSubagentRunner'). See detached-runner stderr for the import error."
+}
+```
+
+This fail-fast behavior prevents the runner from limping on and failing every phase with the generic "No subagent runner injected" error. The real cause (a bad module path, a missing export) is preserved in the `__detach__` phase and in the child's stderr.
+
+### Early exit guard
+
+The parent process captures the child's stderr and registers an `exit` handler. If the child exits with a non-zero code before reaching a terminal state, the parent marks the run failed and writes a `__detach__` phase with the captured stderr:
+
+```json
+{
+  "id": "__detach__",
+  "status": "failed",
+  "error": "Detached runner exited with code 1: [stderr content]"
+}
+```
+
+This guard is race-safe: it checks the child's `pid` and the run's `status` before writing, so it never clobbers a genuine terminal state the runner may have persisted between spawn and exit.
+
+### Spawn failure
+
+If the child process fails to spawn at all (permission denied, missing Node binary), the parent's `error` handler writes a `__detach__` phase with the spawn error. The run is marked failed immediately.
+
+## Use cases
+
+### Long-running audits
+
+A security audit that scans hundreds of files, runs each through a reviewer, and aggregates findings. Inline, this blocks your conversation for 30+ minutes. Detached, you kick it off and check back when it's done.
+
+```json title="long-audit.json"
+{
+  "name": "security-audit",
+  "phases": [
+    {
+      "id": "discover",
+      "type": "agent",
+      "agent": "scout",
+      "task": "List all TypeScript files under {args.dir}. Output a JSON array of paths.",
+      "output": "json"
+    },
+    {
+      "id": "review-each",
+      "type": "map",
+      "over": "{steps.discover.json}",
+      "as": "file",
+      "agent": "security-reviewer",
+      "task": "Review {file} for security vulnerabilities. Return findings or 'No issues.'",
+      "concurrency": 8
+    },
+    {
+      "id": "summarize",
+      "type": "reduce",
+      "from": ["review-each"],
+      "agent": "writer",
+      "task": "Combine these reviews into a prioritized security report:\n{steps.review-each.output}",
+      "final": true
+    }
+  ]
+}
+```
+
+Run it detached:
+
+```bash
+/tf run security-audit dir=src --detach
+```
+
+Check back later:
+
+```bash
+/tf peek <runId> summarize
+```
+
+### CI/CD pipelines
+
+A flow that runs in a CI job, triggered by a webhook or a cron schedule. The CI job starts the flow, captures the `runId`, and exits. A separate monitoring process polls the run state and reports the result.
+
+Detached runs are ideal for CI because they don't require an interactive session. The auto-reject behavior for approval phases is a feature, not a bug — it prevents unreviewed work from shipping in automated contexts.
+
+### Overlapping work
+
+You're in the middle of a conversation, and you realize you need to run a slow flow. Instead of blocking the conversation, you detach the flow and continue talking. When the flow finishes, you can peek at the result or resume the conversation with the new context.
+
+## Limitations
+
+<Callout type="info">
+  Detached runs trade interactivity for independence. These limitations are by design.
+</Callout>
+
+**No approval phases.** Approval gates auto-reject. If your flow requires human approval, run it inline or replace approval phases with deterministic gates.
+
+**No live progress.** The parent conversation does not receive live updates. You poll the run state instead. If you need streaming progress, run the flow inline.
+
+**Independent lifecycle.** The child process survives the parent. If you kill your terminal, the flow keeps running. To stop a detached run, kill the child process by its `pid` (e.g., `kill <pid>`). There is no built-in cancel command.
+
+**Runner module required.** The child process must be able to dynamically import the host's runner module. If the module path is wrong or the module is missing, the run fails fast with a `__detach__` phase. This is rarely an issue in practice — the host serializes the correct path automatically.
+
+**No requestApproval callback.** The detached runner does not inject a `requestApproval` function. This is the mechanism behind the auto-reject behavior. If you need custom approval logic, run the flow inline.
+
+## Runner module injection
+
+taskflow-core is host-neutral. It cannot spawn `pi`, `codex`, or `claude` itself — it doesn't know which host is running it. The host adapter (pi-taskflow, codex-taskflow, etc.) injects a `runTask` function that knows how to spawn subagents for that host.
+
+In a detached run, the child process needs the same injection. The host serializes the path to its runner module into the context file:
+
+```json title="DetachContext (simplified)"
+{
+  "runId": "2026-07-06T14-32-01-audit",
+  "defName": "audit",
+  "args": { "dir": "src" },
+  "cwd": "/Users/beta/work/my-project",
+  "runnerModule": "/Users/beta/.pi/extensions/pi-taskflow/dist/runner.js",
+  "runnerExport": "piSubagentRunner"
+}
+```
+
+The detached runner dynamically imports `runnerModule` and extracts the `runnerExport` (defaulting to `"piSubagentRunner"`). If the import succeeds and the export has a `runTask` function, the runner is ready. If not, the runner fails fast with a `__detach__` phase.
+
+This design means the same `detached-runner.ts` script works for every host — Pi, Codex, Claude Code, OpenCode. The host-specific logic lives in the runner module, not in the detached runner itself.
+
+## Debugging a failed detached run
+
+When a detached run fails, the run state tells you why. Check the `__detach__` phase first:
+
+```bash
+/tf peek <runId> __detach__
+```
+
+If the `__detach__` phase exists, it contains the crash reason — a runner module import error, a spawn failure, or the child's stderr. If the `__detach__` phase does not exist, the failure was a normal flow failure (a gate blocked, a phase exhausted its retries, a budget exceeded). Check the other phases to find the root cause.
+
+You can also inspect the child's stderr directly if you have access to the parent's logs. The parent captures stderr and includes it in the `__detach__` phase on early exit.
+
+## Next
+
+<Cards>
+  <Card title="Using taskflow on Pi" href="/en/docs/guides/pi">
+    The full Pi workflow, including saved flows and run history.
+  </Card>
+  <Card title="Resume and Caching" href="/en/docs/concepts/resume">
+    How taskflow persists run state and resumes from where it stopped.
+  </Card>
+  <Card title="Approval Phases" href="/en/docs/syntax/phase-types">
+    Human-in-the-loop gates and why they auto-reject in detached mode.
+  </Card>
+</Cards>

--- a/website/content/docs/en/guides/claude-code.mdx
+++ b/website/content/docs/en/guides/claude-code.mdx
@@ -1,0 +1,240 @@
+---
+title: Using taskflow on Claude Code
+description: Install taskflow as a Claude Code plugin and orchestrate multi-phase workflows via MCP.
+---
+
+[Claude Code](https://claude.com/product/claude-code) is a natural home for taskflow: it already thinks in terms of subagents, and taskflow gives those subagents a declarative graph to run inside. On Claude Code, taskflow ships as a plugin that registers a dependency-free MCP server plus a routing skill, so the model can call it the moment it sees a multi-step task.
+
+This page walks through the whole arc: install the plugin, confirm the MCP server is live, run a flow through a tool call, and understand the permission and long-running-flow model.
+
+## Install
+
+taskflow is distributed through the shared plugin marketplace. Add the marketplace, then install the plugin:
+
+```bash title="Install the taskflow plugin"
+claude plugin marketplace add heggria/taskflow
+claude plugin install claude-taskflow@taskflow
+```
+
+That single `plugin install` does three things at once:
+
+<Steps>
+  <Step>
+    **Registers the MCP server.** The plugin declares a `taskflow` server launched via `npx -y -p claude-taskflow claude-taskflow-mcp`, so Claude Code can reach the runtime over stdio. The `npx` pin binds the exact code that runs — nothing to install globally.
+  </Step>
+  <Step>
+    **Installs the routing skill.** A bundled skill teaches Claude Code when to reach for the taskflow tools, so you don't have to remember their names.
+  </Step>
+  <Step>
+    **Keeps zero runtime deps.** The MCP server speaks JSON-RPC 2.0 over stdio on Node built-ins — no `@modelcontextprotocol/sdk`, so taskflow keeps its zero-dependency guarantee.
+  </Step>
+</Steps>
+
+Restart your Claude Code session if it was already running, so the new plugin is picked up.
+
+## Verify the install
+
+Before running anything, confirm both the plugin and its MCP server registered cleanly:
+
+```bash title="Verify the plugin and MCP server"
+claude plugin list   # claude-taskflow@taskflow should appear, enabled
+claude mcp list      # taskflow should appear, enabled
+```
+
+If either is missing, the `plugin install` step didn't complete — re-run it and check for errors.
+
+## Run your first flow
+
+On Claude Code, you don't invoke taskflow through a slash command — you invoke it through an MCP tool. The model decides when to call it, guided by the bundled skill. So the most natural way to start is to just describe the work.
+
+### Just ask
+
+Try one of these in a Claude Code session:
+
+```text title="Describe the work in plain language"
+> List my saved taskflows.
+> Verify this flow, then run it: {name:"review-changes", phases:[...]}
+> Run the "review-changes" taskflow with dir set to src.
+```
+
+The skill routes the request to the right tool. If a flow is saved in the current project, the model calls `taskflow_run` with the saved name; if you pasted an inline definition, it passes that instead.
+
+### Call the tool directly
+
+If you want to be explicit — useful in scripts or when you know the exact shape — the tool is `taskflow_run`. It accepts either a saved flow `name` or an inline `define`:
+
+```json title="Run a saved flow via taskflow_run"
+{
+  "name": "review-changes",
+  "args": { "dir": "src" }
+}
+```
+
+```json title="Run an inline flow via taskflow_run"
+{
+  "define": {
+    "name": "quick-review",
+    "phases": [
+      {
+        "id": "discover",
+        "type": "agent",
+        "agent": "scout",
+        "task": "List changed source files under src/. Output ONLY a JSON array of {path} objects.",
+        "output": "json"
+      },
+      {
+        "id": "review-each",
+        "type": "map",
+        "over": "{steps.discover.json}",
+        "as": "file",
+        "agent": "security-reviewer",
+        "task": "Review {file.path} for security risks. Return one paragraph.",
+        "dependsOn": ["discover"],
+        "concurrency": 4
+      },
+      {
+        "id": "summarize",
+        "type": "reduce",
+        "from": ["review-each"],
+        "agent": "writer",
+        "task": "Combine these reviews into one prioritized summary:\n{steps.review-each.output}",
+        "dependsOn": ["review-each"],
+        "final": true
+      }
+    ]
+  }
+}
+```
+
+Either form runs the same DAG. The tool returns only the final output — the intermediate transcripts from `discover`, `review-each`, and `summarize` stay inside the runtime and never enter your context.
+
+<Callout type="info">
+  Only the phase marked `final: true` is returned. Everything else is context-isolated by design.
+</Callout>
+
+## Check a flow before spending tokens
+
+Before running a DAG, you can ask Claude Code to verify it statically. This catches cycles, dangling `dependsOn`, unknown phase references, and malformed configs — all at zero token cost:
+
+```json title="Verify a flow via taskflow_verify"
+{
+  "name": "review-changes"
+}
+```
+
+Or render the DAG as a diagram to eyeball its shape:
+
+```json title="Compile a flow to a diagram via taskflow_compile"
+{
+  "name": "review-changes"
+}
+```
+
+`taskflow_compile` returns the DAG grouped into topological layers as a text outline, plus an inline SVG image for clients that render images.
+
+## How subagents run
+
+Each phase's subagent runs as an isolated `claude -p` session — a real Claude Code headless process, not a pi process. The server discovers saved flows and agents from its **launch cwd**, so the project you start it in determines which flows are visible.
+
+### Permission mapping
+
+Claude Code has no OS-level sandbox in headless (`-p`) mode — a tool call is either whitelisted or denied. The runner maps each phase's tool whitelist to a permission mode:
+
+| Phase tools | Permission mode | What it means |
+|---|---|---|
+| Read-only (no `write`/`edit`/`bash`) | `--allowedTools Read,Grep,Glob,WebFetch,WebSearch` | Mutating tools are denied outright. Note there's no read-only shell — `Bash` is not granted to read-only phases. |
+| Mutating (or no whitelist) | `--permission-mode bypassPermissions` | The subagent can run any tool. Run flows you trust, in a repo you can `git reset`. |
+
+<Callout type="warn">
+  Mutating phases run with `bypassPermissions` and have no OS sandbox backstop. Prefer a throwaway worktree (`cwd: "worktree"`) for flows that touch the filesystem, and only run flows you trust.
+</Callout>
+
+## Long-running flows
+
+Here's the one thing to know about running taskflow on Claude Code: **`taskflow_run` is synchronous.** The tool call doesn't return until the entire DAG finishes — every phase, every subagent. For a three-phase review that's fine; for a fan-out over fifty files with a tournament at the end, it can take a while.
+
+If a flow is genuinely huge, consider splitting it into a few smaller `taskflow_run` calls so each returns promptly, or run it in the background from a plain shell:
+
+```bash title="Run a flow in the background"
+claude -p "run the nightly-audit taskflow" &
+```
+
+Then inspect the run afterward with `taskflow_peek`:
+
+```json title="Peek at a phase's stored output via taskflow_peek"
+{
+  "runId": "run_2026-07-04_abc123",
+  "phaseId": "summarize"
+}
+```
+
+Omit `phaseId` to list every phase with its status and output size. Output is hard-truncated (default 4000 chars) so a peek never floods your context.
+
+<Callout type="warn">
+  `taskflow_peek` is the one intentional exception to taskflow's context isolation. It pulls intermediate output into your conversation — use it for debugging, not as part of your normal flow.
+</Callout>
+
+## Approvals in MCP mode
+
+MCP-driven runs are non-interactive, so an `approval` phase **auto-rejects** (fail-open). Prefer a `gate` (agent review) in flows you run through the `taskflow_*` tools; use `approval` only in flows a human runs interactively.
+
+## Tool reference
+
+Here's the full MCP surface the plugin exposes:
+
+| Tool | Purpose |
+|---|---|
+| `taskflow_run` | Run a saved flow (by `name`) or an inline definition (by `define`). Returns the final output + a `runId`. |
+| `taskflow_list` | List saved flows discoverable from the cwd, with library metadata when available. |
+| `taskflow_show` | Show a saved flow's definition plus its library sidecar metadata. |
+| `taskflow_save` | Save a flow to the library with optional `purpose`, `tags`, and `notes`. |
+| `taskflow_search` | Search the library before authoring. Returns ranked reusable flows. |
+| `taskflow_verify` | Statically verify a flow (cycles, refs, configs) at zero cost. |
+| `taskflow_compile` | Render the DAG as a text outline + inline SVG. |
+| `taskflow_peek` | Inspect a stored phase's output for post-hoc debugging. |
+
+<Callout type="tip">
+  You rarely need to memorize these. The bundled skill tells Claude Code which tool fits the request — "verify this flow", "show me the diagram", "run it" all route correctly on their own.
+</Callout>
+
+## Alternative: register the MCP server manually
+
+If you'd rather not use the plugin, install the package and register its `claude-taskflow-mcp` bin yourself:
+
+```bash title="Manual MCP registration"
+pnpm add -g claude-taskflow
+claude mcp add taskflow -- claude-taskflow-mcp
+```
+
+Verify it registered:
+
+```bash title="Verify manual registration"
+claude mcp list   # taskflow … enabled
+```
+
+The server behaves identically to the plugin version — it just doesn't come with the routing skill or the one-command update path.
+
+## Remove
+
+If you need to take taskflow off a machine:
+
+```bash title="Remove the taskflow plugin"
+claude plugin uninstall claude-taskflow@taskflow   # if installed as a plugin
+claude mcp remove taskflow                          # if registered manually
+```
+
+This unregisters the MCP server and removes the skill. Any saved flow definitions on disk are left untouched.
+
+## Next
+
+<Cards>
+  <Card title="Getting Started" href="/en/docs/getting-started">
+    The five-minute tour, if you haven't seen it yet.
+  </Card>
+  <Card title="Phase Types" href="/en/docs/concepts/phases">
+    The ten building blocks you can compose into a DAG.
+  </Card>
+  <Card title="Using taskflow on Codex" href="/en/docs/guides/codex">
+    The same runtime, wired into OpenAI Codex.
+  </Card>
+</Cards>

--- a/website/content/docs/en/guides/opencode.mdx
+++ b/website/content/docs/en/guides/opencode.mdx
@@ -1,0 +1,251 @@
+---
+title: Using taskflow on OpenCode
+description: Register taskflow as an MCP server on OpenCode and orchestrate multi-phase workflows.
+---
+
+[OpenCode](https://opencode.ai) is a natural home for taskflow: it already thinks in terms of subagents, and taskflow gives those subagents a declarative graph to run inside. On OpenCode, taskflow is exposed as a dependency-free MCP server, so the `taskflow_*` tools appear inside the session and each phase's subagent runs as an isolated `opencode run` process.
+
+This page walks through the whole arc: register the MCP server, confirm it's live, run a flow through a tool call, and understand the permission and model-resolution model.
+
+## Install
+
+OpenCode has no git-based plugin marketplace, so you register the MCP server directly — either with the CLI or by editing your `opencode.json`.
+
+### Option A: the CLI
+
+```bash title="Register the MCP server via the CLI"
+opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
+```
+
+### Option B: edit opencode.json
+
+```jsonc title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "taskflow": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "opencode-taskflow", "opencode-taskflow-mcp"],
+      "enabled": true
+    }
+  },
+  "skills": {
+    "paths": ["./node_modules/opencode-taskflow/plugin/skills"]
+  }
+}
+```
+
+The `command` runs via `npx` (a version-pinned `opencode-taskflow`), so the server is fetched and launched on demand — nothing else to install globally, and the pin binds the exact code that runs.
+
+<Callout type="info">
+  The `skills.paths` entry is optional. OpenCode auto-discovers `**/SKILL.md` skills (including Claude Code `.claude/skills`), and the taskflow tools are self-describing, so the routing skill just helps OpenCode reach for them at the right time. A ready-to-copy `opencode.json` ships in the package's `plugin/` directory.
+</Callout>
+
+## Verify the install
+
+Before running anything, confirm the MCP server registered cleanly:
+
+```bash title="Verify the MCP server"
+opencode mcp list   # taskflow should appear, enabled
+```
+
+If it's missing, the `mcp add` step didn't complete — re-run it and check for errors.
+
+## Run your first flow
+
+On OpenCode, you don't invoke taskflow through a slash command — you invoke it through an MCP tool. The model decides when to call it, guided by the routing skill. So the most natural way to start is to just describe the work.
+
+### Just ask
+
+Try one of these in an OpenCode session:
+
+```text title="Describe the work in plain language"
+> List my saved taskflows.
+> Verify this flow, then run it: {name:"review-changes", phases:[...]}
+> Run the "review-changes" taskflow with dir set to src.
+```
+
+The skill routes the request to the right tool. If a flow is saved in the current project, the model calls `taskflow_run` with the saved name; if you pasted an inline definition, it passes that instead.
+
+### Call the tool directly
+
+If you want to be explicit — useful in scripts or when you know the exact shape — the tool is `taskflow_run`. It accepts either a saved flow `name` or an inline `define`:
+
+```json title="Run a saved flow via taskflow_run"
+{
+  "name": "review-changes",
+  "args": { "dir": "src" }
+}
+```
+
+```json title="Run an inline flow via taskflow_run"
+{
+  "define": {
+    "name": "quick-review",
+    "phases": [
+      {
+        "id": "discover",
+        "type": "agent",
+        "agent": "scout",
+        "task": "List changed source files under src/. Output ONLY a JSON array of {path} objects.",
+        "output": "json"
+      },
+      {
+        "id": "review-each",
+        "type": "map",
+        "over": "{steps.discover.json}",
+        "as": "file",
+        "agent": "security-reviewer",
+        "task": "Review {file.path} for security risks. Return one paragraph.",
+        "dependsOn": ["discover"],
+        "concurrency": 4
+      },
+      {
+        "id": "summarize",
+        "type": "reduce",
+        "from": ["review-each"],
+        "agent": "writer",
+        "task": "Combine these reviews into one prioritized summary:\n{steps.review-each.output}",
+        "dependsOn": ["review-each"],
+        "final": true
+      }
+    ]
+  }
+}
+```
+
+Either form runs the same DAG. The tool returns only the final output — the intermediate transcripts from `discover`, `review-each`, and `summarize` stay inside the runtime and never enter your context.
+
+<Callout type="info">
+  Only the phase marked `final: true` is returned. Everything else is context-isolated by design.
+</Callout>
+
+## Check a flow before spending tokens
+
+Before running a DAG, you can ask OpenCode to verify it statically. This catches cycles, dangling `dependsOn`, unknown phase references, and malformed configs — all at zero token cost:
+
+```json title="Verify a flow via taskflow_verify"
+{
+  "name": "review-changes"
+}
+```
+
+Or render the DAG as a diagram to eyeball its shape:
+
+```json title="Compile a flow to a diagram via taskflow_compile"
+{
+  "name": "review-changes"
+}
+```
+
+`taskflow_compile` returns the DAG grouped into topological layers as a text outline, plus an inline SVG image for clients that render images.
+
+## How subagents run
+
+Each phase's subagent runs as an isolated `opencode run` process — a real OpenCode session, not a pi process. The server discovers saved flows and agents from its **launch cwd**, so the project you start it in determines which flows are visible.
+
+### Permission mapping
+
+OpenCode has no per-run tool-whitelist flag, but it honours a per-process config injected via the `OPENCODE_CONFIG_CONTENT` env var. The runner maps each phase's tool whitelist to a permission policy:
+
+| Phase tools | Permission policy | What it means |
+|---|---|---|
+| Read-only (no `write`/`edit`/`bash`) | Injected policy that **denies** bash/write/edit | A denied tool call is genuinely rejected (not merely un-approved). This is real enforcement, closer to a read-only OS sandbox than an advisory whitelist. |
+| Mutating (or no whitelist) | `opencode run --auto` | Auto-approves every permission — the workspace-write analogue. Run flows you trust, ideally in a throwaway worktree (`cwd: "worktree"`). |
+
+<Callout type="warn">
+  Mutating phases run with `--auto` and auto-approve every permission. Prefer a throwaway worktree (`cwd: "worktree"`) for flows that touch the filesystem, and only run flows you trust.
+</Callout>
+
+### Model resolution
+
+OpenCode model ids are `provider/model` (e.g. `anthropic/claude-sonnet-4-5`). Because a valid OpenCode id contains a slash, the runner does **not** reuse the codex/claude "contains `/` ⇒ drop" rule. It drops only ids that clearly aren't OpenCode models:
+
+- An unresolved role placeholder (`{{fast}}`)
+- A pi thinking suffix (`…:xhigh`)
+- A multi-segment openrouter path (`openrouter/vendor/model`, ≥ 2 slashes)
+
+A dropped id falls back to OpenCode's configured default model.
+
+## Long-running flows
+
+Here's the one thing to know about running taskflow on OpenCode: **`taskflow_run` is synchronous.** The tool call doesn't return until the entire DAG finishes — every phase, every subagent. For a three-phase review that's fine; for a fan-out over fifty files with a tournament at the end, it can take a while.
+
+If a flow is genuinely huge, consider splitting it into a few smaller `taskflow_run` calls so each returns promptly, or run it in the background from a plain shell:
+
+```bash title="Run a flow in the background"
+opencode run "run the nightly-audit taskflow" &
+```
+
+Then inspect the run afterward with `taskflow_peek`:
+
+```json title="Peek at a phase's stored output via taskflow_peek"
+{
+  "runId": "run_2026-07-04_abc123",
+  "phaseId": "summarize"
+}
+```
+
+Omit `phaseId` to list every phase with its status and output size. Output is hard-truncated (default 4000 chars) so a peek never floods your context.
+
+<Callout type="warn">
+  `taskflow_peek` is the one intentional exception to taskflow's context isolation. It pulls intermediate output into your conversation — use it for debugging, not as part of your normal flow.
+</Callout>
+
+## Approvals in MCP mode
+
+MCP-driven runs are non-interactive, so an `approval` phase **auto-rejects** (fail-open). Prefer a `gate` (agent review) in flows you run through the `taskflow_*` tools; use `approval` only in flows a human runs interactively.
+
+## Tool reference
+
+Here's the full MCP surface the server exposes:
+
+| Tool | Purpose |
+|---|---|
+| `taskflow_run` | Run a saved flow (by `name`) or an inline definition (by `define`). Returns the final output + a `runId`. |
+| `taskflow_list` | List saved flows discoverable from the cwd, with library metadata when available. |
+| `taskflow_show` | Show a saved flow's definition plus its library sidecar metadata. |
+| `taskflow_save` | Save a flow to the library with optional `purpose`, `tags`, and `notes`. |
+| `taskflow_search` | Search the library before authoring. Returns ranked reusable flows. |
+| `taskflow_verify` | Statically verify a flow (cycles, refs, configs) at zero cost. |
+| `taskflow_compile` | Render the DAG as a text outline + inline SVG. |
+| `taskflow_peek` | Inspect a stored phase's output for post-hoc debugging. |
+
+<Callout type="tip">
+  You rarely need to memorize these. The bundled skill tells OpenCode which tool fits the request — "verify this flow", "show me the diagram", "run it" all route correctly on their own.
+</Callout>
+
+## Alternative: run from a repo checkout
+
+If you'd rather not install the package, build from a checkout of this repo and point OpenCode at the built bin:
+
+```bash title="Register from a checkout"
+pnpm run build
+opencode mcp add taskflow -- node /abs/path/to/taskflow/packages/opencode-taskflow/dist/mcp/bin.js
+```
+
+The server behaves identically to the `npx` version.
+
+## Remove
+
+If you need to take taskflow off a machine:
+
+```bash title="Remove the taskflow MCP server"
+opencode mcp remove taskflow    # or delete the mcp.taskflow entry from opencode.json
+```
+
+Any saved flow definitions on disk are left untouched.
+
+## Next
+
+<Cards>
+  <Card title="Getting Started" href="/en/docs/getting-started">
+    The five-minute tour, if you haven't seen it yet.
+  </Card>
+  <Card title="Phase Types" href="/en/docs/concepts/phases">
+    The ten building blocks you can compose into a DAG.
+  </Card>
+  <Card title="Using taskflow on Claude Code" href="/en/docs/guides/claude-code">
+    The same runtime, wired into Claude Code.
+  </Card>
+</Cards>

--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -23,6 +23,8 @@
     "---Guides---",
     "guides/pi",
     "guides/codex",
+    "guides/claude-code",
+    "guides/opencode",
     "guides/agents-and-model-roles",
     "guides/dynamic-planning",
     "guides/tournament",

--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -10,6 +10,8 @@
     "concepts/interpolation",
     "concepts/verification",
     "concepts/context-isolation",
+    "concepts/shared-context-tree",
+    "concepts/workspace-isolation",
     "concepts/resume",
     "---Syntax Reference---",
     "syntax/flow-definition",

--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -23,6 +23,7 @@
     "---Guides---",
     "guides/pi",
     "guides/codex",
+    "guides/agents-and-model-roles",
     "guides/dynamic-planning",
     "guides/tournament",
     "guides/background-runs",

--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -19,11 +19,13 @@
     "syntax/control-flow",
     "syntax/caching",
     "syntax/budget",
+    "syntax/scorers",
     "---Guides---",
     "guides/pi",
     "guides/codex",
     "guides/dynamic-planning",
     "guides/tournament",
+    "guides/background-runs",
     "guides/code-audit-case-study",
     "guides/headline-tournament-case-study",
     "guides/migration-planner-case-study",
@@ -33,6 +35,7 @@
     "---Reference---",
     "reference/shorthand",
     "reference/commands",
+    "reference/incremental-recompute",
     "community"
   ]
 }

--- a/website/content/docs/en/reference/incremental-recompute.mdx
+++ b/website/content/docs/en/reference/incremental-recompute.mdx
@@ -1,0 +1,510 @@
+---
+title: Incremental Recompute
+description: FlowIR compilation, observed read-sets, staleness detection, and minimal recompute.
+---
+
+taskflow's incremental recompute is a **cost-asymmetric reactivity system**: the cheap effects (figuring out what *would* be invalidated) run for free; the expensive effects (actually re-running an LLM phase) are gated behind explicit confirmation. This page is the exact reference for how it works.
+
+The system has four layers: **FlowIR compilation** (content-address the flow definition), **dependency tracking** (declared + observed read-sets), **staleness detection** (transitive frontier computation), and **minimal recompute** (force-rerun seeds, reuse everything else). Each layer is pure where possible, never throws into the run, and degrades safely when its preconditions aren't met.
+
+<Callout type="info">
+  The entire recompute toolkit — `/tf ir`, `/tf provenance`, `/tf why-stale`, `/tf recompute` — costs **zero tokens**. Only `recompute --apply` spends tokens, and even then only on the phases whose inputs actually changed.
+</Callout>
+
+## FlowIR compilation
+
+Every run begins by compiling the flow definition into a **content-addressed intermediate representation** (FlowIR). This compilation is the foundation of cross-run memoization: two structurally identical flows produce the same hash, so a phase from one run can be reused in another.
+
+### The compile seam
+
+The compilation is routed through `compileTaskflowToIR(def)`, which returns a `TaskflowIR`:
+
+```typescript
+interface TaskflowIR {
+  ir?: FlowIR;                    // The compiled IR (nodes with inject/emits)
+  meta: TaskflowIRMeta;           // Compile-time metadata (declared deps, sidecar)
+  hash?: string;                  // Content fingerprint (32-hex SHA-256)
+  warnings: CompileWarning[];     // Non-fatal advisories
+  errors: CompileError[];         // Hard compile errors (none in the stub)
+  usedFallbackHash: boolean;      // True when the hash is flowDefHash (not IR-canonical)
+}
+```
+
+The compilation is **pure + async** (uses Web Crypto for hashing) and **never throws** — a hash failure leaves `hash` unset and the cache degrades to the legacy flowName-only key (cross-run disabled for that run).
+
+### Content addressing
+
+The `hash` is currently produced by `flowDefHash(def)`, which serializes the desugared definition to **canonical JSON** (recursively key-sorted, no whitespace, `undefined` dropped) and hashes it with SHA-256 (first 16 bytes, lowercase hex). This is the vendored overstory hashing contract — byte-identical to overstory's `hashIR` algorithm.
+
+```typescript
+// Canonical JSON: keys sorted by UTF-16 code units, arrays preserve order
+function canonicalJson(value: unknown): string;
+
+// SHA-256 of canonical serialization, first 16 bytes hex
+async function hashCanonical(canonical: string): Promise<string>;
+
+// Content fingerprint of the desugared Taskflow definition
+async function flowDefHash(def: Taskflow): Promise<string>;
+```
+
+<Callout type="warn">
+  `usedFallbackHash` is **always true** in the current stub: the hash is the definition fingerprint, not the IR-canonical hash. It flips to `false` only once the genuine overstory compiler is vendored. Callers must never mistake a stub hash for a canonical one.
+</Callout>
+
+### Per-phase sub-fingerprints
+
+`phaseFingerprint(def, phaseId)` produces a **structural sub-fingerprint** of only the phase + its transitive dependency closure. Folding this into the cache key (instead of the whole-flow hash) means editing phase B invalidates only B and its transitive dependents — independent sibling phase A keeps its cache hit.
+
+The fingerprint **strips policy fields** before hashing: `cache`, `retry`, `concurrency`, and `final` do not affect a phase's subagent output, only execution mechanics or result selection. Including them would cause false cache invalidation on a no-op config change.
+
+#### Soundness gates
+
+Per-phase invalidation is only sound when a phase's real dependencies are fully captured by the static `dependsOn ∪ from` closure. Three cases break that guarantee, so `phaseFingerprint` returns `undefined` for them and the caller falls back to the whole-flow `flowDefHash` (safe, = pre-M6 behavior):
+
+1. **Shared Context Tree** (`def.contextSharing === true` or any closure member has `shareContext === true`): a sharing phase can read sibling blackboard writes outside its declared deps, so the static closure under-approximates real reads.
+2. **`flow` phase in the closure** (`type === "flow"`): a `flow` phase's sub-structure is resolved at runtime (inline `def`) or from a saved flow (`use`) and is not statically visible here.
+3. **`join: "any"` phase** (`phase.join === "any"`): validation exempts it from the `{steps.X}`-must-be-in-`dependsOn` check, so it may read phases outside its static closure.
+
+### Compile-time declared dependencies
+
+The compilation also synthesizes a **declared dependency plane** (M2): for each phase, `collectRefs(phase)` scans the `task`, `when`, `until`, `eval`, `score.target`, `score.judge.task`, `branches[].task`, `with.*`, and `context[]` fields for `{steps.X.*}` interpolation refs. These become the phase's declared reads; its writes are `[phase.id]` (1:1 projection).
+
+```typescript
+interface DeclaredDeps {
+  reads: string[];  // Upstream step ids statically referenced
+  writes: string[]; // Step ids this phase emits (currently [phase.id])
+}
+
+interface TaskflowIRMeta {
+  sourceFlowName: string;
+  declaredDeps: Record<string, DeclaredDeps>;  // Per-phase declared footprint
+  sidecar: Record<string, unknown>;             // Pi-taskflow-specific fields (round-trip)
+}
+```
+
+The declared plane is persisted on `RunState.declaredDeps` for audit/provenance, but **recompute derives it fresh** from `def` so old runs (pre-H1, no persisted declaredDeps) also get union semantics.
+
+## Dependency tracking
+
+taskflow tracks dependencies on **two planes**: the *declared* plane (compile-time, static) and the *observed* plane (runtime, dynamic). Staleness detection uses their **union** so a declared-but-unobserved edge (e.g. a `when` ref that never fired) still propagates staleness.
+
+### Observed read-sets (M3)
+
+Every completed phase records an **observed readSet** — not what it *declared* to depend on (`dependsOn`), but what it truly *read* at interpolation time. Each entry carries the **version** (= the read phase's `inputHash`) it consumed, so a later staleness check can tell whether the upstream has moved.
+
+```typescript
+interface PhaseState {
+  // ...
+  reads?: Array<{
+    stepId: string;      // The upstream phase id
+    version?: string;    // The upstream's inputHash when this phase read it
+  }>;
+}
+```
+
+This is the overstory "observed readSet@version" moat: no other orchestrator records what a result **actually** depended on. A phase that interpolates `{steps.scout.output}` and `{steps.analyst.output}` has two read entries; a phase with no interpolation refs has none.
+
+<Callout type="tip">
+  Use `/tf provenance <runId>` to inspect a run's observed read-sets. This is the ground truth for "what did this phase actually consume?"
+</Callout>
+
+### Declared read-sets (M2)
+
+The declared plane is derived from `collectRefs(phase)` at compile time. It captures every `{steps.X.*}` ref the phase *could* read, including refs inside `when` guards that may never fire (because the condition is false) and refs inside `until` convergence checks that may only be evaluated on later iterations.
+
+```typescript
+// Fold a run's PhaseStates into a read map (drops phases with no reads)
+function readMapOf(phases: Record<string, PhaseState>): ReadMap;
+
+// Build a declared ReadMap from a flow definition (collectRefs per phase)
+function declaredReadMapOfDef(def: Taskflow): ReadMap;
+```
+
+A `ReadMap` is `Map<phaseId, readonly string[]>` — phaseId to the upstream stepIds it reads. Both observed and declared planes use this shape.
+
+### Union semantics
+
+When `declared` is provided to `computeStaleFrontier` or `dependentsOf`, the dependent set is the **union** of observed dependents (from `reads`) and declared dependents (from `declared`). This ensures:
+
+- A `when` ref that never fired (because the condition was false) still counts as a dependency — if the referenced phase changes, the guarded phase is marked stale even though it didn't observe the read.
+- An `until` convergence check that only evaluated on iteration 3 still propagates staleness from its refs, even though iterations 1 and 2 didn't observe them.
+- Old runs (pre-H1, no persisted declaredDeps) get union semantics too, because recompute derives the declared plane fresh from `def`.
+
+## Staleness detection
+
+`/tf why-stale` explains why a cached run is stale: which phase changed, and what else is transitively invalidated. The computation is **pure, deterministic, and zero-token** — it reads the persisted `RunState` and walks the dependency graph.
+
+### The stale frontier
+
+`computeStaleFrontier(reads, seeds, declared?)` returns the **transitive closure** of phases that are stale if `seeds` change. A reader is stale if ANY phase it (observed- or declared-)reads is stale (union semantics: when in doubt, assume dependency). The frontier includes the seeds themselves.
+
+```typescript
+function computeStaleFrontier(
+  reads: ReadMap,           // Observed read map
+  seeds: Iterable<string>,  // Phases assumed to have changed
+  declared?: ReadMap        // Declared read map (union when provided)
+): Set<string>;
+```
+
+The algorithm is BFS over the read graph: enqueue the seeds, then for each seed find its dependents (via `dependentsOf`), enqueue those, repeat. A phase is enqueued at most once (visited set), so cycles in a pathological read graph terminate. Complexity is O(phases + read-edges).
+
+### Explaining staleness
+
+`formatWhyStale(runId, flowName, reads, seeds, declared?)` renders a human-readable explanation:
+
+- **No seeds**: shows the full observed dependency graph (who reads what), with declared-only edges annotated `(declared)`.
+- **With seeds**: shows the stale frontier, with each stale phase listing the stale upstreams that caused it (its "why"). Seeds are marked `(changed — seed)`; downstream phases list their stale reads.
+
+```bash
+/tf why-stale abc123 scout
+```
+
+```text title="why-stale output"
+why-stale — run abc123 · flow "review-changes"
+
+Assuming changed: scout
+
+Stale frontier (transitive, 3 phases):
+  ■ scout  (changed — seed)
+  ■ analyst  ← reads scout
+  ■ summary  ← reads analyst
+```
+
+<Callout type="info">
+  The frontier is **conservative**: it marks phases stale if they *might* be affected. The actual recompute (with `--apply`) checks each phase's `inputHash` — if the upstream's new output happens to equal the old, the phase hits its cache (early cutoff) and is reused.
+</Callout>
+
+## Minimal recompute
+
+`/tf recompute <runId> <phaseId>` minimally recomputes a stale phase: force-rerun the seed, then walk its stale frontier in topological order. The cache provides **early cutoff** for free — a downstream whose `inputHash` didn't move (because the seed's new output happened to equal the old) hits its prior result and is reused rather than re-executed.
+
+### Dry-run default
+
+Recompute is **fail-safe by default**: without `--apply`, it computes the worst-case frontier *without spending a token* and returns a `RecomputeReport` describing what *would* happen.
+
+```bash
+/tf recompute abc123 scout        # Dry-run: what would change?
+/tf recompute abc123 scout --apply  # Real recompute: spend tokens
+```
+
+The dry-run report explains each phase's outcome:
+
+```typescript
+interface RecomputeReport {
+  dryRun: boolean;
+  aborted: boolean;                // True if the user cancelled mid-recompute
+  seeds: readonly string[];        // The phase(s) forced to re-run
+  rerun: readonly string[];        // Phases that were (would be) re-executed
+  reused: readonly string[];       // Phases outside the frontier (untouched)
+  cutoff: readonly string[];       // Frontier phases whose inputHash didn't move
+  decisions: readonly RecomputeDecision[];  // Per-phase WHY
+}
+
+interface RecomputeDecision {
+  phaseId: string;
+  outcome: "rerun" | "cutoff" | "reused" | "failed";
+  reason: string;                  // Human-readable cause
+  causedBy?: readonly string[];    // Upstream phases that caused this outcome
+}
+```
+
+<Callout type="tip">
+  The `decisions` array is the "explainable reactivity" layer — like React DevTools telling you why a component re-rendered. Use it to understand why a phase was rerun vs. cut off vs. reused.
+</Callout>
+
+### Early cutoff
+
+Early cutoff is the prize: phases in the stale frontier whose `inputHash` did **not** move after their upstreams re-ran. This happens when:
+
+- The seed's new output is byte-identical to the old (e.g. a refactor that didn't change the rendered docs).
+- The seed's output changed, but the downstream phase doesn't interpolate the changed part (e.g. `summary` reads `{steps.analyst.output}` but only uses the first paragraph, which didn't change).
+
+Early cutoff is what makes recompute cheaper than a full re-run: you pay for the seed and any downstream whose inputs actually moved; everything else is free.
+
+### Topological order
+
+Real recompute (`--apply`) walks the frontier in **topological order** respecting `dependsOn ∪ observed reads ∪ declared reads` (M2 union). This ensures a downstream always sees its (already-refreshed) upstreams when it re-evaluates its cache key — no false early-cutoff from evaluating against stale upstream state.
+
+Self-edges are filtered: a loop `until` checking `{steps.thisId.output}` must not create a self-loop in the scheduling graph (topoLayers would deadlock).
+
+### Safety guards
+
+Recompute with `--apply` is **gated** for flows with unobserved dependencies. The observed readSet only tracks `{steps.X.*}` interpolation refs; it is blind to:
+
+- **Shared Context Tree** (`shareContext`, `contextSharing`, `ctx_read`/`ctx_write`)
+- **Sub-flow internals** (`flow` phase's `use` or inline `def`)
+- **Context file pre-reads** (`context: ["src/**/*.ts"]`)
+- **Non-steps interpolation** (`{previous.output}`, `{args.*}`, `{item.*}`)
+
+Recomputing such a run with `--apply` could silently skip phases whose deps changed outside the observed frontier and then persist a corrupted run over the original. The runtime throws:
+
+```text
+recompute dryRun:false is unsafe for this run: it contains dependencies
+(shareContext, flow/ctx_spawn, context: files, {previous.output}, {args.*}, or {item.*})
+that are not tracked by the observed readSet. Use dryRun:true to inspect
+the frontier, or change the upstream phase and re-run the whole flow.
+```
+
+<Callout type="warn">
+  If your flow uses any of the above, `--apply` is blocked. Use `dryRun:true` to inspect the frontier, then either (a) change the upstream phase and re-run the whole flow, or (b) refactor to remove the unobserved dependency.
+</Callout>
+
+## Cross-run caching
+
+The cross-run cache (`CacheStore`) memoizes phase results across runs. A phase with the same `inputHash` (interpolated task + flow definition hash + fingerprint) reuses the prior result for $0.00.
+
+### Fingerprint resolution
+
+Phases can declare a `cache.fingerprint` list to fold external state into the cache key. Each entry is resolved to a deterministic string:
+
+| Prefix | Resolution | Example |
+|---|---|---|
+| `git:<ref>` | `git rev-parse <ref>` → SHA | `git:HEAD` → `git:HEAD=a1b2c3d...` |
+| `glob:<pattern>` | File list + size + mtime digest | `glob:src/**/*.ts` → `glob:src/**/*.ts=<digest>` |
+| `glob!:<pattern>` | File list + content SHA digest | `glob!:src/**/*.ts` → `glob!:src/**/*.ts=<digest>` |
+| `file:<path>` | File content SHA | `file:package.json` → `file:package.json=<sha>` |
+| `env:<name>` | Environment variable value | `env:NODE_ENV` → `env:NODE_ENV=production` |
+
+Unknown prefixes are rejected at validation time; defensively encoded as `<unknown>` at runtime. Missing files, non-git repos, and unreadable paths resolve to stable sentinels (`<missing>`, `<no-git>`, `<skip>`) so the key stays deterministic — a later appearance of the resource simply changes the key → cache miss (safe direction).
+
+```typescript
+function resolveFingerprint(entries: string[] | undefined, cwd: string): string;
+```
+
+<Callout type="tip">
+  Use `glob!:` (content mode) for source files — a file whose mtime changed but content didn't (e.g. `touch`) won't invalidate the cache. Use `glob:` (stat mode) for generated files where mtime matters.
+</Callout>
+
+### Cache entry shape
+
+```typescript
+interface CacheEntry {
+  key: string;              // The full cache key (inputHash)
+  createdAt: number;        // Unix timestamp
+  output?: string;          // Trimmed phase output
+  json?: unknown;           // Parsed JSON (for output: "json" phases)
+  model?: string;           // Model that produced this result
+  state?: PhaseState;       // Full PhaseState (gate, approval, reads, loop, etc.)
+  flowName?: string;        // Provenance
+  phaseId?: string;
+  runId?: string;
+}
+```
+
+The full `PhaseState` is stored (not just `output`/`json`) so cross-run reuse is semantically equivalent to within-run resume — storing only the output would drop `gate`, `approval`, `reads`, `loop`, `tournament`, `warnings`, etc., breaking recompute soundness and gate-block detection.
+
+### Cache lifecycle
+
+- **TTL**: entries expire after `cache.ttl` (parsed to ms). Default: no TTL (entries persist until evicted).
+- **Max age**: hard backstop — entries older than 90 days are dropped regardless of TTL.
+- **Max entries**: 1000 entries per cache dir; oldest evicted when exceeded.
+- **Clear**: `/tf cache-clear` (or `action: "cache-clear"`) removes all entries.
+
+## The incremental loop
+
+The full incremental workflow is: **compile → inspect → explain → recompute**.
+
+### 1. Compile the flow
+
+```bash
+/tf ir review-changes
+```
+
+Output:
+
+```text title="/tf ir output"
+FlowIR — flow "review-changes"
+  hash: a1b2c3d4e5f6789012345678 (usedFallbackHash: true)
+  nodes: 4
+    ■ scout       kind: agent    inject: []              emits: [scout]
+    ■ analyst     kind: agent    inject: [scout]         emits: [analyst]
+    ■ gate        kind: gate     inject: [analyst]       emits: [gate]       when: {steps.analyst.json.issues}
+    ■ summary     kind: agent    inject: [analyst, gate] emits: [summary]
+  declaredDeps:
+    scout:     reads: []               writes: [scout]
+    analyst:   reads: [scout]          writes: [analyst]
+    gate:      reads: [analyst]        writes: [gate]
+    summary:   reads: [analyst, gate]  writes: [summary]
+```
+
+### 2. Inspect provenance
+
+After a run, inspect what each phase actually read:
+
+```bash
+/tf provenance abc123
+```
+
+```text title="/tf provenance output"
+Provenance — run abc123 · flow "review-changes"
+
+  ■ scout
+    reads: (none — root phase)
+    inputHash: 1a2b3c4d5e6f7890
+
+  ■ analyst
+    reads:
+      - scout (version: 1a2b3c4d5e6f7890)
+    inputHash: 2b3c4d5e6f789012
+
+  ■ gate
+    reads:
+      - analyst (version: 2b3c4d5e6f789012)
+    inputHash: 3c4d5e6f78901234
+
+  ■ summary
+    reads:
+      - analyst (version: 2b3c4d5e6f789012)
+      - gate (version: 3c4d5e6f78901234)
+    inputHash: 4d5e6f7890123456
+```
+
+### 3. Explain staleness
+
+A week later, the summary looks stale. Check why:
+
+```bash
+/tf why-stale abc123 scout
+```
+
+```text title="/tf why-stale output"
+why-stale — run abc123 · flow "review-changes"
+
+Assuming changed: scout
+
+Stale frontier (transitive, 4 phases):
+  ■ scout  (changed — seed)
+  ■ analyst  ← reads scout
+  ■ gate  ← reads analyst
+  ■ summary  ← reads analyst, gate
+```
+
+### 4. Recompute minimally
+
+Dry-run first to see what would change:
+
+```bash
+/tf recompute abc123 scout
+```
+
+```text title="/tf recompute output (dry-run)"
+Recompute report (dry-run) — run abc123 · flow "review-changes"
+  seeds: [scout]
+  rerun: [scout, analyst, gate, summary]
+  reused: []
+  cutoff: []
+  decisions:
+    ■ scout     outcome: rerun    reason: forced by recompute request (seed)
+    ■ analyst   outcome: rerun    reason: reads a phase in the stale frontier; may re-run if that upstream's output moves
+                                   causedBy: [scout]
+    ■ gate      outcome: rerun    reason: reads a phase in the stale frontier; may re-run if that upstream's output moves
+                                   causedBy: [analyst]
+    ■ summary   outcome: rerun    reason: reads a phase in the stale frontier; may re-run if that upstream's output moves
+                                   causedBy: [analyst, gate]
+```
+
+Apply the recompute:
+
+```bash
+/tf recompute abc123 scout --apply
+```
+
+```text title="/tf recompute output (applied)"
+Recompute report — run abc123 · flow "review-changes"
+  seeds: [scout]
+  rerun: [scout, analyst, summary]
+  reused: []
+  cutoff: [gate]
+  decisions:
+    ■ scout     outcome: rerun    reason: forced by recompute request (seed)
+    ■ analyst   outcome: rerun    reason: input changed — an upstream's output moved
+                                   causedBy: [scout]
+    ■ gate      outcome: cutoff   reason: input unchanged — upstream(s) re-ran but produced identical output (early cutoff)
+                                   causedBy: [analyst]
+    ■ summary   outcome: rerun    reason: input changed — an upstream's output moved
+                                   causedBy: [analyst, gate]
+```
+
+The `gate` phase hit early cutoff: its upstream (`analyst`) re-ran, but the analyst's output (the list of issues) didn't change, so the gate's `inputHash` was unchanged and it reused its prior result. You paid for 3 phases, not 4.
+
+## Concrete walkthrough
+
+A realistic session from first run to incremental recompute:
+
+```bash title="1. Author and verify a flow"
+/tf verify review-changes
+```
+
+Verify catches a cycle and a missing `dependsOn` before any tokens are spent. Fix the JSON.
+
+```bash title="2. Run the flow"
+/tf run review-changes dir=src
+```
+
+The run completes. The runtime:
+- Compiles the flow to FlowIR (content-addressed hash).
+- Executes phases in topological order.
+- Captures observed read-sets at interpolation time.
+- Persists the run state (including `flowDefHash`, `declaredDeps`, `reads`).
+
+```bash title="3. Inspect the compiled IR"
+/tf ir review-changes
+```
+
+Check the hash and declared dependencies. The hash is stable across runs of the same flow definition.
+
+```bash title="4. Inspect provenance after the run"
+/tf runs  # Find the runId
+/tf provenance <runId>
+```
+
+See what each phase actually read. This is the ground truth for dependency tracking.
+
+```bash title="5. A week later: check staleness"
+/tf why-stale <runId> scout
+```
+
+The `scout` phase read `src/` files; those files changed. The stale frontier includes `scout` and everything that transitively reads it.
+
+```bash title="6. Dry-run recompute"
+/tf recompute <runId> scout
+```
+
+See what would change without spending tokens. The report shows which phases would be rerun vs. reused vs. cut off.
+
+```bash title="7. Apply the recompute"
+/tf recompute <runId> scout --apply
+```
+
+Only the seed and downstream phases whose inputs actually moved are re-executed. Early cutoff saves tokens for phases whose upstreams re-ran but produced identical output.
+
+```bash title="8. Clear the cache (optional)"
+/tf cache-clear
+```
+
+Remove all cross-run cache entries. Use this when you want to force a fresh run (e.g. after a model upgrade).
+
+## Command reference
+
+| Command | Description |
+|---|---|
+| `/tf ir <name>` | Compile to FlowIR + content hash. Zero tokens. |
+| `/tf provenance <runId>` | Show observed read-set provenance for a run. Zero tokens. |
+| `/tf why-stale <runId> [phaseId]` | Explain why a cached run is stale. Zero tokens. |
+| `/tf recompute <runId> <phaseId>` | Dry-run minimal recompute. Zero tokens. |
+| `/tf recompute <runId> <phaseId> --apply` | Apply minimal recompute. Spends tokens on rerun phases only. |
+| `/tf cache-clear` | Clear the cross-run memoization cache. Zero tokens. |
+
+## Next
+
+<Cards>
+  <Card title="Commands" href="/en/docs/reference/commands">
+    Full command reference for Pi and MCP hosts.
+  </Card>
+  <Card title="Caching" href="/en/docs/syntax/caching">
+    Cross-run memoization syntax: cache scope, TTL, fingerprint.
+  </Card>
+  <Card title="Flow Definition" href="/en/docs/syntax/flow-definition">
+    The full phases DAG that FlowIR compiles from.
+  </Card>
+</Cards>

--- a/website/content/docs/en/syntax/scorers.mdx
+++ b/website/content/docs/en/syntax/scorers.mdx
@@ -1,0 +1,620 @@
+---
+title: Scoring Gates
+description: Deterministic output validation with zero-token scorers, optional LLM judges, and fail-open semantics.
+---
+
+A scoring gate is a quality checkpoint that validates upstream output against a list of deterministic rules before spending a single token on an LLM. You declare what "good" looks like — a substring present, a regex matched, a JSON schema satisfied, a length in range, or code that compiles — and taskflow evaluates every check at zero cost. When all checks pass, the gate auto-passes. When they fail, an optional LLM judge can decide whether to let the flow continue or halt it.
+
+You might be wondering: *why not just use a regular gate with an LLM?* Because deterministic checks are faster, cheaper, and more predictable. A regex either matches or it doesn't — there's no hallucination risk. Scorers run before the judge, so if your checks are sufficient, you never pay for a token at all.
+
+## When to reach for scoring gates
+
+| If your problem is… | Use | In one line |
+|---|---|---|
+| "Does the output contain a required phrase?" | `contains` | Substring search. |
+| "Does it match a pattern?" | `regex` | Regular expression with optional negation. |
+| "Is it exactly this string?" | `exact-match` | Byte-for-byte equality. |
+| "Does the JSON match a schema?" | `json-schema` | TypeBox-style contract validation. |
+| "Is the output length reasonable?" | `length-range` | Inclusive character count bounds. |
+| "Does the code compile?" | `code-compiles` | Spawn a real compiler in isolation. |
+| "Deterministic checks failed, but maybe it's still okay" | `judge` | LLM-as-judge fallback. |
+
+<Callout type="tip">
+  Start with deterministic scorers. Add a judge only when the checks are insufficient — for subjective quality, tone, or correctness that can't be expressed as a pattern.
+</Callout>
+
+## A running example
+
+The rest of this page builds a single, realistic flow: **validate a generated API response before shipping it**. You will see the gate grow from a single check into a multi-scorer gate with a judge fallback as each new need introduces a new scorer type.
+
+Save this as `validate.json` — we will keep extending it:
+
+```json title="validate.json — starting point"
+{
+  "name": "validate",
+  "phases": [
+    {
+      "id": "generate",
+      "type": "agent",
+      "agent": "executor",
+      "task": "Generate a JSON API response for GET /users. Include status, data, and message fields.",
+      "output": "json"
+    },
+    {
+      "id": "check-response",
+      "type": "gate",
+      "dependsOn": ["generate"],
+      "score": {
+        "scorers": [
+          { "type": "contains", "value": "\"status\"" }
+        ]
+      },
+      "task": "Is this a valid API response? VERDICT: PASS or VERDICT: BLOCK."
+    }
+  ]
+}
+```
+
+## The six scorer types
+
+Each scorer is a deterministic check that returns `passed: true` or `passed: false` with an optional detail message. Scorers are pure (except `code-compiles`) and never throw — a bad configuration fails the scorer with a diagnostic rather than crashing the run.
+
+### `exact-match`
+
+Tests whether the target string is byte-for-byte equal to the `value`.
+
+```json title="exact-match scorer"
+{
+  "type": "exact-match",
+  "value": "PASS"
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `value` | `string` | yes | The string to compare against. |
+
+**Pass semantics:** `target === value`. Case-sensitive, no trimming.
+
+**When to use:** Exact sentinel values, fixed status codes, known-good outputs.
+
+### `contains`
+
+Tests whether the target string includes the `value` as a substring.
+
+```json title="contains scorer"
+{
+  "type": "contains",
+  "value": "0 errors"
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `value` | `string` | yes | The substring to search for. |
+
+**Pass semantics:** `target.includes(value)`. Case-sensitive.
+
+**When to use:** Checking for required phrases, error counts, status markers.
+
+<Callout type="info">
+  The `contains` scorer is case-sensitive. If you need case-insensitive matching, use `regex` with the `i` flag: `{"type": "regex", "pattern": "success", "negate": false}`.
+</Callout>
+
+### `regex`
+
+Tests whether the target matches a JavaScript regular expression.
+
+```json title="regex scorer"
+{
+  "type": "regex",
+  "pattern": "\"status\"\\s*:\\s*\"success\"",
+  "negate": false
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `pattern` | `string` | yes | JavaScript RegExp source (no delimiters). |
+| `negate` | `boolean` | no | Invert the match result. Default `false`. |
+
+**Pass semantics:** `new RegExp(pattern).test(target)`, inverted when `negate: true`.
+
+**Error handling:** An invalid pattern fails the scorer with a detail message (e.g., `"invalid pattern: Invalid regular expression"`). The gate then falls through to the judge or task — it does not crash.
+
+**When to use:** Pattern matching, format validation, negative checks (e.g., "does not contain ERROR").
+
+### `json-schema`
+
+Validates the parsed target against a TypeBox-style contract (the same schema language used by `expect`).
+
+```json title="json-schema scorer"
+{
+  "type": "json-schema",
+  "schema": {
+    "type": "object",
+    "required": ["status", "data"],
+    "properties": {
+      "status": { "enum": ["success", "error"] },
+      "data": { "type": "object" }
+    }
+  }
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schema` | `object` | yes | A TypeBox-style JSON schema. |
+
+**Pass semantics:** The target is parsed with the same lenient JSON parser used by `output: "json"` (fenced code blocks are extracted). If parsing fails, the scorer fails. Otherwise, `contractViolations` checks the parsed value against the schema.
+
+**When to use:** Validating structured output, enforcing response shapes, checking enum values.
+
+<Callout type="tip">
+  The `json-schema` scorer uses the same lenient parser as the `expect` contract, so if your agent wraps JSON in a code fence, it's extracted automatically.
+</Callout>
+
+### `length-range`
+
+Tests whether the target's character count falls within an inclusive range.
+
+```json title="length-range scorer"
+{
+  "type": "length-range",
+  "min": 100,
+  "max": 10000
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `min` | `number` | at least one | Minimum character count (inclusive, `>= 0`). |
+| `max` | `number` | at least one | Maximum character count (inclusive, `>= 0`). |
+
+**Pass semantics:** `len >= min && len <= max`. If only `min` is provided, there's no upper bound. If only `max` is provided, the lower bound is `0`.
+
+**Validation:** `min` must be `<= max` when both are present. Both must be `>= 0`.
+
+**When to use:** Sanity checks on output size, preventing empty responses, capping verbosity.
+
+### `code-compiles`
+
+Spawns a real compiler in an isolated temp directory and checks whether the target parses or compiles.
+
+```json title="code-compiles scorer"
+{
+  "type": "code-compiles",
+  "language": "typescript"
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `language` | `"javascript"` \| `"typescript"` | yes | Which compiler to run. |
+
+**Pass semantics:**
+
+- **`javascript`:** Runs `node --check <file>`. Syntax check only — no execution, no dependencies.
+- **`typescript`:** Runs `npx --no-install tsc --noEmit --skipLibCheck <file>`. Requires a resolvable `tsc` in the environment. Its absence fails the scorer with a detail.
+
+**Code extraction:** If the target contains exactly one fenced code block, its body is compiled. Multiple fences or no fences means the raw target is compiled.
+
+**Security model:** The compiler runs in an isolated temp directory (`mkdtempSync` with `0700` permissions), not the phase's working directory. This prevents it from resolving a repo-planted `node_modules/.bin/tsc` or accessing project files. The `--no-install` flag prevents `npx` from downloading packages.
+
+**Timeout:** 30 seconds per compiler invocation. A timeout fails the scorer with a detail.
+
+**Error handling:** An unavailable compiler, a spawn error, or a timeout is a failed scorer (not a crash). The gate's fail-open path then decides what a failed check means.
+
+**When to use:** Validating generated code, catching syntax errors before shipping, type-checking TypeScript output.
+
+<Callout type="warn">
+  `code-compiles` is the only impure scorer — it spawns a child process. All other scorers are pure and evaluated in-process.
+</Callout>
+
+## Combining scorers
+
+A `score` block declares a list of scorers and a `combine` mode that decides how their results are aggregated. The default is `all`, which requires every scorer to pass.
+
+### `all` (default)
+
+Every scorer must pass. The combined score is `1` if all pass, `0` if any fail.
+
+```json title="combine: all"
+{
+  "scorers": [
+    { "type": "contains", "value": "\"status\"" },
+    { "type": "regex", "pattern": "\"status\"\\s*:\\s*\"success\"" }
+  ],
+  "combine": "all"
+}
+```
+
+**Semantics:** `results.every(r => r.passed)`. Binary outcome.
+
+### `any`
+
+At least one scorer must pass. The combined score is `1` if any pass, `0` if all fail.
+
+```json title="combine: any"
+{
+  "scorers": [
+    { "type": "contains", "value": "PASS" },
+    { "type": "contains", "value": "OK" }
+  ],
+  "combine": "any"
+}
+```
+
+**Semantics:** `results.some(r => r.passed)`. Binary outcome.
+
+### `weighted`
+
+Each scorer contributes a weighted score to a total, which is compared against a threshold.
+
+```json title="combine: weighted"
+{
+  "scorers": [
+    { "type": "contains", "value": "\"status\"" },
+    { "type": "json-schema", "schema": { "type": "object" } }
+  ],
+  "combine": "weighted",
+  "weights": [0.3, 0.7],
+  "threshold": 0.5
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `weights` | `number[]` | yes | Aligned to `scorers`. Each must be `> 0`. |
+| `threshold` | `number` | no | Combined score cutoff in `(0, 1]`. Default `0.5`. |
+
+**Semantics:** Each scorer's score is `0` (fail) or `1` (pass). The combined score is `sum(score[i] * weight[i]) / sum(weight[i])`. When a judge is present, its weight is appended to the weights array and its score folds into the combination.
+
+**Early cutoff:** When a judge is configured but hasn't run yet, the deterministic-only combination is a lower bound. If it already clears the threshold, the judge's score could not change the outcome and the gate auto-passes without spending judge tokens.
+
+<Callout type="info">
+  **Weight alignment.** `weights` must have exactly `scorers.length` entries when there's no judge, or `scorers.length + 1` entries when a judge is present (the last weight is the judge's). Validation enforces this.
+</Callout>
+
+## The judge fallback
+
+When deterministic scorers fail, an optional LLM judge can decide whether to let the flow continue. The judge runs only when the scorers don't pass — if they do, the gate auto-passes with zero tokens spent on the judge.
+
+```json title="gate with judge fallback"
+{
+  "id": "quality",
+  "type": "gate",
+  "dependsOn": ["generate"],
+  "score": {
+    "scorers": [
+      { "type": "json-schema", "schema": { "type": "object", "required": ["status"] } }
+    ],
+    "judge": {
+      "agent": "reviewer",
+      "task": "Is this a reasonable API response even if it doesn't match the schema exactly?"
+    }
+  }
+}
+```
+
+**Judge fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `task` | `string` | yes | The judge's prompt. The scorer report is appended automatically. |
+| `agent` | `string` | no | Agent name for the judge. Defaults to the gate's `agent`. |
+
+**Judge output parsing:** The judge can respond in three formats:
+
+1. **JSON:** `{"score": 0.0-1.0, "verdict": "pass"|"block", "reason": "..."}`
+2. **Bare verdict:** `{"verdict": "pass"}` or `{"verdict": "block"}`
+3. **Text markers:** `SCORE: 0.8` and/or `VERDICT: PASS` (case-insensitive, last match wins)
+
+**Fail-open semantics:** An unparseable judge output passes with `score: 1` and `verdict: "pass"`. Ambiguity must not block the flow.
+
+**Combining with scorers:**
+
+- **`weighted` mode:** The judge's score folds into the weighted combination using the last weight in `weights`. The threshold decides the verdict.
+- **`all` or `any` mode:** The judge's verdict is authoritative. If the judge says `pass`, the gate passes regardless of scorer results.
+
+<Callout type="tip">
+  The judge's prompt automatically includes the deterministic scorer report, so the LLM sees exactly which checks failed and why. You don't need to manually interpolate the results.
+</Callout>
+
+## The `target` field
+
+By default, scorers evaluate the upstream phase's output — the text produced by the phase listed in `dependsOn`. You can override this with the `target` field, which accepts an interpolation expression.
+
+```json title="Custom target"
+{
+  "id": "check-json",
+  "type": "gate",
+  "dependsOn": ["generate"],
+  "score": {
+    "target": "{steps.generate.json.response}",
+    "scorers": [
+      { "type": "contains", "value": "\"status\"" }
+    ]
+  }
+}
+```
+
+**Default:** `"{previous.output}"` — the output of the immediately upstream phase.
+
+**Interpolation:** The `target` is interpolated before scorers run, so you can reach into JSON fields with `{steps.<id>.json.<field>}` or use any other placeholder.
+
+## Complete gate with scoring
+
+Here's the running example after adding multiple scorers, a weighted combination, and a judge fallback:
+
+```json title="validate.json — complete scoring gate"
+{
+  "name": "validate",
+  "phases": [
+    {
+      "id": "generate",
+      "type": "agent",
+      "agent": "executor",
+      "task": "Generate a JSON API response for GET /users. Include status, data, and message fields.",
+      "output": "json"
+    },
+    {
+      "id": "check-response",
+      "type": "gate",
+      "dependsOn": ["generate"],
+      "score": {
+        "target": "{steps.generate.output}",
+        "scorers": [
+          { "type": "contains", "value": "\"status\"", "name": "has-status-field" },
+          { "type": "regex", "pattern": "\"status\"\\s*:\\s*\"success\"", "name": "status-is-success" },
+          { "type": "json-schema", "schema": { "type": "object", "required": ["status", "data"] }, "name": "valid-schema" },
+          { "type": "length-range", "min": 50, "max": 5000, "name": "reasonable-length" }
+        ],
+        "combine": "weighted",
+        "weights": [0.2, 0.3, 0.4, 0.1],
+        "threshold": 0.7,
+        "judge": {
+          "agent": "reviewer",
+          "task": "Is this a reasonable API response even if some checks failed?"
+        }
+      }
+    }
+  ]
+}
+```
+
+The gate evaluates four scorers at zero tokens. If the weighted combination clears `0.7`, it auto-passes. Otherwise, the judge runs and decides.
+
+## Scorer naming
+
+Each scorer can carry an optional `name` field. If omitted, the runtime generates a default label: `<type>-<index>` (e.g., `contains-0`, `regex-1`).
+
+```json title="Named scorers"
+{
+  "scorers": [
+    { "type": "contains", "value": "PASS", "name": "contains-pass-marker" },
+    { "type": "regex", "pattern": "\\d+", "name": "has-numeric-id" }
+  ]
+}
+```
+
+Names appear in the scorer report that's appended to the judge's prompt, making it easier for the LLM to understand which checks failed.
+
+## Fail-open semantics
+
+Scoring gates follow the same fail-open principle as the rest of taskflow: ambiguity must not block the flow.
+
+| Scenario | Behavior |
+|---|---|
+| Invalid regex pattern | Scorer fails with detail; gate falls through to judge or task. |
+| Target is not valid JSON (for `json-schema`) | Scorer fails with `"target is not valid JSON"`. |
+| Compiler unavailable (for `code-compiles`) | Scorer fails with `"compiler unavailable: <error>"`. |
+| Compiler timeout (for `code-compiles`) | Scorer fails with `"compiler timed out after 30000ms"`. |
+| Unparseable judge output | Judge passes with `score: 1`, `verdict: "pass"`. |
+| `min > max` in `length-range` | Validation error at flow definition time. |
+| Unknown scorer type | Validation error at flow definition time. |
+
+<Callout type="warn">
+  A failed scorer is not a failed gate. The gate only blocks when the combination (scorers + judge) fails to clear the threshold. If you want a failed scorer to always block, use `combine: "all"` and omit the judge.
+</Callout>
+
+## Accessing scorer results downstream
+
+The gate's structured result is exposed as `PhaseState.json`, reachable via interpolation:
+
+| Path | Value |
+|---|---|
+| `{steps.<gate>.json.verdict}` | `"pass"` or `"block"` |
+| `{steps.<gate>.json.combined}` | Combined score (number in `[0, 1]`) |
+| `{steps.<gate>.json.results}` | Array of `{name, type, passed, score, detail?}` |
+| `{steps.<gate>.json.threshold}` | Threshold (only for `weighted` mode) |
+| `{steps.<gate>.json.judge}` | `{score, reason?}` (only when judge ran) |
+
+```json title="Using scorer results downstream"
+{
+  "id": "report",
+  "type": "agent",
+  "dependsOn": ["check-response"],
+  "task": "The gate verdict was {steps.check-response.json.verdict} with a combined score of {steps.check-response.json.combined}. Summarize."
+}
+```
+
+## Interaction with `eval` and `task`
+
+A gate can have `eval`, `score`, and `task` fields. They run in this order:
+
+1. **`eval`** (if present): Zero-token machine checks. If all pass, the gate auto-passes. If any fail, continue to step 2.
+2. **`score`** (if present): Deterministic scorers. If they pass (per `combine` and `threshold`), the gate auto-passes. If they fail and a judge is configured, the judge runs. If they fail and no judge is configured, continue to step 3.
+3. **`task`** (if present): The LLM gate runs as normal, parsing a `VERDICT:` marker.
+
+<Callout type="info">
+  Setting both `eval` and `score` is valid but usually redundant — pick one. If both are present, `eval` runs first. Validation emits a warning when both are set.
+</Callout>
+
+## Security restrictions
+
+The `code-compiles` scorer is the only scorer that spawns a child process. It runs under strict isolation:
+
+- **Isolated temp directory:** Created with `mkdtempSync` (atomic, `0700` permissions). Closed the predictable-name symlink/TOCTOU race on shared `/tmp`.
+- **No project access:** The compiler runs with the temp dir as its working directory, not the phase's `cwd`. It cannot resolve a repo-planted `node_modules/.bin/tsc`.
+- **No network:** `npx --no-install` prevents downloading packages. The compiler can only check syntax and types from the standard library.
+- **Timeout:** 30-second wall-clock cap per invocation. A timeout kills the process with `SIGKILL`.
+- **Cleanup:** The temp directory is removed with `rmSync({recursive: true, force: true})` in a `finally` block. Best-effort cleanup — a failure to delete is swallowed.
+
+All other scorers are pure and run in-process with no filesystem or network access.
+
+## Field reference
+
+### `score` object
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `target` | `string` | `"{previous.output}"` | Interpolation ref for the scored string. |
+| `scorers` | `Scorer[]` | — | **Required.** Non-empty array of scorers. |
+| `combine` | `"all"` \| `"any"` \| `"weighted"` | `"all"` | How to aggregate scorer results. |
+| `weights` | `number[]` | — | Required for `weighted`. Aligned to `scorers` (+1 for judge). |
+| `threshold` | `number` | `0.5` | Combined score cutoff for `weighted`. Must be in `(0, 1]`. |
+| `judge` | `object` | — | Optional LLM-as-judge fallback. `{agent?, task}`. |
+
+### Scorer object
+
+Every scorer has these common fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | `string` | yes | One of the six scorer types. |
+| `name` | `string` | no | Result label. Defaults to `<type>-<index>`. |
+
+Per-type fields:
+
+| Type | Fields |
+|---|---|
+| `exact-match` | `value` (required string) |
+| `contains` | `value` (required string) |
+| `regex` | `pattern` (required string), `negate` (optional boolean) |
+| `json-schema` | `schema` (required object) |
+| `length-range` | `min` and/or `max` (at least one required, both `>= 0`) |
+| `code-compiles` | `language` (required: `"javascript"` or `"typescript"`) |
+
+**Validation:** A field set on a scorer whose type ignores it is a shape error. For example, `{type: "contains", negate: true}` is rejected — silently dropping `negate` would let the author believe negation happened.
+
+### Gate verdict grammar
+
+A gate phase (with or without `score`) parses its output into a verdict using this grammar:
+
+**JSON format:**
+
+```json
+{"continue": true}  → pass
+{"continue": false} → block
+{"pass": true}      → pass
+{"pass": false}     → block
+{"verdict": "PASS"} → pass
+{"verdict": "BLOCK"} → block
+{"verdict": "pass"} → pass (case-insensitive)
+{"verdict": "block"} → block
+{"verdict": "anything-else"} → pass (fail-open)
+```
+
+**Text format:**
+
+```
+VERDICT: PASS    → pass
+VERDICT: BLOCK   → block
+VERDICT: FAIL    → block
+VERDICT: STOP    → block
+VERDICT: OK      → pass
+VERDICT: REJECT  → block
+VERDICT: HALT    → block
+```
+
+- Case-insensitive.
+- Last occurrence wins (if the output contains multiple `VERDICT:` lines).
+- Supports both `:` and `=` separators: `VERDICT=PASS` works.
+
+**Fail-open:** Ambiguous output (no JSON, no `VERDICT:` marker) passes. A gate never accidentally loses your work.
+
+### Tournament winner grammar
+
+A tournament judge picks the winning variant using this grammar:
+
+**JSON format:**
+
+```json
+{"winner": 2}     → variant 2
+{"best": 3}       → variant 3
+{"choice": 1}     → variant 1
+```
+
+**Text format:**
+
+```
+WINNER: 2         → variant 2
+WINNER: #3        → variant 3 (hash prefix optional)
+WINNER=1          → variant 1 (supports = separator)
+```
+
+- 1-based index.
+- Last occurrence wins.
+- Clamped to `[1, variant-count]`: a verdict of `0` becomes `1`, a verdict of `99` becomes the last variant.
+
+**Fail-open:** An unparseable verdict defaults to variant `1` with reason `"no parseable winner; defaulted to variant 1"`. The tournament never loses your work.
+
+### Common errors
+
+<details>
+<summary>Validation errors</summary>
+
+| Error | Cause | Fix |
+|---|---|---|
+| `score.scorers: must be a non-empty array` | Empty or missing `scorers`. | Add at least one scorer. |
+| `score.scorers[i].type: must be one of ...` | Unknown scorer type. | Use one of the six supported types. |
+| `score.scorers[i].value: required string for 'contains'` | Missing required field. | Add the field. |
+| `score.scorers[i].negate: not applicable to 'contains'` | Field set on wrong scorer type. | Remove the field or use a different scorer. |
+| `score.weights: required array for combine:"weighted"` | `weighted` mode without weights. | Add `weights` aligned to scorers. |
+| `score.weights: expected N entries, got M` | Weight count mismatch. | Adjust the array length. If a judge is present, add one more weight. |
+| `score.threshold: must be a number in (0, 1]` | Invalid threshold. | Use a value in `(0, 1]`. |
+| `score.judge.task: required non-empty string` | Judge without a task. | Add a `task` string. |
+
+</details>
+
+<details>
+<summary>Runtime errors (scorer failures)</summary>
+
+| Error | Cause | Behavior |
+|---|---|---|
+| `invalid pattern: <message>` | Bad regex in `regex` scorer. | Scorer fails; gate falls through to judge or task. |
+| `target is not valid JSON` | `json-schema` scorer on non-JSON target. | Scorer fails; gate falls through. |
+| `compiler unavailable: <error>` | `tsc` or `node` not found. | Scorer fails; gate falls through. |
+| `compiler timed out after 30000ms` | Compiler exceeded the time cap. | Scorer fails; gate falls through. |
+| `length N outside [min, max]` | Target length out of range. | Scorer fails; gate falls through. |
+
+</details>
+
+## Next
+
+<Cards>
+  <Card title="Phase Types" href="/en/docs/syntax/phase-types">
+    The ten building blocks of a taskflow, including the gate type.
+  </Card>
+  <Card title="Control Flow" href="/en/docs/syntax/control-flow">
+    Deep dive into `when`, `join`, `retry`, and gates.
+  </Card>
+  <Card title="Output Contracts" href="/en/docs/syntax/contracts">
+    The `expect` field for validating JSON output.
+  </Card>
+</Cards>

--- a/website/content/docs/en/syntax/scorers.mdx
+++ b/website/content/docs/en/syntax/scorers.mdx
@@ -614,7 +614,7 @@ WINNER=1          → variant 1 (supports = separator)
   <Card title="Control Flow" href="/en/docs/syntax/control-flow">
     Deep dive into `when`, `join`, `retry`, and gates.
   </Card>
-  <Card title="Output Contracts" href="/en/docs/syntax/contracts">
+  <Card title="Output Contracts" href="/en/docs/syntax/flow-definition">
     The `expect` field for validating JSON output.
   </Card>
 </Cards>

--- a/website/content/docs/zh-cn/concepts/phases.mdx
+++ b/website/content/docs/zh-cn/concepts/phases.mdx
@@ -1,5 +1,5 @@
 ---
-title: 阶段类型
+title: 阶段
 description: taskflow 的十个构建块，以及如何在它们之间做选择。
 ---
 

--- a/website/content/docs/zh-cn/concepts/shared-context-tree.mdx
+++ b/website/content/docs/zh-cn/concepts/shared-context-tree.mdx
@@ -1,0 +1,339 @@
+---
+title: 共享上下文树
+description: 隔离的子代理如何在不破坏上下文隔离的前提下进行协作。
+---
+
+想象一个安全审计流程：十个并行的子代理审查十个不同的文件，但都需要读取第一个代理已经读过的同一份架构图。如果没有协调机制，每个代理都会独立读取该图——花费十倍的 token，付出十倍的成本。再想象一个父代理需要在运行过程中引导其子代理："跳过模块 X，我们在那里发现了一个关键 bug。"如果没有向上通道，父代理只能旁观并希望一切顺利。
+
+taskflow 通过共享上下文树（Shared Context Tree）解决了这两个问题。
+
+## 两个问题，一个基础设施
+
+共享上下文树是一个 IPC 层，让隔离的子代理进程能够协作，同时保持上下文隔离保证（中间转录永远不会进入你的对话）。它解决两个不同的问题：
+
+**水平协调**（黑板）：兄弟子代理彼此共享发现。第一个读取昂贵文档的代理发布一个摘要；后面九个代理读取摘要而不是原文。
+
+**垂直监督**（树）：子代理向上报告给其父代理，父代理可以动态生成新的子代理。父代理审查其子代理的工作并决定是升级、重试还是继续。
+
+```txt title="两个通道"
+水平（黑板）                  垂直（监督）
+                                 
+代理 A ——写入——┐              父代理
+               │                 │
+代理 B ——读取——┤              ┌——┴——┐
+               │              │     │
+代理 C ——读取——┘           子1   子2
+                              │     │
+                            报告   报告
+                              │     │
+                              └──┬——┘
+                                 ▼
+                               父代理
+```
+
+两个通道都位于同一个磁盘目录中，由与运行存储相同的原子写入和文件锁原语保护。两者都是可选的且有界的。
+
+## 四个工具
+
+当一个阶段选择加入共享上下文时，其子代理会收到四个工具：
+
+```json title="按阶段选择加入"
+{
+  "id": "review-each",
+  "type": "map",
+  "shareContext": true,
+  "over": "{steps.discover.json.files}",
+  "as": "file",
+  "agent": "security-reviewer",
+  "task": "审查 {file.path} 中的漏洞。"
+}
+```
+
+子代理现在可以调用：
+
+- **`ctx_write(key, value)`** — 向共享黑板发布发现。
+- **`ctx_read(key?)`** — 从黑板读取发现（可选单个键）。
+- **`ctx_report(summary, structured?)`** — 向上向父代理发送摘要。
+- **`ctx_spawn(assignments[])`** — 排队子任务，运行时在此代理完成后接收。
+
+<Steps>
+  <Step title="发布发现">
+    第一个审查者读取架构图并发布摘要：
+    
+    ```json title="ctx_write 调用"
+    {
+      "key": "architecture-summary",
+      "value": {
+        "pattern": "微服务",
+        "critical_paths": ["/auth", "/payment"],
+        "trust_boundaries": ["api-gateway", "service-mesh"]
+      }
+    }
+    ```
+  </Step>
+  
+  <Step title="读取发现">
+    后面九个审查者读取摘要而不是重新读取图表：
+    
+    ```json title="ctx_read 调用"
+    {
+      "key": "architecture-summary"
+    }
+    ```
+    
+    每个审查者都节省了第一个代理完整读取所花费的 token。
+  </Step>
+  
+  <Step title="向上报告">
+    当审查者完成时，它报告其结论：
+    
+    ```json title="ctx_report 调用"
+    {
+      "summary": "在 /auth/oauth.ts 中发现 2 个关键问题",
+      "structured": {
+        "severity": "critical",
+        "issues": ["CSRF-token-leak", "SQL-injection"]
+      }
+    }
+    ```
+  </Step>
+  
+  <Step title="生成子代理">
+    审查者发现一个需要更深入检查的子模块并排队子任务：
+    
+    ```json title="ctx_spawn 调用"
+    {
+      "assignments": [
+        {
+          "task": "深度审计 /auth/oauth.ts 的令牌处理",
+          "agent": "security-reviewer"
+        },
+        {
+          "task": "检查 /auth/session.ts 的会话固定",
+          "agent": "security-reviewer"
+        }
+      ]
+    }
+    ```
+    
+    运行时在父代理完成后接收这些分配，并将它们作为监督树中的子节点运行。
+  </Step>
+</Steps>
+
+## 谁能看到什么
+
+黑板不是自由放养的。可见性受到限制以防止读取半完成的工作：
+
+**一个节点可以看到：**
+
+- 它**自己的**发现，始终（即使在运行时）。
+- 它的**祖先**的发现（父、祖父等）。
+- **已完成的兄弟**的发现——永远不会看到仍在运行的兄弟。
+
+最后一条规则至关重要。你永远不会读取半完成的黑板。兄弟的发现只有在它报告完成（`status: "done"` 或 `"failed"`）后才可见，所以你看到的是完成的结果，而不是进行中的工作。
+
+```txt title="扇出中的可见性"
+父代理（完成）
+  ├─ 写入: "architecture-summary"
+  │
+  └─ 子代理（并行映射）：
+      ├─ child-1（运行中）→ 看到：父的发现 + 自己的发现
+      ├─ child-2（完成）  → 看到：父的发现 + 自己的发现 + child-2 的发现
+      └─ child-3（运行中）→ 看到：父的发现 + 自己的发现
+                           （child-2 可见因为它已完成）
+```
+
+**键冲突：** 当两个节点写入相同的键时，更近的作用域获胜。节点自己的发现覆盖其祖先的，祖先覆盖已完成的兄弟。这符合节点最信任自己笔记的直觉。
+
+## 磁盘布局
+
+共享上下文树位于每个运行的目录 `<runs-root>/ctx/<run-id>/` 下：
+
+```txt title="目录结构"
+<ctxDir>/
+├── tree.json                  节点树（谁生成了谁 + 状态）
+├── tree.json.lock             保护 tree.json RMW 循环的锁
+├── findings/
+│   ├── <nodeId>.json          一个节点写入的发现（每个键最后写入获胜）
+│   └── <nodeId>.json.lock     每节点锁（兄弟永远不会争用）
+├── reports/
+│   └── <nodeId>.json          节点的向上报告（{summary, structured?}）
+└── pending/
+    └── <nodeId>-<seq>.json    运行时将接收的 ctx_spawn 意图
+```
+
+**为什么是每节点发现文件**（而不是一个共享的 `findings.json`）：兄弟子代理并发运行。给每个节点自己的文件意味着并发写入者永远不会争用同一个锁——一个节点只锁定自己的文件。读取者联合相关节点的文件（其祖先加上已完成的兄弟）。这是运行索引用来避免全局写入瓶颈的相同"按写入者分片"技巧。
+
+**原子写入和锁：** 每个文件操作都使用 `writeFileAtomic`（写入临时文件，然后 `renameSync`）和 `withLock`（基于文件的锁，带有过期锁接管），与 `store.ts` 相同的原语。树免费继承了项目的"所有文件操作都是原子的"不变量。
+
+## 限制和安全
+
+共享上下文树是可选的，正是因为它在上下文隔离中打了一个洞。为了保持这个洞小，每个通道都有上限：
+
+| 通道 | 限制 | 理由 |
+|------|------|------|
+| 单个发现值 | 256 KB | 防止失控的工具调用填满磁盘 |
+| 单个报告摘要 | 256 KB | 同上 |
+| 报告结构化负载 | 256 KB | 同上 |
+| 每节点键数 | 256 | 限制一个节点黑板的大小 |
+| 每次调用生成分配数 | 16 | 防止无限扇出 |
+| 生成任务提示 | 64 KB | 限制动态排队任务的大小 |
+| 生成子流程负载 | 256 KB | 限制内联子 DAG 的大小 |
+| 键字符集 | `[A-Za-z0-9._-]`（≤128 字符） | 防止路径遍历和冲突 |
+
+**当你达到限制时会发生什么：** 工具调用抛出错误，子代理将其视为工具失败。代理可以用更小的值重试、跳过写入或使阶段失败——运行时不会崩溃。
+
+**什么被清理：** 整个 `<ctxDir>` 作用于一个运行。当运行被清理时（根据你的保留策略），上下文树也随之清理。没有东西会跨运行或会话泄漏。
+
+## 启用共享上下文
+
+你可以在两个级别选择加入：
+
+### 按阶段：`shareContext`
+
+为单个阶段启用共享上下文：
+
+```json title="按阶段选择加入"
+{
+  "id": "review-each",
+  "type": "map",
+  "shareContext": true,
+  "over": "{steps.discover.json.files}",
+  "as": "file",
+  "agent": "security-reviewer",
+  "task": "审查 {file.path}。"
+}
+```
+
+### 流程范围：`contextSharing`
+
+为流程中的每个阶段启用共享上下文：
+
+```json title="流程范围选择加入"
+{
+  "name": "security-audit",
+  "contextSharing": true,
+  "phases": [
+    { "id": "discover", "type": "agent", "agent": "scout", "task": "..." },
+    { "id": "review-each", "type": "map", "over": "...", "task": "..." },
+    { "id": "summarize", "type": "agent", "agent": "auditor", "task": "..." }
+  ]
+}
+```
+
+**优先级：** `shareContext` 优先于 `contextSharing`。如果你在流程上设置 `contextSharing: true` 但在一个阶段上设置 `shareContext: false`，该阶段将被排除。这让你可以全局启用共享并创建例外。
+
+<Callout type="warn">
+  共享上下文是一种权衡。你以获得效率和协作的代价是阶段不再是完全独立的。在你有具体理由启用它之前保持关闭——共享昂贵的读取，或父代理需要引导其子代理。
+</Callout>
+
+## 具体用例
+
+### 去重昂贵读取
+
+十个并行审查者都需要同一份 50 页的架构文档。第一个审查者读取它并向黑板发布 2 页摘要。后面九个读取摘要而不是原文，每个代理节省约 48 页的上下文。
+
+```json title="去重模式"
+{
+  "id": "review-each",
+  "type": "map",
+  "shareContext": true,
+  "over": "{steps.list-files.json}",
+  "as": "file",
+  "agent": "reviewer",
+  "task": "如果 ctx_read('architecture-summary') 为空，读取 ARCHITECTURE.md 并 ctx_write('architecture-summary', <2页摘要>)。然后使用摘要审查 {file.path}。"
+}
+```
+
+### 父代理引导子代理
+
+父代理审查其子代理的工作并在运行中决定跳过模块：
+
+```json title="引导模式"
+{
+  "id": "parent",
+  "type": "agent",
+  "shareContext": true,
+  "agent": "coordinator",
+  "task": "审查初始扫描。如果 /auth 有问题，ctx_write('skip-auth', true) 让你的子代理跳过它。"
+}
+```
+
+子代理在开始工作前检查黑板：
+
+```json title="子代理检查父代理的发现"
+{
+  "id": "children",
+  "type": "map",
+  "shareContext": true,
+  "dependsOn": ["parent"],
+  "over": "{steps.list-modules.json}",
+  "as": "module",
+  "agent": "auditor",
+  "task": "如果 ctx_read('skip-auth') 且 {module.path} 以 '/auth' 开头，跳过。否则审计 {module.path}。"
+}
+```
+
+### 使用 ctx_spawn 动态扇出
+
+审查者发现需要更深入检查的子模块并动态生成子任务：
+
+```json title="动态生成模式"
+{
+  "id": "reviewer",
+  "type": "agent",
+  "shareContext": true,
+  "agent": "security-reviewer",
+  "task": "审查 /auth。如果你发现需要深度审计的子模块，ctx_spawn 它们作为子任务。"
+}
+```
+
+运行时在审查者完成后接收生成意图，并将它们作为监督树中的子节点运行。每个子代理继承其父代理的上下文（它看到父代理的发现）并且本身可以生成孙代理。
+
+### 聚合报告
+
+父代理从其子代理收集结构化报告并决定是否升级：
+
+```json title="聚合模式"
+{
+  "id": "parent",
+  "type": "reduce",
+  "shareContext": true,
+  "dependsOn": ["children"],
+  "agent": "coordinator",
+  "task": "从每个子代理读取 ctx_report()。如果任何报告的 severity='critical'，升级给用户。否则总结。"
+}
+```
+
+## 恢复安全
+
+共享上下文树是恢复安全的。当运行恢复时：
+
+- **树节点按 `nodeId` 进行 upsert**，所以重新运行不会重复树条目（这会重复计算祖先发现）。
+- **`dedicated` 工作区**（如果你在工作区隔离的同时使用共享上下文）每个 `(runId, phaseId)` 重用相同的目录路径。
+- **发现在恢复期间持久化**，所以已经发布发现的阶段不需要重新发布。
+
+这意味着你可以恢复长时间运行的流程而不会丢失其阶段建立的协作状态。
+
+## 契约重申
+
+共享上下文树有两个关键保证：
+
+1. **可选且有界。** 默认情况下禁用共享上下文。启用时，每个通道都有上限，所以协作不会失控。
+2. **原子且隔离。** 每个写入都是原子的且有锁的。兄弟永远不会争用同一个锁。没有东西会跨运行泄漏。
+
+它们共同意味着你可以协调复杂的多代理工作流，而不会牺牲上下文隔离提供的安全性和可预测性。
+
+## 下一步
+
+<Cards>
+  <Card title="上下文隔离" href="/zh-cn/docs/concepts/context-isolation">
+    共享上下文构建的默认行为。
+  </Card>
+  <Card title="阶段类型" href="/zh-cn/docs/concepts/phases">
+    十种阶段类型如何使用共享上下文。
+  </Card>
+  <Card title="恢复" href="/zh-cn/docs/concepts/resume">
+    共享上下文如何跨会话存活。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/concepts/workspace-isolation.mdx
+++ b/website/content/docs/zh-cn/concepts/workspace-isolation.mdx
@@ -1,0 +1,653 @@
+---
+title: 工作区隔离
+description: taskflow 如何为每个阶段分配独立的工作目录——并在完成后清理。
+---
+
+大多数阶段在你启动 flow 的目录中运行。当子代理只是读取代码时这没问题，但一旦某个阶段需要写文件、跑构建或执行 git commit，这就成了隐患。两个并行分支同时编辑同一个 `src/index.ts` 会互相覆盖。一次失败的实验在你的目录树中留下残余文件，干扰下一个阶段。一个 `script` 阶段执行 `npm install` 会把只有某个子代理需要的包污染到你的 `node_modules` 里。
+
+工作区隔离通过阶段定义上的一个字段 `cwd` 解决所有这些问题。
+
+## 三个保留关键字
+
+将一个阶段的 `cwd` 设为三个保留关键字之一，运行时会在执行前为它分配一个隔离的工作目录，然后在完成后清理。把 `cwd` 留作字面路径（或完全省略），阶段就像以前一样在默认目录中运行——隔离是 opt-in 的。
+
+```txt title="三种工作区模式"
+cwd: "temp"        →  /tmp/pi-tf-ws-<phase>-XXXXXX   （阶段完成后删除）
+cwd: "dedicated"   →  <runs>/ws/<runId>/<phaseId>    （保留以供检查）
+cwd: "worktree"    →  基于一次性分支的 git worktree  （阶段完成后删除）
+```
+
+每种模式在隔离性和持久性之间权衡。正确的选择取决于阶段的副作用是否需要在运行结束后保留。
+
+### `temp` — 临时草稿空间
+
+`temp` 工作区是通过 `fs.mkdtempSync` 在系统的 `os.tmpdir()` 下创建的操作系统级临时目录。前缀 `pi-tf-ws-<phaseId>-` 使目录在 `/tmp` 列表中可识别；随机后缀保证并发阶段之间的唯一性。
+
+```json title="一个不触碰你目录树的代码起草阶段"
+{
+  "id": "draft-patch",
+  "type": "agent",
+  "cwd": "temp",
+  "task": "根据下面的描述编写补丁。\n{steps.analyze.output}"
+}
+```
+
+**清理：** 阶段完成时——无论成功还是失败——目录会被递归删除。删除操作是 best-effort 且有容器限制的：运行时拒绝删除 OS tmpdir 之外的任何东西，所以未来路径构造中的 bug 永远不会删除你的项目文件。
+
+**何时使用：** 起草实验、代码生成、中间文件转换——任何产生的文件在阶段完成后你不再需要的场景。如果阶段的价值在于它的文本输出（由运行时捕获），而不是它的文件系统产物，`temp` 是正确的选择。
+
+### `dedicated` — 持久化的 per-phase 目录
+
+`dedicated` 工作区是位于运行状态树 `<runsRoot>/ws/<runId>/<phaseId>` 下的目录。它通过 `mkdirSync({ recursive: true })` 创建，并且——关键点——运行时**从不删除**它。
+
+```json title="一个你希望在运行后检查其产物的阶段"
+{
+  "id": "generate-report",
+  "type": "agent",
+  "cwd": "dedicated",
+  "task": "根据审计数据生成完整的 HTML 报告。\n{steps.audit.json}"
+}
+```
+
+**清理：** 无。目录与运行状态一起持久存在。只有当运行本身被保留策略（`maxKeptRuns` / `maxRunAgeDays`）修剪时才会被清理。
+
+**续跑行为：** 路径基于 `(runId, phaseId)` 是确定性的。如果你续跑一次失败的运行，同一个目录会被复用——先前尝试的产物仍然存在。这是刻意设计的：`dedicated` 工作区是运行时假设你想跨尝试检查或积累产物的唯一模式。
+
+**何时使用：** 产生你想在运行后审查的文件的阶段（报告、生成的代码、测试 fixture）。也适用于下游兄弟需要从磁盘（而不是通过插值系统）读取产物的阶段。
+
+### `worktree` — 基于一次性分支的真实 git worktree
+
+`worktree` 工作区是一次真正的 `git worktree add -b <branch> <dir> HEAD` 调用。分支名为 `tf/<runId>/<phaseId>-<timestamp>`（时间戳用 base-36 编码以保持紧凑），工作目录分配在 OS tmpdir 下，然后由 git 用 `HEAD` 的完整检出填充。
+
+```json title="一个执行隔离 git commit 的阶段"
+{
+  "id": "apply-migration",
+  "type": "agent",
+  "cwd": "worktree",
+  "task": "应用上一步的数据库迁移方案。每个迁移文件单独 commit。"
+}
+```
+
+**清理：** 阶段完成后，运行时执行 `git worktree remove --force <dir>`（30 秒超时），然后 `rmrf` 目录作为纵深防御，最后 `git branch -D <branch>`（10 秒超时）。每一步都是 best-effort：残留的 worktree 或分支无害，不会导致阶段失败。
+
+**fail-open 降级：** worktree 要求阶段的基目录位于一个 git work tree 内。如果不是——基目录没有 `.git`，或者 `git rev-parse --is-inside-work-tree` 失败——运行时会优雅地降级为 `temp` 工作区。阶段仍然在隔离目录中运行；只是失去了 git 语义。一个警告会被附加到阶段的 `warnings` 数组：
+
+```txt title="降级 worktree 的警告"
+workspace:temp — worktree requested but base cwd is not a git work tree; used a temp dir instead
+```
+
+同样的降级也适用于 `git worktree add` 本身失败的情况（例如分支名冲突、detached HEAD 或 60 秒超时）。运行时会清理失败的分配并用 `temp` 重试。
+
+**何时使用：** 需要执行 git commit、运行 diff、应用补丁，或操作一份可以丢弃而不影响主工作树的仓库副本的阶段。一个 N 个变体各自独立 commit 的 tournament 是典型用例。
+
+## 运行时如何集成
+
+生命周期很直观：
+
+```txt title="运行时中的工作区生命周期"
+1. phase.cwd 是关键字？
+   否  → 在 deps.cwd（默认路径）中运行阶段。完毕。
+   是  ↓
+2. allocateWorkspace(keyword, {baseCwd, runId, phaseId, runsRoot})
+   → Workspace { dir, kind, teardown, branch?, note? }
+3. 将 deps.cwd 覆盖为 ws.dir 用于阶段的子代理
+4. 执行阶段
+5. 将工作区诊断信息附加到 PhaseState.warnings（如有降级）
+6. 在 finally 块中调用 ws.teardown()（best-effort）
+```
+
+teardown 运行在 `finally` 块中，所以无论阶段成功、失败还是被中止，它都会触发。teardown 本身被 `try/catch` 包裹——一个清理错误永远不会替代阶段的真实结果（项目错误处理惯例中的"safe emit"不变量）。
+
+## 始终 fail-open
+
+每种工作区模式都是降级而非失败。完整的降级阶梯：
+
+| 失败 | 降级 |
+|---|---|
+| `temp`：`mkdtempSync` 抛出异常 | 回退到 `baseCwd`（运行的默认目录），附带警告 |
+| `dedicated`：`mkdirSync` 抛出异常 | 回退到 `baseCwd`，附带警告 |
+| `worktree`：基目录不在 git 仓库中 | 降级为 `temp`（仍然隔离，但无 git） |
+| `worktree`：temp 目录分配失败 | 先重试 `temp`，再回退到 `baseCwd` |
+| `worktree`：`git worktree add` 失败 | 降级为 `temp`（警告中包含 git 的 stderr） |
+| 任何 teardown 错误 | 静默吞掉；best-effort 清理 |
+
+在每种情况下，阶段仍然运行。运行时将一个 `note` 附加到 workspace 句柄上，作为 `PhaseState.warnings` 条目展示，所以降级在 `/tf peek` 中可见，但从不阻塞运行。
+
+```txt title="降级工作区的警告示例"
+workspace — dedicated workspace alloc failed: EACCES: permission denied
+```
+
+<Callout type="info">
+  fail-open 设计是刻意的：工作区是隔离增强，不是正确性要求。一个在基目录而非隔离目录中运行的阶段可能会留下残余文件，但它仍然产出正确的结果。替代方案——因为 `/tmp` 满了就失败阶段——严格来说会更糟。
+</Callout>
+
+## 续跑安全
+
+续跑（在[续跑](/zh-cn/docs/concepts/resume)中记录的跨会话重放系统）与工作区的交互有特定方式：
+
+- **`temp`** 和 **`worktree`** 在每次运行时从零开始重新分配。如果一个阶段被续跑（输入变了，或你强制了重新运行），会创建一个全新的目录。旧的 temp/worktree 目录在先前的尝试完成时已经被清理了。
+- **`dedicated`** 是确定性的：路径 `<runs>/ws/<runId>/<phaseId>` 在续跑尝试之间相同。如果先前的尝试留下了文件，它们在重新运行开始时仍然存在。这是有意为之——`dedicated` 工作区是积累模式。
+- 被缓存的阶段（输入哈希未变，结果从缓存恢复）根本不会触发工作区分配。缓存结果被直接复用，不重新运行子代理，因此不创建或触碰任何目录。
+
+<Callout type="warn">
+  `dedicated` 工作区在续跑尝试之间积累。如果一个阶段在尝试 1 写入了 `output.json`，然后失败并在尝试 2 重新运行，尝试 2 开始时尝试 1 的文件仍然在目录中。设计 `dedicated` 阶段时确保它是幂等的，或检查已有产物。
+</Callout>
+
+## 路径容器化
+
+运行时在两个层面强制执行容器化：
+
+1. **`dedicated` 目录根植于运行状态下。** 路径 `<runsRoot>/ws/<runId>/<phaseId>` 由经过 sanitize 的段构成——phase id 经过 `safeSegment()` 处理，剥离 `[A-Za-z0-9._-]` 之外的所有字符，折叠前导点，并限制在 100 字符以内。一个像 `../../etc` 的 phase id 会变成 `______etc`。
+
+2. **`temp` 和 `worktree` 的删除受根目录限制。** `rmrf` 辅助函数拒绝删除 OS tmpdir 和运行自己的 `ws/` 树之外的任何东西。即使未来的 bug 产生了一个错误路径，容器化检查也能防止项目文件被删除。
+
+3. **动态子流完全不能使用工作区关键字。** 一个生成的子流（由 LLM 通过 `flow { def }` 或 `ctx_spawn` 编写的）如果任何阶段将 `cwd` 设为 `temp`、`dedicated` 或 `worktree`，会被验证拒绝。LLM 编写的计划不得分配隔离目录或创建会变更仓库的 git worktree。只有作者编写的 flow 才能使用工作区隔离。
+
+## 选择正确的模式
+
+```txt title="决策树"
+阶段是否写入你在它完成后需要的文件？
+  是 → dedicated
+  否 ↓
+阶段是否需要 git（commit、diff、分支）？
+  是 → worktree
+  否 → temp
+```
+
+| 模式 | 隔离 | 持久 | Git | 清理 | 续跑 |
+|---|---|---|---|---|---|
+| `temp` | ✓ | ✗ | ✗ | 完成后删除 | 重新分配 |
+| `dedicated` | ✓ | ✓ | ✗ | 保留直到运行被修剪 | 复用同一目录 |
+| `worktree` | ✓ | ✗ | ✓ | worktree + 分支删除 | 重新分配 |
+
+## 示例
+
+### 无冲突的并行实验
+
+两个阶段各自生成完整实现，并行运行。没有隔离的话它们会写同一个文件：
+
+```json title="并行隔离草稿"
+{
+  "name": "compare-approaches",
+  "phases": [
+    {
+      "id": "approach-a",
+      "type": "agent",
+      "cwd": "temp",
+      "task": "使用方案 A 实现该功能。"
+    },
+    {
+      "id": "approach-b",
+      "type": "agent",
+      "cwd": "temp",
+      "task": "使用方案 B 实现该功能。"
+    },
+    {
+      "id": "judge",
+      "type": "agent",
+      "task": "比较：\nA: {steps.approach-a.output}\nB: {steps.approach-b.output}",
+      "dependsOn": ["approach-a", "approach-b"],
+      "final": true
+    }
+  ]
+}
+```
+
+每个草稿在自己的 temp 目录中运行。谁也看不到或覆盖不了对方的文件。
+
+### 带 git commit 的 tournament
+
+每个变体在自己的一次性分支上做独立 commit，然后评委选出最佳：
+
+```json title="带 worktree 隔离的 tournament"
+{
+  "name": "refactor-tournament",
+  "phases": [
+    {
+      "id": "variant-1",
+      "type": "agent",
+      "cwd": "worktree",
+      "task": "使用策略模式重构 auth 模块。每个文件变更单独 commit。"
+    },
+    {
+      "id": "variant-2",
+      "type": "agent",
+      "cwd": "worktree",
+      "task": "使用中间件链重构 auth 模块。每个文件变更单独 commit。"
+    },
+    {
+      "id": "judge",
+      "type": "gate",
+      "task": "审查两种重构方案。对更好的那个输出 VERDICT: PASS 并说明理由。",
+      "dependsOn": ["variant-1", "variant-2"],
+      "final": true
+    }
+  ]
+}
+```
+
+每个变体获得自己的一次性分支上的 worktree（`tf/<runId>/variant-1-<ts>` 和 `tf/<runId>/variant-2-<ts>`）。commit 是真正的 git commit，与主目录树完全隔离。两个 worktree 和分支在各自阶段完成时被清理。
+
+### 留下产物以供审查的审计
+
+```json title="dedicated 工作区用于可检查的输出"
+{
+  "name": "security-audit",
+  "phases": [
+    {
+      "id": "scan",
+      "type": "agent",
+      "cwd": "dedicated",
+      "task": "扫描代码库中的漏洞。将发现的所有问题写入 findings.json 文件。"
+    },
+    {
+      "id": "report",
+      "type": "agent",
+      "task": "读取扫描结果：\n{steps.scan.output}\n写一份人类可读的摘要。",
+      "dependsOn": ["scan"],
+      "final": true
+    }
+  ]
+}
+```
+
+`scan` 阶段的 `dedicated` 工作区在运行完成后将 `findings.json` 保留在磁盘上。你可以通过 `/tf peek` 检查它，或者直接在运行的 `ws/` 目录下找到它。
+
+## 警告与诊断
+
+当工作区降级或遇到问题时，运行时将警告附加到阶段状态。这些在 `/tf peek <runId>` 和持久化的运行记录中可见：
+
+```txt title="工作区警告示例"
+workspace:temp at /tmp/pi-tf-ws-draft-patch-a1b2c3/
+workspace:temp — worktree requested but base cwd is not a git work tree; used a temp dir instead
+workspace — dedicated workspace alloc failed: EACCES: permission denied
+workspace:worktree at /tmp/pi-tf-wt-apply-migration-x4y5z6/ (branch: tf/abc123/apply-migration-m3k2j1)
+```
+
+显示 `workspace:<kind> at <path>` 的警告是信息性的——工作区分配成功。kind 后面带 `—` 的警告表示降级。
+
+## 下一步
+
+<Cards>
+  <Card title="上下文隔离" href="/zh-cn/docs/concepts/context-isolation">
+    工作区隔离处理文件系统；上下文隔离处理 transcript。
+  </Card>
+  <Card title="续跑" href="/zh-cn/docs/concepts/resume">
+    缓存的阶段如何完全跳过工作区分配。
+  </Card>
+  <Card title="阶段类型" href="/zh-cn/docs/concepts/phases">
+    `script` 阶段类型以及工作区隔离最重要的场景。
+  </Card>
+</Cards>
+```
+
+---
+
+## meta.json Placement
+
+Insert `concepts/workspace-isolation` after `concepts/context-isolation` in both meta.json files:
+
+**`website/content/docs/en/meta.json`** — change:
+```
+"concepts/context-isolation",
+"concepts/resume",
+```
+to:
+```
+"concepts/context-isolation",
+"concepts/workspace-isolation",
+"concepts/resume",
+```
+
+**`website/content/docs/zh-cn/meta.json`** — same change:
+```
+"concepts/context-isolation",
+"concepts/workspace-isolation",
+"concepts/resume",
+```
+
+This places Workspace Isolation between Context Isolation (which covers the transcript-level isolation) and Resume (which references workspace behavior on re-run). The conceptual flow is: "your outputs are isolated → your filesystem can be isolated → and all of this survives across sessions."
+
+## Risk Review
+
+**Severity summary:** 0 critical, 0 high, 1 medium, 2 low findings. No issues block the documentation merge.
+
+### Medium
+
+**M1 — `dedicated` workspace is NOT idempotent across resume attempts (documentation accuracy risk).**
+The doc states: *"A `dedicated` workspace accumulates across resume attempts."* This is technically correct per the code (`workspace.ts:131-137` — `mkdirSync({ recursive: true })` is idempotent, but never clears prior contents). However, the doc's warning about this could be stronger. If a `dedicated` phase writes a file that the next resume attempt reads and misinterprets as "already done," you get a silent data-integrity bug at the flow-author level. The doc addresses this with the Callout about idempotency, which is appropriate.
+
+**Evidence:** `workspace.ts:134` — `fs.mkdirSync(dir, { recursive: true })` does not clear the directory.
+
+### Low
+
+**L1 — `worktree` branch name is not collision-proof on rapid sequential runs.**
+The branch name `tf/<runId>/<phaseId>-<Date.now().toString(36)>` uses millisecond-resolution timestamps. Two rapid sequential runs (same runId, same phaseId, within 1ms) could theoretically collide, though in practice `runId` uniqueness prevents this. Not a documentation concern; just a code observation.
+
+**Evidence:** `workspace.ts:149` — `branch = \`tf/${safeSegment(runId)}/${seg}-${Date.now().toString(36)}\``.
+
+**L2 — The `rmrf` containment check for `dedicated` workspaces relies on `runsRoot` being passed as an `allowedRoots` parameter.**
+The `teardown` for `dedicated` is a no-op, so this is moot today. But if someone adds teardown later, the `rmrf` function at `workspace.ts:85-93` only checks `os.tmpdir()` by default. The `dedicated` path under `runsRoot/ws/` would NOT be in the allowed roots unless explicitly passed. Again, not a current bug — just a latent risk if teardown semantics change.
+
+**Evidence:** `workspace.ts:136` — `teardown() {}` (no-op for dedicated).
+
+### Passes
+
+- **Fail-open documentation is accurate.** Every degradation path documented in the article matches the code: temp alloc failure → inherited (workspace.ts:122-125), dedicated alloc failure → inherited (workspace.ts:137-139), worktree non-git → temp (workspace.ts:144-147), worktree add failure → temp (workspace.ts:159-164), teardown errors → swallowed (runtime.ts:747-749).
+- **Path containment documentation is accurate.** `safeSegment` sanitization (workspace.ts:80-83) and `rmrf` root restriction (workspace.ts:85-93) are correctly described.
+- **Dynamic sub-flow restriction is accurately documented.** Schema validation blocks workspace keywords in dynamic flows (schema.ts:588-590).
+- **Resume behavior is correctly described.** `temp`/`worktree` are re-allocated; `dedicated` is deterministic; cached phases skip allocation entirely (verified via runtime.ts:723-724 early return for non-keyword cwd, and the cached phase path never reaches workspace allocation).
+
+### Recommendation: **Approved.**
+
+The documentation is technically precise, matches the source code evidence, and correctly describes all failure modes, cleanup semantics, and resume behavior.
+
+### Decisions
+
+- Assumed the `<Callout>` MDX component and `<Cards>`/`<Card>` components are available project-wide (confirmed from existing concepts docs).
+- Assumed frontmatter `title`/`description` is the correct schema (confirmed from existing docs).
+- Did not verify whether the Chinese `zh-cn` docs are auto-translated or hand-maintained; wrote a full hand-translated Chinese version matching the style of `zh-cn/concepts/context-isolation.mdx` (which preserves technical English terms like `fail-open`, `opt-in`, `best-effort`, `transcript`).
+
+---
+
+### [3/5] risk-reviewer
+
+Now I have all the evidence needed. Here are the two complete `.mdx` files:
+
+---
+
+## Risk Review
+
+Not applicable to this task — this is a documentation authoring task, not a code change review. Proceeding with the deliverable.
+
+---
+
+## `meta.json` placement
+
+Insert `guides/background-runs` **after `guides/tournament` and before the case studies**. Updated `pages` array section:
+
+```
+"guides/tournament",
+"guides/background-runs",        ← NEW
+"guides/code-audit-case-study",
+```
+
+---
+
+## FILE: `website/content/docs/en/guides/background-runs.mdx`
+
+```mdx
+---
+title: Background Runs
+description: Fire off a long-running flow and get your prompt back immediately. Poll status by runId.
+---
+
+A normal `taskflow` call blocks your session until every phase finishes. For a three-phase code audit that takes eight minutes, that is eight minutes your prompt is frozen.
+
+Background runs fix this. Set `detach: true` and the MCP tool returns a `runId` in under a second. A child process picks up the work, persists progress after every phase, and writes the terminal state when it finishes — or crashes. You poll the run state from disk whenever you want a status update, and resume it later if it fails partway through.
+
+This guide walks through the exact spawn mechanism, how to check on a background run, what happens to approval gates, and the limitations that come with running headless.
+
+## The basic pattern
+
+Ask the `taskflow` tool to run a flow with `detach: true`:
+
+```json
+{
+  "action": "run",
+  "name": "code-audit",
+  "args": { "target": "src/auth" },
+  "detach": true
+}
+```
+
+The tool returns immediately:
+
+```
+Taskflow 'code-audit' started in background (pid: 48231). Run id: 20260706T143022-a1b2c3
+```
+
+Your session is free. The flow is running in a detached child process. The PID is recorded on the run state so you can check if it is still alive.
+
+## How it works
+
+<Steps>
+  <Step>
+    **The host creates a `RunState` on disk.** The run starts with `status: "running"`, `detached: true`, and the flow definition + args are persisted. This is the same atomic-write path every run uses — the detached process will read it back.
+  </Step>
+  <Step>
+    **Context is serialized to a temp file.** A JSON file at `/tmp/taskflow-detach-<runId>.json` carries the `runId`, `defName`, `args`, `cwd`, and the absolute path of the host adapter's runner module (`runnerModule`). This file is the child's only input.
+  </Step>
+  <Step>
+    **A child process is spawned.** The host forks `node <detached-runner.js> <context-file>` with `detached: true` and `stdio: ["ignore", "ignore", "pipe"]`. Stdout is ignored; stderr is piped back to the parent so crash diagnostics are captured. The child is immediately `unref()`'d — it does not keep the parent's event loop alive.
+  </Step>
+  <Step>
+    **The parent returns the runId.** The child's PID is written to `RunState.pid` and the MCP tool response includes both the PID and the runId. The parent session can continue with other work.
+  </Step>
+  <Step>
+    **The child boots and runs the flow.** The detached runner reads the context file, re-discovers agents from disk, dynamically imports the host adapter's runner module, and calls `executeTaskflow`. Progress is persisted after every phase via the same `saveRun` path.
+  </Step>
+  <Step>
+    **Terminal state is written.** On success, the child persists `status: "completed"` with all phase outputs. On failure, a top-level `catch` writes `status: "failed"`. On crash, the parent's crash guard writes a synthetic `__detach__` phase with the stderr.
+  </Step>
+</Steps>
+
+## Checking on a background run
+
+The run state is a JSON file on disk — the same file the detached process updates after every phase. Read it back:
+
+```
+/tf runs
+```
+
+The runs panel shows the run's current status, phase progress, and timing. For background runs, the panel **polls the file on an interval** so you see live progress without reopening — `updatedAt` advances after each phase.
+
+You can also check whether the child process is still alive. `RunState.pid` stores the OS PID; `isProcessAlive(pid)` uses `process.kill(pid, 0)` (signal 0 — no signal sent, just a liveness check). If the process has exited but the run is still `"running"`, something went wrong — check the `__detach__` phase for the error.
+
+### Run statuses at a glance
+
+| Status | Meaning |
+|---|---|
+| `running` | The detached process is alive and executing phases. |
+| `completed` | Every phase finished. `finalOutput` is in the last phase's output. |
+| `failed` | A phase failed (and retries were exhausted), or the child crashed. |
+| `paused` | A `loop` phase hit its iteration cap and paused for review. |
+| `blocked` | A `gate` phase returned `VERDICT: BLOCK`. |
+
+## Crashes and the `__detach__` phase
+
+If the child process dies before writing a terminal state — an OOM kill, a segfault, a bad runner module import — the parent process's crash guard fires. It writes a **synthetic `__detach__` phase** onto the run:
+
+```json
+{
+  "id": "__detach__",
+  "status": "failed",
+  "error": "Detached runner exited with code 1: Failed to load runner module 'pi-taskflow/dist/runner.js'..."
+}
+```
+
+The crash guard only fires when the run is still `"running"` and the PID matches — it never clobbers a genuine terminal state the runner already persisted. This means:
+
+- **Clean exit (code 0):** The runner persisted its own state. The crash guard does nothing.
+- **Non-zero exit:** The crash guard checks the run state. If it is still `"running"`, it marks it `"failed"` with the captured stderr.
+- **Spawn error:** The `child.on("error")` handler writes the same synthetic phase with the spawn error message.
+
+The `__detach__` phase is pollable and debuggable — you see it in `/tf runs` and in the run detail view just like any other phase.
+
+## Approval gates auto-reject
+
+Approval phases are safety boundaries. In a normal interactive run, the host pops up a prompt and waits for you to approve, reject, or edit. In a detached run, there is no interactive approver — the `requestApproval` callback is not injected.
+
+When the runtime encounters an `approval` phase without an approver:
+
+```
+output: "(auto-rejected: no interactive approver available)"
+approval: { decision: "reject", auto: true }
+gate: { verdict: "block" }
+```
+
+The approval auto-rejects and the gate blocks. Downstream phases that depend on the approval's output see the rejection text. The run records the decision so you can audit it later.
+
+<Callout type="warn">
+  Approval gates are **never bypassed** in detached mode. Auto-reject is not auto-approve — the gate blocks, and downstream phases cascade-fail. If your flow has an approval gate and you need it to pass in CI, remove the gate or restructure the flow for headless execution.
+</Callout>
+
+## Use cases
+
+### CI pipelines
+
+A CI job can fire a taskflow, capture the `runId`, and poll the run state in a loop. No interactive session needed. The job exits based on the terminal status:
+
+```bash
+# Pseudocode for a CI step
+RUN_ID=$(taskflow run --name code-audit --detach --json | jq -r '.runId')
+
+while true; do
+  STATUS=$(taskflow status --run-id "$RUN_ID" --json | jq -r '.status')
+  case "$STATUS" in
+    completed) exit 0 ;;
+    failed|blocked) exit 1 ;;
+    running) sleep 10 ;;
+  esac
+done
+```
+
+Approval phases auto-reject in CI, which is correct — you want the pipeline to halt at approval gates, not silently rubber-stamp them.
+
+### Long-running flows
+
+A 20-phase migration planner that takes 30 minutes should not block your coding session. Detach it, keep working, and check back:
+
+```
+/tf runs          ← see progress
+```
+
+When it completes, the run history panel shows the final output. You can inspect individual phase outputs, usage stats, and timing — the same data as a foreground run.
+
+### Overnight batch work
+
+Queue several detached runs before you walk away. Each one runs independently, persists its own state, and is pollable by `runId` the next morning. The run cleanup policy (`maxKeptRuns`, `maxRunAgeDays`) prunes old runs automatically.
+
+### Fire-and-forget side tasks
+
+A background flow that generates documentation, runs a linter sweep, or produces a report — tasks you want done but do not need to watch — are natural detach candidates. The flow runs to completion (or fails visibly) without consuming your attention.
+
+## Context file format
+
+The temp file at `/tmp/taskflow-detach-<runId>.json` carries:
+
+```json
+{
+  "runId": "20260706T143022-a1b2c3",
+  "defName": "code-audit",
+  "args": { "target": "src/auth" },
+  "cwd": "/Users/you/project",
+  "runnerModule": "/Users/you/.pi/extensions/pi-taskflow/dist/runner.js",
+  "runnerExport": "piSubagentRunner"
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `runId` | The pre-allocated run identifier. The child loads its `RunState` by this id. |
+| `defName` | The flow name — used to resolve the saved definition from disk. |
+| `args` | Invocation arguments, already resolved against the flow's `args` schema. |
+| `cwd` | The working directory — where agents run and where `runsDir` is rooted. |
+| `runnerModule` | Absolute path of the host adapter's runner module. The child `import()`s this at runtime to get the `runTask` function. |
+| `runnerExport` | Named export on the runner module (defaults to `"piSubagentRunner"`). |
+
+The file is written once at spawn time and is not updated during the run. It can be safely deleted after the child exits.
+
+## The detached runner entry point
+
+`detached-runner.ts` is a **spawn-only entry** — it is not imported by the `taskflow-core` barrel (`index.ts`). It lives at `taskflow-core/detached-runner` and is resolved by the host adapter via `import.meta.resolve`. The runner is precompiled to `.js` in the published package, so no `--experimental-strip-types` flag is needed.
+
+The runner's startup sequence:
+
+1. Read and parse the context file from `process.argv[2]`.
+2. Load the pre-saved `RunState` by `runId`.
+3. Re-discover agents using `readSubagentSettings()` and `discoverAgents()`.
+4. Dynamically `import(runnerModule)` and extract the `runTask` function.
+5. **Fail fast** if the runner module was specified but could not be loaded — writes a synthetic `__detach__` phase and exits non-zero rather than limping on with the "no runner injected" stub.
+6. Call `executeTaskflow()` with a `persist` callback that saves state after every phase.
+7. On success, persist the terminal `RunState`. On crash, the top-level `catch` writes `status: "failed"`.
+
+## Limitations
+
+<Callout type="info">
+  Background runs trade interactivity for concurrency. These limitations are by design.
+</Callout>
+
+| Limitation | Why |
+|---|---|
+| **Approval gates auto-reject** | No interactive approver is available. Safety gates must not be silently bypassed. |
+| **No live TUI streaming** | The child's stdout is ignored (`stdio: "ignore"`). Progress is visible only via file polling. |
+| **No `AbortSignal` from host** | The parent cannot cancel the child mid-run. You can kill the PID manually. |
+| **`runnerModule` must be resolvable** | The child `import()`s the host adapter's runner at runtime. If the module path is wrong, every phase fails. The fail-fast guard catches this early. |
+| **Temp file must persist until child reads it** | The context file at `/tmp/taskflow-detach-<runId>.json` is read synchronously at startup. Deleting it before the child boots causes an immediate exit. |
+| **No `requestApproval` callback** | The host cannot inject an approval handler into a detached process. This is the mechanism behind auto-reject. |
+
+## Resume after failure
+
+A detached run that fails partway through is a normal failed run — it has a `runId`, persisted phase states, and all the data the resume mechanism needs. Resume it the same way:
+
+```json
+{
+  "action": "resume",
+  "runId": "20260706T143022-a1b2c3"
+}
+```
+
+Completed phases are skipped (their outputs are cached). Only the failed phase and its downstream dependents re-execute. Resume can itself be detached — set `detach: true` on the resume call to fire it in the background again.
+
+## Cross-run caching
+
+Detached runs participate in the same cross-run cache as foreground runs. If a phase's fingerprint (input hash + flow definition hash) matches a previously cached result, the detached runner skips it — no tokens spent. This means re-running a detached flow after fixing one phase's input only pays for the changed work.
+
+Set `incremental: true` on the tool call to opt every phase into cross-run caching by default:
+
+```json
+{
+  "action": "run",
+  "name": "code-audit",
+  "detach": true,
+  "incremental": true
+}
+```
+
+## Process lifecycle
+
+```
+Parent (host session)                    Child (detached runner)
+│                                        │
+├─ saveRun(state, detached:true)         │
+├─ write context JSON to /tmp            │
+├─ spawn(node, [runner, tmpFile])  ───►  ├─ readFileSync(contextPath)
+│                                        ├─ loadRun(runId)
+├─ child.on("exit", crashGuard)          ├─ import(runnerModule)
+├─ child.unref()                         ├─ executeTaskflow(...)
+├─ return { runId, pid }                 │   ├─ phase 1 → saveRun
+│                                        │   ├─ phase 2 → saveRun
+│   ... session continues ...            │   ├─ phase 3 → saveRun
+│                                        │   └─ persist terminal state
+│                                        └─ exit(0)
+│
+├─ (crash guard: exit code 0 → no-op)
+└─ user polls /tf runs → sees "completed"
+```
+
+If the child exits non-zero before writing a terminal state, the crash guard fires between the `exit` event and the next `saveRun` from the user's poll, marking the run as `"failed"` with the captured stderr.
+
+## Next
+
+<Cards>
+  <Card title="Resume & Caching" href="/en/docs/concepts/resume">
+    How within-run resume and cross-run caching skip work on re-execution.
+  </Card>
+  <Card title="Gate Phase" href="/en/docs/syntax/phase-types">
+    Quality gates and the verdict-parsing machinery that interacts with approval auto-reject.
+  </Card>
+  <Card title="Tournament Guide" href="/en/docs/guides/tournament">
+    Run competing variants and let a judge pick the best — also works in detached mode.
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/guides/agents-and-model-roles.mdx
+++ b/website/content/docs/zh-cn/guides/agents-and-model-roles.mdx
@@ -1,0 +1,487 @@
+---
+title: Agents 与 Model Roles
+description: taskflow 如何从三层发现 agents、将它们映射到六个 model roles，并为每个 phase 解析出正确的 agent。
+---
+
+taskflow 中的每个 phase 都作为 subagent 运行——一个独立的 LLM 进程，拥有自己的 context window、system prompt 和工具集。正是这种隔离让中间的 transcript 不进入你的对话：只有最终的 phase 输出会返回。
+
+但是哪个 agent 运行哪个 phase？这个 agent 又用哪个模型？taskflow 用一套分层发现系统和基于角色的模型映射来回答这两个问题。你可以直接使用 18 个内置 agent、用项目专用的版本覆盖它们，或者编写完全自定义的 agent——所有这些都不需要改动任何 flow 定义。
+
+本指南涵盖完整图景：agent 如何被发现、内置 agent 做什么、model role 如何工作，以及如何自定义这一切。
+
+## Agent 发现
+
+taskflow 从三层加载 agent，顺序如下：
+
+<Steps>
+  <Step>
+    **内置 agent。** taskflow 包内置了十八个 agent。它们覆盖完整的软件开发生命周期：规划、执行、审查、安全、测试和恢复。除非显式禁用，这些 agent 始终可用。
+  </Step>
+  <Step>
+    **用户 agent。** 位于 `~/.pi/agent/agents/`（或由 `TASKFLOW_AGENT_DIR` / `PI_CODING_AGENT_DIR` 设置的目录）。这些是你的个人 agent，在你所有项目间共享。
+  </Step>
+  <Step>
+    **项目 agent。** 位于项目根目录（或任意父目录）的 `.pi/agents/`。taskflow 从当前工作目录向上遍历目录树，找到最近的 `.pi/agents/` 文件夹。这些是项目专用的 agent，与你的代码库一起版本化。
+  </Step>
+</Steps>
+
+各层之间按名称相互覆盖。如果你有一个名为 `executor` 的项目 agent，同时内置 agent 也叫 `executor`，则项目版本胜出。这让你可以在不 fork 整个 agent 集合的情况下自定义行为。
+
+<Callout type="info">
+  Agent 名称使用连字符，而不是下划线：`executor-code` 是正确的，`executor_code` 是错误的。运行时会校验这一点，并在你使用下划线时发出警告。
+</Callout>
+
+### `agentScope` 字段
+
+并非每个 flow 都需要全部三层。taskflow 上的 `agentScope` 字段控制哪些层处于激活状态：
+
+| Scope | 加载内容 | 使用场景 |
+|---|---|---|
+| `"user"`（默认） | 内置 + 用户 agent | 不依赖项目专用 agent 的个人工作流。 |
+| `"project"` | 内置 + 项目 agent | 项目 agent 覆盖用户偏好的团队工作流。 |
+| `"both"` | 内置 + 用户 + 项目 agent | 完整解析：项目覆盖用户覆盖内置。 |
+
+在 taskflow 顶层设置 `agentScope`：
+
+```json title="project-scoped.json"
+{
+  "name": "project-review",
+  "agentScope": "project",
+  "phases": [...]
+}
+```
+
+<Callout type="tip">
+  如果你要构建一个会在队友机器上运行的 flow，请使用 `agentScope: "project"`，这样它就不会依赖对方个人的 `~/.pi/agent/agents/` 目录。
+</Callout>
+
+## 18 个内置 agent
+
+taskflow 内置了 18 个 agent，按四类组织。每个 agent 都是一个带 YAML frontmatter 的 markdown 文件，指定其名称、描述、工具、model role 和 thinking 级别。
+
+### 规划与分析
+
+这些 agent 在代码编写之前分析需求、创建计划并挑战假设。
+
+| Agent | Role | Thinking | 用途 |
+|---|---|---|---|
+| `analyst` | `{{thinker}}` | high | 分析需求，暴露歧义，识别隐藏约束。只读。 |
+| `critic` | `{{thinker}}` | xhigh | 挑战计划和结论，在承诺之前发现矛盾。只读。 |
+| `planner` | `{{strong}}` | high | 创建带文件级细节的具体实现计划。只读。 |
+| `plan-arbiter` | `{{arbiter}}` | high | 在执行开始之前审查并挑战计划。只读。 |
+
+`analyst` 在复杂流水线中率先运行以澄清需求。`planner` 把这些需求转化为可执行的计划。`critic` 和 `plan-arbiter` 充当质量门控——它们在昂贵的执行开始之前对薄弱的计划推回。
+
+### 执行
+
+这些 agent 编写代码。它们在范围和复杂度上有所不同。
+
+| Agent | Role | Thinking | 用途 |
+|---|---|---|---|
+| `executor` | `{{fast}}` | high | 默认 executor，用于有清晰计划的 1–4 文件改动。 |
+| `executor-fast` | `{{fast}}` | off | 琐碎改动：≤2 文件、≤50 行、不涉及架构决策。 |
+| `executor-code` | `{{strong}}` | high | 复杂的多文件改动：≥5 文件、跨模块、结构性重构。 |
+| `executor-ui` | `{{vision}}` | high | UI/前端改动：组件、样式、布局、响应式设计。 |
+
+默认的 `executor` 处理大部分工作。机械清理用 `executor-fast`，结构性重构用 `executor-code`，当你需要视觉能力来理解设计意图时用 `executor-ui`。
+
+### 审查与质量
+
+这些 agent 审查代码、评估风险并验证结果。它们都不编辑文件。
+
+| Agent | Role | Thinking | 用途 |
+|---|---|---|---|
+| `reviewer` | `{{strong}}` | high | 通用代码审查：质量、架构、测试覆盖。 |
+| `risk-reviewer` | `{{reasoner}}` | high | 后端/基础设施风险：数据完整性、并发、迁移。 |
+| `security-reviewer` | `{{reasoner}}` | high | 安全漏洞：认证、注入、密钥、信任边界。 |
+| `final-arbiter` | `{{arbiter}}` | xhigh | 在多个审查者意见冲突时裁决。决胜者。 |
+
+`reviewer` 处理通用质量。`risk-reviewer` 和 `security-reviewer` 专注于高风险领域，并在领域边界处互相推让。`final-arbiter` 在审查冲突时打破平局。
+
+### 支持
+
+这些 agent 处理辅助任务：测试、文档、探索和恢复。
+
+| Agent | Role | Thinking | 用途 |
+|---|---|---|---|
+| `test-engineer` | `{{fast}}` | high | 设计和实现测试策略，检测不稳定模式。 |
+| `verifier` | `{{fast}}` | off | 运行校验命令，复现失败，检查日志。只读。 |
+| `scout` | `{{fast}}` | off | 快速代码库探索，为其他 agent 返回结构化发现。 |
+| `doc-writer` | `{{fast}}` | off | 编写和编辑文档文件（README、指南、changelog）。 |
+| `visual-explorer` | `{{vision}}` | high | 分析 Figma 设计，提取颜色、token 和组件规格。 |
+| `recover` | `{{fast}}` | low | 在 context compaction 之后恢复工作，从交接文件接续。 |
+
+`scout` 做快速侦察，让其他 agent 不必重新读取所有内容。`test-engineer` 和 `verifier` 处理验证。`visual-explorer` 解析设计文件。`recover` agent 在 context window 重置之后接续工作。
+
+## Model roles
+
+每个内置 agent 在其 frontmatter 中指定一个 model role——不是具体的模型 ID，而是用双花括号包裹的角色名：`{{fast}}`、`{{strong}}`、`{{thinker}}`、`{{arbiter}}`、`{{vision}}` 或 `{{reasoner}}`。
+
+这种间接存在是因为不同用户可用的模型不同。一个 role 是一个语义契约（"这个 agent 需要快速、廉价的推理"），它会在运行时根据你的配置解析为具体的模型 ID。
+
+### 六个 roles
+
+| Role | 语义契约 | 默认模型 | 使用者 |
+|---|---|---|---|
+| `{{fast}}` | 便宜且快速，高吞吐低风险 | `openrouter/deepseek/deepseek-v4-flash` | `executor`、`executor-fast`、`scout`、`verifier`、`doc-writer`、`test-engineer`、`recover` |
+| `{{strong}}` | 均衡能力，中等复杂度 | `openrouter/xiaomi/mimo-v2.5-pro` | `planner`、`reviewer`、`executor-code` |
+| `{{thinker}}` | 深度推理，高 thinking 预算 | `openrouter/deepseek/deepseek-v4-pro` | `analyst`、`critic` |
+| `{{arbiter}}` | 高风险判断，决胜 | `openrouter/qwen/qwen3.7-max` | `plan-arbiter`、`final-arbiter` |
+| `{{vision}}` | 多模态，图像理解 | `minimax/MiniMax-M3` | `executor-ui`、`visual-explorer` |
+| `{{reasoner}}` | 谨慎推理，安全敏感 | `z-ai/glm-5.1` | `risk-reviewer`、`security-reviewer` |
+
+默认值开箱即用效果良好。但你可能想替换它们——例如，如果你有 Claude Pro 订阅，想把 `{{strong}}` 换成 `anthropic/claude-3.5-sonnet`。
+
+### Roles 如何解析
+
+当一个 phase 生成一个 subagent 时，运行时会检查 agent 的 `model` 字段。如果它匹配 `{{roleName}}` 模式，运行时会查找该 role 的设置并替换为具体的模型 ID。如果不存在映射，则 model 字段留空，并使用宿主的默认模型。
+
+```text
+Agent frontmatter:  model: "{{strong}}"
+                       ↓
+settings.json:      modelRoles: { "strong": "anthropic/claude-3.5-sonnet" }
+                       ↓
+Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
+```
+
+带有字面模型 ID（无花括号）的 agent 完全绕过 role 解析。这对于必须始终使用特定模型的自定义 agent 很有用。
+
+## 使用 `/tf init` 配置
+
+`/tf init` 命令会交互式地引导你完成 role 配置。它读取你当前的设置，从你的 provider registry 显示可用模型，并以原子方式写回你的选择。
+
+<Callout type="tip">
+  首次安装 taskflow 时运行 `/tf init`。推荐的默认值对大多数用户效果良好，但你可能想把 `vision` role 换成另一个多模态模型，或把 `arbiter` role 换成更强的推理模型。
+</Callout>
+
+### 操作菜单
+
+当你运行 `/tf init` 时，会看到一个操作菜单：
+
+1. **使用推荐默认值** —— 应用上表中的默认模型。
+2. **逐个配置 role** —— 依次遍历全部六个 role。
+3. **编辑单个 role** —— 只改一个 role，不动其他。
+4. **配置 taskflow 偏好** —— 调整内置 agent 设置。
+5. **显示当前 roles** —— 不做改动地显示当前配置。
+
+对于每个 role，选择器会从你的 registry 显示可用模型，并带有能力标签（多模态 `image ✓`、推理能力 `reasoning ✓`），以及你当前选择和推荐默认值的标记。
+
+### 自定义模型标识符
+
+你也可以在 `provider/model-id` 格式中输入自定义模型标识符。运行时会根据你的模型 registry 校验它，并在模型不存在时发出警告——一个拼写错误会静默破坏使用该 role 的每个 flow。确认提示可防止拼写错误。
+
+### 设置存储位置
+
+所有配置都保存到 `~/.pi/agent/settings.json`（或由 `TASKFLOW_AGENT_DIR` / `PI_CODING_AGENT_DIR` 设置的路径）：
+
+```json title="settings.json"
+{
+  "modelRoles": {
+    "fast": "openrouter/deepseek/deepseek-v4-flash",
+    "strong": "openrouter/xiaomi/mimo-v2.5-pro",
+    "thinker": "openrouter/deepseek/deepseek-v4-pro",
+    "arbiter": "openrouter/qwen/qwen3.7-max",
+    "vision": "minimax/MiniMax-M3",
+    "reasoner": "z-ai/glm-5.1"
+  },
+  "taskflow": {
+    "builtInAgents": true,
+    "syncBuiltinAgentsToProject": false,
+    "maxKeptRuns": 100,
+    "maxRunAgeDays": 30
+  }
+}
+```
+
+### Taskflow 偏好
+
+`/tf init` 中的"配置 taskflow 偏好"选项调整四个设置：
+
+| 设置 | 默认值 | 说明 |
+|---|---|---|
+| `builtInAgents` | `true` | 启用或禁用 18 个内置 agent。如果你只想要自己的 agent，请禁用。 |
+| `syncBuiltinAgentsToProject` | `false` | 在会话开始时把内置 agent 复制到项目的 `.pi/agents/`，以便原生 Pi `@agent` 语法也能发现它们。 |
+| `maxKeptRuns` | `100` | 保留的已完成/失败运行的最大数量。设为 `0` 禁用按数量清理。 |
+| `maxRunAgeDays` | `30` | 已完成/失败运行的最大保留天数。设为 `0` 禁用按时间清理。 |
+
+<Callout type="info">
+  清理自动运行，节流为每分钟一次。它只移除终态（已完成或失败）的运行——活跃的运行永远不会被触碰。
+</Callout>
+
+## 自定义 agent
+
+你可以通过编写带 YAML frontmatter 的 markdown 文件来创建自定义 agent。自定义 agent 位于用户范围（`~/.pi/agent/agents/`）或项目范围（`.pi/agents/`）。
+
+### Agent 文件格式
+
+每个 agent 文件有三部分：`---` 分隔符之间的 YAML frontmatter、一个空行，以及 system prompt 正文。
+
+```markdown title="~/.pi/agent/agents/code-reviewer.md"
+---
+name: code-reviewer
+description: Review code for quality and best practices
+tools: read, grep, find, ls, bash
+model: "{{strong}}"
+thinking: high
+---
+
+You are a code reviewer focused on quality and best practices.
+
+Review the provided code for:
+- Code style and consistency
+- Performance implications
+- Error handling
+- Test coverage
+
+Be specific and actionable. Don't just say "this could be better" — explain why and how.
+```
+
+### Frontmatter 字段
+
+| 字段 | 必需 | 说明 |
+|---|---|---|
+| `name` | 是 | 唯一标识符，用于在 flow 中引用该 agent。使用连字符。 |
+| `description` | 是 | 简短描述，显示在 agent 列表和选择器 UI 中。 |
+| `tools` | 否 | 逗号分隔的工具列表：`read`、`write`、`edit`、`bash`、`grep`、`find`、`ls`。省略时默认为全部工具。 |
+| `model` | 否 | 模型 ID 或 role 引用（如 `openai/gpt-4o` 或 `"{{strong}}"`）。回退到宿主默认模型。 |
+| `thinking` | 否 | Thinking 级别：`off`、`low`、`high`、`xhigh`。回退到 `globalThinking` 设置。 |
+
+<Callout type="info">
+  格式错误的 agent 文件永远不会破坏发现过程。运行时会捕获解析错误并跳过坏文件（附带警告），因此其余 agent 仍正常加载。
+</Callout>
+
+### 覆盖内置 agent
+
+要覆盖内置 agent，请在用户或项目 agent 目录中创建同名自定义 agent。层级顺序决定哪个版本胜出：
+
+```markdown title=".pi/agents/executor.md"
+---
+name: executor
+description: Custom executor with project-specific conventions
+tools: read, grep, find, ls, bash, edit, write
+model: "{{strong}}"
+thinking: high
+---
+
+You are the executor agent for the Acme Corp codebase.
+
+Always follow these project-specific rules:
+- Use TypeScript strict mode
+- Prefer functional patterns over classes
+- Write tests for all public functions
+- Run `pnpm typecheck` before committing
+```
+
+这个项目级 `executor` 会替换内置 `executor`，对在此项目中运行的任何 flow 生效。`~/.pi/agent/agents/executor.md` 中的用户级覆盖则会在你所有项目中生效。
+
+<Callout type="warn">
+  覆盖按精确名称匹配。`my-executor` 不会覆盖 `executor`。如果你想要一个变体，请给它起不同的名字，并在你的 flow 中显式引用。
+</Callout>
+
+## Flow 中的 agent 解析
+
+当一个 phase 运行时，运行时通过一个特定过程解析其 agent：
+
+<Steps>
+  <Step>
+    **检查 phase 的 `agent` 字段。** 如果 phase 指定了 agent 名称，在发现结果中查找它。
+  </Step>
+  <Step>
+    **对未知 agent 发出警告。** 如果指定的 agent 在发现结果中不存在，记录一条警告（每个未知 agent 每次运行一次），并回退到默认 agent。
+  </Step>
+  <Step>
+    **回退到默认 agent。** 默认值是发现结果中的第一个 agent——通常是按字母序的第一个内置 agent，除非用户或项目 agent 覆盖了它。如果根本没有任何 agent，则使用名称 `"default"`。
+  </Step>
+</Steps>
+
+### 在 phase 中指定 agent
+
+大多数 phase 显式指定 agent：
+
+```json title="phase-with-agent.json"
+{
+  "id": "review",
+  "type": "agent",
+  "agent": "reviewer",
+  "task": "Review the code changes for quality issues."
+}
+```
+
+你也可以省略 `agent` 字段。该 phase 会使用默认 agent：
+
+```json title="phase-without-agent.json"
+{
+  "id": "review",
+  "type": "agent",
+  "task": "Review the code changes for quality issues."
+}
+```
+
+<Callout type="info">
+  默认 agent 取决于你的 `agentScope` 以及每层中存在哪些 agent。为了在不同环境下行为可预测，请显式指定 agent。
+</Callout>
+
+### Phase 级别覆盖
+
+Phase 可以覆盖 agent 的 model、thinking 级别和工具访问，而无需修改 agent 文件：
+
+```json title="phase-with-overrides.json"
+{
+  "id": "deep-review",
+  "type": "agent",
+  "agent": "reviewer",
+  "model": "anthropic/claude-3.5-sonnet",
+  "thinking": "xhigh",
+  "tools": ["read", "grep"],
+  "task": "Deep review of the authentication module."
+}
+```
+
+这些覆盖只对该次 phase 调用生效。未覆盖的 phase 仍使用 agent frontmatter 的设置。
+
+| 覆盖 | 效果 |
+|---|---|
+| `model` | 替换该 phase 的 agent 模型。接受 role（`"{{strong}}"`）或字面模型 ID。 |
+| `thinking` | 覆盖 thinking 级别：`off`、`low`、`high`、`xhigh`。 |
+| `tools` | 限制工具集。对不应修改文件的只读 phase 很有用。 |
+
+### 分支与子 phase
+
+带多个分支的 phase 类型（`parallel`、`tournament`）允许每个分支指定自己的 agent：
+
+```json title="parallel-with-per-branch-agents.json"
+{
+  "id": "review-all",
+  "type": "parallel",
+  "branches": [
+    {
+      "agent": "security-reviewer",
+      "task": "Review for security vulnerabilities."
+    },
+    {
+      "agent": "risk-reviewer",
+      "task": "Review for data integrity risks."
+    },
+    {
+      "agent": "reviewer",
+      "task": "Review for general code quality."
+    }
+  ]
+}
+```
+
+未指定 agent 的分支继承父 phase 的 agent。Tournament phase 还支持 `judgeAgent` 字段用于 judge 步骤，默认为 phase 的主 agent。
+
+### 子 flow 中的继承
+
+当一个 `flow` phase 生成一个内联子 flow 时，未指定自己 agent 的内部 phase 会继承父 phase 的 `defaultAgent`（或 `agent` 字段）。这意味着父层级的单次 agent 赋值会级联到每个未覆盖的子 phase。
+
+## 实用示例
+
+### 多阶段审查流水线
+
+不同的 agent 处理不同的审查关注点，最后的 arbiter 综合结果：
+
+```json title="multi-stage-review.json"
+{
+  "name": "review-pipeline",
+  "phases": [
+    {
+      "id": "plan",
+      "type": "agent",
+      "agent": "planner",
+      "task": "Analyze the code changes and create a review plan."
+    },
+    {
+      "id": "security-review",
+      "type": "agent",
+      "agent": "security-reviewer",
+      "dependsOn": ["plan"],
+      "task": "Review for security issues based on this plan: {steps.plan.output}"
+    },
+    {
+      "id": "quality-review",
+      "type": "agent",
+      "agent": "reviewer",
+      "dependsOn": ["plan"],
+      "task": "Review for code quality: {steps.plan.output}"
+    },
+    {
+      "id": "synthesis",
+      "type": "agent",
+      "agent": "final-arbiter",
+      "dependsOn": ["security-review", "quality-review"],
+      "task": "Synthesize these reviews and resolve any conflicts:\n\nSecurity: {steps.security-review.output}\n\nQuality: {steps.quality-review.output}",
+      "final": true
+    }
+  ]
+}
+```
+
+### 自定义领域 agent
+
+为你的领域创建一个专用 agent，然后在 flow 中引用它：
+
+```markdown title=".pi/agents/api-designer.md"
+---
+name: api-designer
+description: Design RESTful APIs following OpenAPI 3.0 spec
+tools: read, grep, find, ls, write
+model: "{{strong}}"
+thinking: high
+---
+
+You are an API designer specializing in RESTful APIs.
+
+Follow these principles:
+- Use nouns for resource names, verbs for actions
+- Return appropriate HTTP status codes
+- Include pagination for list endpoints
+- Version APIs in the URL path (e.g., /v1/users)
+- Write OpenAPI 3.0 specs in YAML format
+```
+
+```json title="api-design-flow.json"
+{
+  "id": "design-api",
+  "type": "agent",
+  "agent": "api-designer",
+  "output": "text",
+  "task": "Design a REST API for a task management system with projects, tasks, and users."
+}
+```
+
+### 项目范围的团队工作流
+
+使用 `agentScope: "project"`，让每个团队成员获得相同的 agent 行为：
+
+```json title="team-review.json"
+{
+  "name": "team-review",
+  "agentScope": "project",
+  "phases": [
+    {
+      "id": "review",
+      "type": "agent",
+      "agent": "team-reviewer",
+      "task": "Review the code using team standards documented in .pi/agents/team-reviewer.md."
+    }
+  ]
+}
+```
+
+配合 `.pi/agents/team-reviewer.md` 中编码了你们团队特定审查标准的项目 agent。这个 flow 对团队中的每个人运行方式相同，不受他们个人 agent 目录的影响。
+
+## 下一步
+
+<Cards>
+  <Card title="阶段类型" href="/zh-cn/docs/syntax/phase-types">
+    了解全部 10 种 phase 类型以及何时使用每一种。
+  </Card>
+  <Card title="Tournament 选择" href="/zh-cn/docs/guides/tournament">
+    生成竞争变体并让 judge 挑选最佳结果。
+  </Card>
+  <Card title="动态规划" href="/zh-cn/docs/guides/dynamic-planning">
+    在运行时生成子 flow 并在执行前校验它们。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/guides/background-runs.mdx
+++ b/website/content/docs/zh-cn/guides/background-runs.mdx
@@ -1,0 +1,862 @@
+---
+title: 后台运行
+description: 启动长时间运行的流程并立即返回提示符。通过 runId 轮询状态。
+---
+
+普通的 `taskflow` 调用会阻塞你的会话，直到所有阶段完成。一个三阶段的代码审计如果耗时八分钟，你的提示符就冻结八分钟。
+
+后台运行解决了这个问题。设置 `detach: true`，MCP 工具在一秒内返回一个 `runId`。一个子进程接管工作，在每个阶段完成后持久化进度，并在结束时写入最终状态——或者在崩溃时写入失败状态。你可以随时从磁盘轮询运行状态来获取进度更新，也可以在中途失败后恢复它。
+
+本指南详细说明具体的 spawn 机制、如何检查后台运行的状态、审批（approval）阶段会发生什么，以及无头运行的限制。
+
+## 基本模式
+
+在调用 `taskflow` 工具时设置 `detach: true`：
+
+```json
+{
+  "action": "run",
+  "name": "code-audit",
+  "args": { "target": "src/auth" },
+  "detach": true
+}
+```
+
+工具立即返回：
+
+```
+Taskflow 'code-audit' started in background (pid: 48231). Run id: 20260706T143022-a1b2c3
+```
+
+你的会话已释放。流程在一个分离的子进程中运行。PID 记录在运行状态上，你可以检查它是否仍然存活。
+
+## 工作原理
+
+<Steps>
+  <Step>
+    **宿主在磁盘上创建 `RunState`。** 运行以 `status: "running"`、`detached: true` 开始，流程定义和参数被持久化。这与所有运行使用的原子写入路径相同——分离进程会把它读回来。
+  </Step>
+  <Step>
+    **上下文序列化到临时文件。** `/tmp/taskflow-detach-<runId>.json` 的 JSON 文件携带 `runId`、`defName`、`args`、`cwd` 以及宿主适配器运行模块的绝对路径（`runnerModule`）。这个文件是子进程的唯一输入。
+  </Step>
+  <Step>
+    **生成子进程。** 宿主 fork `node <detached-runner.js> <context-file>`，使用 `detached: true` 和 `stdio: ["ignore", "ignore", "pipe"]`。stdout 被忽略；stderr 被管道回父进程以捕获崩溃诊断信息。子进程立即 `unref()`——它不会保持父进程的事件循环存活。
+  </Step>
+  <Step>
+    **父进程返回 runId。** 子进程的 PID 写入 `RunState.pid`，MCP 工具响应同时包含 PID 和 runId。父会话可以继续其他工作。
+  </Step>
+  <Step>
+    **子进程启动并运行流程。** 分离运行器读取上下文文件，从磁盘重新发现 agent 配置，动态导入宿主适配器的运行模块，然后调用 `executeTaskflow`。每个阶段完成后通过同一个 `saveRun` 路径持久化进度。
+  </Step>
+  <Step>
+    **写入终态。** 成功时，子进程持久化 `status: "completed"` 和所有阶段输出。失败时，顶层 `catch` 写入 `status: "failed"`。崩溃时，父进程的崩溃保护写入合成的 `__detach__` 阶段和 stderr 信息。
+  </Step>
+</Steps>
+
+## 检查后台运行状态
+
+运行状态是磁盘上的 JSON 文件——与分离进程在每个阶段完成后更新的文件相同。读回来：
+
+```
+/tf runs
+```
+
+运行面板显示运行的当前状态、阶段进度和时间。对于后台运行，面板**定时轮询文件**，你无需重新打开即可看到实时进度——`updatedAt` 在每个阶段完成后推进。
+
+你也可以检查子进程是否仍然存活。`RunState.pid` 存储操作系统 PID；`isProcessAlive(pid)` 使用 `process.kill(pid, 0)`（信号 0——不发送信号，仅做存活检查）。如果进程已退出但运行仍为 `"running"`，说明出了问题——检查 `__detach__` 阶段获取错误信息。
+
+### 运行状态一览
+
+| 状态 | 含义 |
+|---|---|
+| `running` | 分离进程存活并正在执行阶段。 |
+| `completed` | 所有阶段完成。`finalOutput` 在最后一个阶段的输出中。 |
+| `failed` | 某个阶段失败（重试已耗尽），或子进程崩溃。 |
+| `paused` | `loop` 阶段达到迭代上限并暂停以供审查。 |
+| `blocked` | `gate` 阶段返回 `VERDICT: BLOCK`。 |
+
+## 崩溃与 `__detach__` 阶段
+
+如果子进程在写入终态之前死亡——OOM kill、段错误、运行模块导入失败——父进程的崩溃保护会触发。它在运行上写入一个**合成的 `__detach__` 阶段**：
+
+```json
+{
+  "id": "__detach__",
+  "status": "failed",
+  "error": "Detached runner exited with code 1: Failed to load runner module 'pi-taskflow/dist/runner.js'..."
+}
+```
+
+崩溃保护仅在运行仍为 `"running"` 且 PID 匹配时触发——它永远不会覆盖运行器已持久化的真正终态。这意味着：
+
+- **正常退出（code 0）：** 运行器已持久化自己的状态。崩溃保护不执行操作。
+- **非零退出：** 崩溃保护检查运行状态。如果仍为 `"running"`，则标记为 `"failed"` 并附上捕获的 stderr。
+- **Spawn 错误：** `child.on("error")` 处理器用 spawn 错误信息写入相同的合成阶段。
+
+`__detach__` 阶段可轮询、可调试——你可以在 `/tf runs` 和运行详情视图中看到它，就像任何其他阶段一样。
+
+## 审批阶段自动拒绝
+
+审批阶段是安全边界。在正常的交互式运行中，宿主弹出提示并等待你批准、拒绝或编辑。在分离运行中，没有交互式审批者——`requestApproval` 回调未被注入。
+
+当运行时遇到没有审批者的 `approval` 阶段时：
+
+```
+output: "(auto-rejected: no interactive approver available)"
+approval: { decision: "reject", auto: true }
+gate: { verdict: "block" }
+```
+
+审批自动拒绝，门控阻塞。依赖审批输出的下游阶段会看到拒绝文本。运行记录该决策，你以后可以审计它。
+
+<Callout type="warn">
+  审批门控在分离模式下**永远不会被绕过**。自动拒绝不是自动批准——门控阻塞，下游阶段级联失败。如果你的流程有审批门控且需要在 CI 中通过，请移除该门控或重构流程以支持无头执行。
+</Callout>
+
+## 使用场景
+
+### CI 流水线
+
+CI 任务可以触发 taskflow、捕获 `runId`，并在循环中轮询运行状态。无需交互式会话。任务根据终态退出：
+
+```bash
+# CI 步骤的伪代码
+RUN_ID=$(taskflow run --name code-audit --detach --json | jq -r '.runId')
+
+while true; do
+  STATUS=$(taskflow status --run-id "$RUN_ID" --json | jq -r '.status')
+  case "$STATUS" in
+    completed) exit 0 ;;
+    failed|blocked) exit 1 ;;
+    running) sleep 10 ;;
+  esac
+done
+```
+
+审批阶段在 CI 中自动拒绝，这是正确的行为——你希望流水线在审批门控处暂停，而不是静默地盖章通过。
+
+### 长时间运行的流程
+
+一个耗时 30 分钟的 20 阶段迁移规划器不应该阻塞你的编码会话。分离它，继续工作，然后回来看：
+
+```
+/tf runs          ← 查看进度
+```
+
+完成后，运行历史面板显示最终输出。你可以检查各个阶段的输出、使用统计和时间——与前台运行相同的数据。
+
+### 过夜批处理
+
+在离开前排队几个分离运行。每个运行独立执行，持久化自己的状态，第二天早上可以通过 `runId` 轮询。运行清理策略（`maxKeptRuns`、`maxRunAgeDays`）自动修剪旧运行。
+
+### 即发即忘的辅助任务
+
+生成文档、运行 linter 扫描或生成报告的后台流程——你想完成但不需要监视的任务——是天然的分离候选。流程运行到完成（或可见地失败），不消耗你的注意力。
+
+## 上下文文件格式
+
+`/tmp/taskflow-detach-<runId>.json` 的临时文件携带：
+
+```json
+{
+  "runId": "20260706T143022-a1b2c3",
+  "defName": "code-audit",
+  "args": { "target": "src/auth" },
+  "cwd": "/Users/you/project",
+  "runnerModule": "/Users/you/.pi/extensions/pi-taskflow/dist/runner.js",
+  "runnerExport": "piSubagentRunner"
+}
+```
+
+| 字段 | 用途 |
+|---|---|
+| `runId` | 预分配的运行标识符。子进程通过此 id 加载其 `RunState`。 |
+| `defName` | 流程名称——用于从磁盘解析已保存的定义。 |
+| `args` | 调用参数，已根据流程的 `args` 模式解析。 |
+| `cwd` | 工作目录——agent 运行的位置以及 `runsDir` 的根目录。 |
+| `runnerModule` | 宿主适配器运行模块的绝对路径。子进程在运行时 `import()` 此模块以获取 `runTask` 函数。 |
+| `runnerExport` | 运行模块上的命名导出（默认为 `"piSubagentRunner"`）。 |
+
+文件在 spawn 时写入一次，运行期间不更新。子进程退出后可安全删除。
+
+## 分离运行器入口点
+
+`detached-runner.ts` 是一个**仅 spawn 的入口**——它不被 `taskflow-core` 的 barrel（`index.ts`）导入。它位于 `taskflow-core/detached-runner`，由宿主适配器通过 `import.meta.resolve` 解析。运行器在发布的包中已预编译为 `.js`，因此不需要 `--experimental-strip-types` 标志。
+
+运行器的启动序列：
+
+1. 从 `process.argv[2]` 读取并解析上下文文件。
+2. 通过 `runId` 加载预保存的 `RunState`。
+3. 使用 `readSubagentSettings()` 和 `discoverAgents()` 重新发现 agent 配置。
+4. 动态 `import(runnerModule)` 并提取 `runTask` 函数。
+5. **快速失败**——如果指定了运行模块但无法加载，写入合成的 `__detach__` 阶段并以非零退出码退出，而不是带着"未注入运行器"的存根继续跛行。
+6. 调用 `executeTaskflow()`，带有在每个阶段完成后保存状态的 `persist` 回调。
+7. 成功时持久化终态 `RunState`。崩溃时，顶层 `catch` 写入 `status: "failed"`。
+
+## 限制
+
+<Callout type="info">
+  后台运行以交互性换取并发性。这些限制是有意为之。
+</Callout>
+
+| 限制 | 原因 |
+|---|---|
+| **审批门控自动拒绝** | 没有交互式审批者可用。安全门控不得被静默绕过。 |
+| **无实时 TUI 流式传输** | 子进程的 stdout 被忽略（`stdio: "ignore"`）。进度仅通过文件轮询可见。 |
+| **宿主无法发送 `AbortSignal`** | 父进程无法在运行中途取消子进程。你可以手动 kill PID。 |
+| **`runnerModule` 必须可解析** | 子进程在运行时 `import()` 宿主适配器的运行器。如果模块路径错误，每个阶段都会失败。快速失败保护会提前捕获此问题。 |
+| **临时文件必须在子进程读取前保持存在** | `/tmp/taskflow-detach-<runId>.json` 的上下文文件在启动时同步读取。在子进程启动前删除它会导致立即退出。 |
+| **无 `requestApproval` 回调** | 宿主无法将审批处理器注入分离进程。这是自动拒绝背后的机制。 |
+
+## 失败后恢复
+
+中途失败的分离运行是一个普通的失败运行——它有 `runId`、持久化的阶段状态，以及恢复机制所需的所有数据。以相同的方式恢复它：
+
+```json
+{
+  "action": "resume",
+  "runId": "20260706T143022-a1b2c3"
+}
+```
+
+已完成的阶段被跳过（它们的输出已缓存）。只有失败的阶段及其下游依赖项重新执行。恢复本身也可以是分离的——在恢复调用上设置 `detach: true` 再次在后台触发它。
+
+## 跨运行缓存
+
+分离运行与前台运行共享同一个跨运行缓存。如果阶段的指纹（输入哈希 + 流程定义哈希）匹配之前缓存的结果，分离运行器会跳过它——不消耗 token。这意味着在修复一个阶段的输入后重新运行分离流程，只需为变更的工作付费。
+
+在工具调用上设置 `incremental: true` 以默认让每个阶段选择跨运行缓存：
+
+```json
+{
+  "action": "run",
+  "name": "code-audit",
+  "detach": true,
+  "incremental": true
+}
+```
+
+## 进程生命周期
+
+```
+父进程（宿主会话）                        子进程（分离运行器）
+│                                        │
+├─ saveRun(state, detached:true)         │
+├─ 写上下文 JSON 到 /tmp                  │
+├─ spawn(node, [runner, tmpFile])  ───►  ├─ readFileSync(contextPath)
+│                                        ├─ loadRun(runId)
+├─ child.on("exit", crashGuard)          ├─ import(runnerModule)
+├─ child.unref()                         ├─ executeTaskflow(...)
+├─ 返回 { runId, pid }                   │   ├─ 阶段 1 → saveRun
+│                                        │   ├─ 阶段 2 → saveRun
+│   ... 会话继续 ...                      │   ├─ 阶段 3 → saveRun
+│                                        │   └─ 持久化终态
+│                                        └─ exit(0)
+│
+├─（崩溃保护：退出码 0 → 无操作）
+└─ 用户轮询 /tf runs → 看到 "completed"
+```
+
+如果子进程在写入终态之前以非零退出码退出，崩溃保护在 `exit` 事件和用户下一次轮询的 `saveRun` 之间触发，将运行标记为 `"failed"` 并附上捕获的 stderr。
+
+## 下一步
+
+<Cards>
+  <Card title="恢复与缓存" href="/zh-cn/docs/concepts/resume">
+    运行内恢复和跨运行缓存如何在重新执行时跳过工作。
+  </Card>
+  <Card title="Gate 阶段" href="/zh-cn/docs/syntax/phase-types">
+    质量门控和与审批自动拒绝交互的裁决解析机制。
+  </Card>
+  <Card title="锦标赛指南" href="/zh-cn/docs/guides/tournament">
+    运行竞争变体并让裁判选出最佳结果——也适用于分离模式。
+  </Card>
+</Cards>
+```
+
+---
+
+## `meta.json` update
+
+For both `en` and `zh-cn`, insert `guides/background-runs` in the `pages` array. The relevant section becomes:
+
+```json
+"guides/tournament",
+"guides/background-runs",
+"guides/code-audit-case-study",
+"guides/headline-tournament-case-study",
+"guides/migration-planner-case-study",
+```
+
+This places it after the tournament guide (the last "feature deep-dive" guide) and before the case studies, which is the natural reading order: users learn the feature mechanics first, then see real-world examples.
+
+---
+
+### [4/5] risk-reviewer
+
+Based on my analysis of the source files (stale.ts, flowir/index.ts, flowir/translate.ts, flowir/hash.ts, flowir/meta.ts, flowir/phasefp.ts, runtime.ts recompute section, and context-store.ts), I'll now write the two complete reference pages.
+
+---
+
+## Risk Review
+
+I'm acting as a risk-reviewer for documentation changes. Since this is a documentation task (not backend logic/DB/API contracts), this falls outside my primary domain. However, I can assess **technical accuracy** of the documentation against the source code.
+
+### Evidence Verification
+
+**Critical facts extracted from source:**
+
+1. **FlowIR Compilation (M1)** - `compileTaskflowToIR(def)` in `flowir/index.ts:48` returns `TaskflowIR` with `hash`, `meta.declaredDeps`, `usedFallbackHash` (always true in stub).
+
+2. **Hash Algorithm** - `flowDefHash` in `flowir/hash.ts:64` = `hashCanonical(canonicalJson(def))` = SHA-256 truncated to 16 bytes hex. Vendored from overstory for byte-identical contract.
+
+3. **Per-Phase Fingerprinting (M6)** - `phaseFingerprint` in `flowir/phasefp.ts:68` returns `undefined` when soundness breaks (shareContext, flow phases, join:"any"), caller falls back to whole-flow hash. Strips policy fields (cache, retry, concurrency, final).
+
+4. **Observed Read-Sets (M3)** - `PhaseState.reads` in `store.ts:105` = `Array<{stepId, version}>`. Captured at runtime via `onRead` callback in `buildInterpolationContext` (runtime.ts).
+
+5. **Stale Frontier (M4)** - `computeStaleFrontier` in `stale.ts:89` uses **union semantics** (observed ∪ declared). O(phases + read-edges). Cycles terminate.
+
+6. **Why-Stale** - `formatWhyStale` in `stale.ts:147` annotates declared-only edges with `(declared)`.
+
+7. **Recompute (M5)** - `recomputeTaskflow` in `runtime.ts:2738` defaults to `dryRun: true` (fail-safe). Guards against unobserved deps (shareContext, flow phases, context files, {previous.output}, {args.*}, {item.*}) in `hasUnobservedDependencies`. Uses `structuredClone` to avoid mutation.
+
+8. **Early Cutoff** - In `runtime.ts:2877`: phases whose `inputHash` didn't move after upstream re-ran hit their cached result (no re-execution).
+
+9. **Topological Order** - `runtime.ts:2838`: frontier phases executed in topological order respecting observed + declared deps (union).
+
+Now I'll write the two .mdx files:
+
+---
+
+## FILE: website/content/docs/en/reference/incremental-recompute.mdx
+
+```mdx
+---
+title: Incremental Recompute
+description: FlowIR compilation, observed read-sets, stale frontier, and minimal re-execution.
+---
+
+When a phase's upstream changes, taskflow can **recompute only the affected phases** instead of re-running the entire flow. This is the incremental-recompute system: a compile-time dependency graph (FlowIR), runtime provenance tracking (observed read-sets), conservative transitive invalidation (stale frontier), and minimal re-execution with early cutoff (recompute).
+
+This page is the technical reference. For the user-facing commands (`/tf why-stale`, `/tf recompute`), see [Commands](/en/docs/reference/commands). For the cross-run cache that recompute builds on, see [Caching](/en/docs/syntax/caching).
+
+## Architecture
+
+The incremental-recompute system has four layers:
+
+| Layer | Milestone | Purpose |
+|---|---|---|
+| **FlowIR compilation** | M1 | Project the flow definition into a content-addressed IR with declared dependencies. |
+| **Observed read-sets** | M3 | Track which upstream outputs a phase actually interpolated at runtime. |
+| **Stale frontier** | M4 | Compute the transitive closure of phases invalidated by a changed seed. |
+| **Recompute** | M5 | Re-execute only the frontier, with early cutoff for phases whose inputs didn't move. |
+
+Two additional refinements:
+
+- **Per-phase fingerprinting (M6)** — invalidates only the affected phase + its dependents, not independent siblings.
+- **Declared-plane derivation (M2)** — synthesizes the declared read-map from the flow definition so staleness uses **union semantics** (observed ∪ declared).
+
+## FlowIR compilation (M1)
+
+`compileTaskflowToIR(def)` projects a desugared `Taskflow` into a `FlowIR` shape:
+
+```typescript
+interface TaskflowIR {
+  ir?: FlowIR;                    // The compiled IR (nodes with inject/emits)
+  meta: TaskflowIRMeta;           // Compile-time metadata
+  hash?: string;                  // Content fingerprint (32 hex chars)
+  warnings: CompileWarning[];     // Non-fatal advisories
+  errors: CompileError[];         // Hard errors (none in stub)
+  usedFallbackHash: boolean;      // true in stub (hash is flowDefHash, not IR-canonical)
+}
+```
+
+### The IR projection
+
+Each phase becomes one `FlowIRNode`:
+
+```typescript
+interface FlowIRNode {
+  id: string;
+  kind: string;       // Phase type (agent, parallel, map, gate, ...)
+  inject: string[];   // Declared reads: {steps.X} refs from collectRefs
+  emits: string[];    // [phase.id] (1:1 projection)
+  when?: string;      // Raw when guard passthrough
+}
+```
+
+The stub is a **structural mirror**, not a compile to overstory's native inject/emits model (which expects explicit `emit` declarations pi-taskflow doesn't have). Each phase's `inject` is synthesized from `{steps.X}` interpolation refs; `emits` is `[phase.id]`.
+
+### Content hashing
+
+`flowDefHash` is a content fingerprint of the desugared definition:
+
+```typescript
+async function flowDefHash(def: Taskflow): Promise<string> {
+  return hashCanonical(canonicalJson(def));
+}
+```
+
+- **`canonicalJson`** — recursively key-sorted (UTF-16 code units), no whitespace, `undefined` dropped, arrays ordered.
+- **`hashCanonical`** — SHA-256, first 16 bytes, lowercase hex (32 chars).
+- **Vendored from overstory** — byte-identical to `packages/core/src/ir/hash.ts` (pinned commit).
+
+The hash folds into the cross-run cache key (`v3:phasefp:<subfp>`) so two flows with the same name but different structures never collide.
+
+### Declared dependencies (M2)
+
+`meta.declaredDeps` is the **declared plane** — the static dependency footprint synthesized at compile time:
+
+```typescript
+interface DeclaredDeps {
+  reads: string[];   // Upstream step ids referenced by {steps.X} interpolation
+  writes: string[];  // [phase.id] (what this phase emits)
+}
+```
+
+Derived from `collectRefs(phase)` which scans `task`, `when`, `branches`, `with`, `context`, `until`, `eval` for `{steps.X.*}` placeholders. Self-refs are excluded (a loop `until` checking `{steps.thisId.output}` doesn't create a self-edge).
+
+### Per-phase fingerprinting (M6)
+
+`phaseFingerprint(def, phaseId)` produces a **structural sub-fingerprint** of only the phase + its transitive dependency closure:
+
+```typescript
+async function phaseFingerprint(def: Taskflow, phaseId: string): Promise<string | undefined>
+```
+
+- **Soundness gate** — returns `undefined` when per-phase invalidation is unsound:
+  - `def.contextSharing === true` or any closure member has `shareContext === true` (cross-sibling reads outside declared deps)
+  - `type === "flow"` in the closure (sub-structure resolved at runtime)
+  - `phase.join === "any"` (may read phases outside declared dependsOn)
+- **Policy fields stripped** — `cache`, `retry`, `concurrency`, `final` are removed before hashing (they don't affect subagent output).
+- **Fallback** — caller uses the whole-flow `flowDefHash` when `undefined` is returned.
+
+Editing phase B invalidates only B + its transitive dependents; independent sibling A keeps its cache hit.
+
+### Stub status
+
+`usedFallbackHash` is **always true** in the stub: the hash is `flowDefHash` (the definition fingerprint), not the overstory-IR-canonical hash. It flips to `false` once the genuine overstory compiler is vendored.
+
+## Observed read-sets (M3)
+
+At runtime, `buildInterpolationContext` tracks which `{steps.X.*}` refs a phase actually resolves via an `onRead` callback:
+
+```typescript
+interface PhaseState {
+  // ...
+  reads?: Array<{ stepId: string; version?: string }>;
+}
+```
+
+- **`stepId`** — the upstream phase id (e.g., `"scout"` from `{steps.scout.output}`).
+- **`version`** — the upstream's `inputHash` at the time of the read (for provenance).
+
+Captured only for `steps.*` refs; `args.*`, `item.*`, `previous.*` are invocation/loop values, not upstream dependencies.
+
+### Read map
+
+`readMapOf(phases)` folds a run's `PhaseState` into a dependency graph:
+
+```typescript
+type ReadMap = Map<string, readonly string[]>;  // phaseId → upstream stepIds
+
+function readMapOf(phases: Record<string, PhaseState>): ReadMap {
+  const m: ReadMap = new Map();
+  for (const [id, ps] of Object.entries(phases)) {
+    const deps = (ps.reads ?? []).map((r) => r.stepId);
+    if (deps.length) m.set(id, deps);
+  }
+  return m;
+}
+```
+
+Phases with no reads are dropped (they have no upstream dependencies).
+
+## Stale frontier (M4)
+
+`computeStaleFrontier(reads, seeds, declared)` returns the **transitive closure** of phases invalidated if `seeds` change:
+
+```typescript
+function computeStaleFrontier(
+  reads: ReadMap,
+  seeds: Iterable<string>,
+  declared?: ReadMap
+): Set<string>
+```
+
+### Union semantics (observed ∪ declared)
+
+When `declared` is provided, the read graph is the **union** of:
+
+- **Observed** (`reads`) — what the phase actually interpolated at runtime (M3).
+- **Declared** (`declared`) — what the phase statically references per `collectRefs` (M2).
+
+A declared-but-unobserved edge (e.g., a `when` ref that never fired) still propagates staleness. This is the **conservative** choice: when in doubt, assume dependency.
+
+### Algorithm
+
+BFS from `seeds`, following dependents (phases that read the seed):
+
+```typescript
+const stale = new Set<string>();
+const queue: string[] = [...seeds];
+while (queue.length) {
+  const s = queue.shift() as string;
+  if (stale.has(s)) continue;  // Cycle termination: each phase enqueued at most once
+  stale.add(s);
+  for (const dep of dependentsOf(reads, s, declared)) {
+    if (!stale.has(dep)) queue.push(dep);
+  }
+}
+return stale;
+```
+
+- **O(phases + read-edges)** — linear in the size of the dependency graph.
+- **Cycles terminate** — a correct DAG can't produce them, but a pathological one could; the `stale.has(s)` guard prevents infinite loops.
+- **Includes seeds** — the changed phases themselves are in the frontier.
+
+### Declared-plane derivation
+
+`declaredReadMapOfDef(def)` synthesizes the declared read-map from the flow definition:
+
+```typescript
+function declaredReadMapOfDef(def: Taskflow): ReadMap {
+  const m: ReadMap = new Map();
+  for (const p of def.phases) {
+    const refs = collectRefs(p);
+    const reads = refs.steps.filter((id) => id !== p.id);  // Exclude self-refs
+    if (reads.length) m.set(p.id, reads);
+  }
+  return m;
+}
+```
+
+Pure. Used by `recomputeTaskflow` so old runs (pre-H1, no persisted `declaredDeps`) also get union semantics.
+
+## Why-stale semantics
+
+`formatWhyStale` renders the stale frontier for human consumption:
+
+```typescript
+function formatWhyStale(
+  runId: string,
+  flowName: string,
+  reads: ReadMap,
+  seeds: readonly string[],
+  declared?: ReadMap
+): string
+```
+
+### No seeds (dependency graph)
+
+When `seeds.length === 0`, shows the full observed dependency graph:
+
+```
+why-stale — run abc123 · flow "review-changes"
+
+Observed dependency graph (who reads what):
+
+■ lint  reads: scout
+■ test  reads: scout
+■ summary  reads: lint, test
+```
+
+### With seeds (stale frontier)
+
+When seeds are provided, shows the transitive closure with "why" annotations:
+
+```
+why-stale — run abc123 · flow "review-changes"
+
+Assuming changed: scout
+
+Stale frontier (transitive, 4 phases):
+  ■ scout  (changed — seed)
+  ■ lint  ← reads scout
+  ■ test  ← reads scout
+  ■ summary  ← reads lint, test
+```
+
+### Declared-only edges
+
+Edges present only in the declared plane (not observed at runtime) are annotated with `(declared)`:
+
+```
+■ summary  ← reads lint, test (declared)
+```
+
+This happens when a phase statically references an upstream via `{steps.X}` but the interpolation never fired (e.g., a `when` guard evaluated to false, so the task with the ref was never executed).
+
+## Recompute (M5)
+
+`recomputeTaskflow` minimally re-executes a stale run:
+
+```typescript
+async function recomputeTaskflow(
+  state: RunState,
+  deps: RuntimeDeps,
+  seeds: readonly string[],
+  opts: { dryRun?: boolean } = { dryRun: true }
+): Promise<{ report: RecomputeReport; state: RunState }>
+```
+
+### Fail-safe default
+
+`dryRun: true` by default — computes the worst-case frontier **without spending a token**. A real recompute (`dryRun: false`) overwrites the run and spends tokens.
+
+### Dry-run report
+
+```typescript
+interface RecomputeReport {
+  readonly dryRun: boolean;
+  readonly aborted: boolean;
+  readonly seeds: readonly string[];
+  readonly rerun: readonly string[];      // Phases that would be (or were) re-executed
+  readonly reused: readonly string[];     // Phases outside the frontier (untouched)
+  readonly cutoff: readonly string[];     // Phases in frontier whose inputHash didn't move (early cutoff)
+  readonly decisions: readonly RecomputeDecision[];  // Per-phase "why"
+}
+
+interface RecomputeDecision {
+  readonly phaseId: string;
+  readonly outcome: "rerun" | "cutoff" | "reused" | "failed";
+  readonly reason: string;
+  readonly causedBy?: readonly string[];
+}
+```
+
+Dry-run `cutoff` is always empty (unknowable without execution).
+
+### Unobserved dependency guard
+
+`dryRun: false` throws when the flow has dependencies the observed read-set can't track:
+
+```typescript
+function hasUnobservedDependencies(state: RunState): boolean {
+  // Scans for:
+  // - shareContext / contextSharing (Shared Context Tree)
+  // - type === "flow" (sub-flows)
+  // - context: [...] (file pre-reads)
+  // - {previous.output}, {args.*}, {item.*} (interpolation outside steps.*)
+}
+```
+
+These dependencies are **invisible** to the observed read-set. Recomputing with `dryRun: false` could silently skip phases whose deps changed outside the observed frontier, corrupting the run. Use `dryRun: true` to inspect the frontier, or re-run the whole flow.
+
+### Topological order
+
+Frontier phases are executed in topological order respecting **observed + declared deps** (union):
+
+```typescript
+const augmentedPhases = newState.def.phases.map((p) => ({
+  ...p,
+  dependsOn: [...new Set([...(p.dependsOn ?? []), ...depsFor(p.id)])],
+}));
+const order = topoLayers(augmentedPhases)
+  .flat()
+  .map((p) => p.id)
+  .filter((id) => frontier.has(id));
+```
+
+This ensures a downstream always sees its (already-refreshed) upstreams when it re-evaluates its cache key. A declared-but-unobserved edge (e.g., a `when` ref that never fired) still orders the reader after its upstream, preventing false early-cutoff.
+
+### Early cutoff
+
+A phase in the frontier whose `inputHash` didn't move (because its upstream's new output happened to equal the old) hits its cached result — no re-execution:
+
+```typescript
+const ps = await executePhase(phase, newState, deps, prior, noop, 0, execOpts);
+if (isSeed || ps.inputHash !== before) {
+  rerun.push(id);
+  outputMoved.add(id);
+} else {
+  cutoff.push(id);  // Early cutoff: input unchanged, cached result reused
+}
+```
+
+This is the **prize** — early cutoff makes recompute cheaper than a full re-run.
+
+### Seed forcing
+
+Seeds are always re-executed (`execOpts = { forceRerun: true }`), bypassing the cache:
+
+```typescript
+const isSeed = seedSet.has(id);
+const execOpts = isSeed ? { forceRerun: true } : undefined;
+```
+
+### Abort safety
+
+A partial recompute is never persisted over the original run:
+
+```typescript
+if (deps.signal?.aborted) {
+  aborted = true;
+  break;  // Caller discards state when aborted
+}
+```
+
+### State isolation
+
+`recomputeTaskflow` uses `structuredClone(state)` to avoid mutating the caller's `RunState`. Recompute is a speculative replay; only the caller decides whether to persist the new state.
+
+## The incremental loop
+
+The three commands form a diagnostic workflow:
+
+```
+/tf ir <flow>           → inspect the FlowIR + content hash
+/tf why-stale <runId> [phaseId]  → inspect the stale frontier
+/tf recompute <runId> <phaseId> [--apply]  → minimally re-execute
+```
+
+### Step 1: Inspect the IR
+
+```bash
+/tf ir review-changes
+```
+
+Shows the compiled FlowIR, the content hash, and declared dependencies. Useful for understanding what the runtime sees as the flow's structure.
+
+### Step 2: Diagnose staleness
+
+```bash
+/tf why-stale abc123
+```
+
+No seed → shows the full dependency graph (who reads what).
+
+```bash
+/tf why-stale abc123 scout
+```
+
+With seed → shows the stale frontier if `scout` changed.
+
+### Step 3: Recompute
+
+```bash
+/tf recompute abc123 scout
+```
+
+Dry-run by default — shows what would be re-executed without spending tokens.
+
+```bash
+/tf recompute abc123 scout --apply
+```
+
+Real recompute — re-executes the frontier, with early cutoff for phases whose inputs didn't move.
+
+## Concrete walkthrough
+
+A 4-phase flow: `scout` → `lint` → `test` → `summary`. You've run it once; everything is cached.
+
+### Scenario 1: Upstream changed
+
+You edit the `scout` phase's task. Re-run the flow:
+
+```bash
+/tf run review-changes
+```
+
+- `scout` re-executes (task text changed → `inputHash` moved).
+- `lint` reads `scout` → in the stale frontier. Re-executes, but its `inputHash` moved (scout's output changed) → no early cutoff.
+- `test` reads `scout` → same as `lint`.
+- `summary` reads `lint` and `test` → in the frontier. Re-executes.
+
+All 4 phases re-run. No early cutoff because the upstream change propagated.
+
+### Scenario 2: Mid-flow changed
+
+You edit the `lint` phase's task. Re-run:
+
+```bash
+/tf run review-changes
+```
+
+- `scout` unchanged → cache hit (cross-run memoization).
+- `lint` re-executes (task text changed).
+- `test` unchanged, but reads `scout` (not `lint`) → cache hit.
+- `summary` reads `lint` (changed) and `test` (unchanged) → in the frontier. Re-executes, but its `inputHash` moved (lint's output changed) → no early cutoff.
+
+3 phases re-run (`lint`, `summary`, and `scout`/`test` from cache). `test` is an independent sibling — not invalidated.
+
+### Scenario 3: Early cutoff
+
+You edit `scout`'s task, but the new task produces **identical output** (e.g., you added a comment). Re-run:
+
+```bash
+/tf run review-changes
+```
+
+- `scout` re-executes (task text changed).
+- `lint` reads `scout` → in the frontier. Re-executes, but `scout`'s output is identical → `lint`'s `inputHash` is unchanged → **early cutoff**. Cache hit.
+- `test` same as `lint` → early cutoff.
+- `summary` reads `lint` and `test` → in the frontier, but both upstreams hit early cutoff → `summary`'s `inputHash` is unchanged → early cutoff.
+
+Only `scout` re-runs. The rest hit early cutoff (0 tokens).
+
+### Scenario 4: Manual recompute
+
+You want to force `scout` to re-run without changing its task:
+
+```bash
+/tf recompute <runId> scout --apply
+```
+
+- `scout` is the seed → forced re-execution.
+- `lint`, `test`, `summary` are in the frontier → re-execute, with early cutoff if inputs didn't move.
+
+Useful when an external factor changed (e.g., the repo `scout` reads was updated outside the flow).
+
+## Cache-clear
+
+`cache-clear` wipes the cross-run memoization cache:
+
+```bash
+# Pi
+/tf cache-clear
+
+# MCP
+taskflow_cache_clear
+```
+
+Use when:
+
+- You've edited the flow definition and want to ensure a clean re-run (though `flowDefHash` should invalidate automatically).
+- You suspect a cache corruption (rare; the cache uses atomic writes).
+- You want to measure the true cost of a flow without cache reuse.
+
+## Limitations
+
+### Unobserved dependencies
+
+The observed read-set tracks only `{steps.X.*}` interpolation refs. These are **invisible**:
+
+- **Shared Context Tree** (`shareContext`, `contextSharing`) — phases can read sibling blackboard writes outside declared deps.
+- **Sub-flows** (`type === "flow"`) — sub-structure resolved at runtime or from a saved flow.
+- **File pre-reads** (`context: [...]`) — files read before the phase runs.
+- **Loop locals** (`{args.*}`, `{item.*}`, `{previous.output}`) — not upstream phase dependencies.
+
+Flows with these dependencies cannot be safely recomputed with `dryRun: false`. Use `dryRun: true` to inspect the frontier, or re-run the whole flow.
+
+### Stub hash
+
+The current hash (`flowDefHash`) is the **definition fingerprint**, not the overstory-IR-canonical hash. Two flows with the same structure but different `when` guards hash differently (even if the guards never fire). This is conservative — it over-invalidates rather than under-invalidates.
+
+### No early cutoff for seeds
+
+Seeds are always re-executed (`forceRerun: true`), even if their task text is unchanged. This is by design — a seed is an explicit "re-run this" request.
+
+## Next
+
+<Cards>
+  <Card title="Commands" href="/en/docs/reference/commands">
+    Pi /tf commands and MCP tools for why-stale and recompute.
+  </Card>
+  <Card title="Caching" href="/en/docs/syntax/caching">
+    Cross-run memoization and the cache key structure.
+  </Card>
+  <Card title="Resume" href="/en/docs/concepts/resume">
+    Within-run resume for interrupted flows.
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/guides/claude-code.mdx
+++ b/website/content/docs/zh-cn/guides/claude-code.mdx
@@ -1,0 +1,240 @@
+---
+title: 在 Claude Code 上使用 taskflow
+description: 将 taskflow 作为 Claude Code 插件安装，通过 MCP 编排多阶段工作流。
+---
+
+[Claude Code](https://claude.com/product/claude-code) 是 taskflow 的天然宿主：它本身就以 subagent 的方式思考，而 taskflow 给这些 subagent 提供了一个声明式图来运行。在 Claude Code 上，taskflow 以插件形式发布，注册一个零依赖的 MCP 服务器外加一个路由 skill，这样模型一看到多步骤任务就能调用它。
+
+本页带你走完整个流程：安装插件、确认 MCP 服务器已就绪、通过工具调用运行一个 flow，并理解权限与长时运行 flow 的模型。
+
+## 安装
+
+taskflow 通过共享的插件市场分发。先添加市场，再安装插件：
+
+```bash title="安装 taskflow 插件"
+claude plugin marketplace add heggria/taskflow
+claude plugin install claude-taskflow@taskflow
+```
+
+这一条 `plugin install` 同时完成三件事：
+
+<Steps>
+  <Step>
+    **注册 MCP 服务器。** 插件声明了一个通过 `npx -y -p claude-taskflow claude-taskflow-mcp` 启动的 `taskflow` 服务器，让 Claude Code 能通过 stdio 访问运行时。`npx` 的版本锁定绑定了确切运行的代码——无需全局安装任何东西。
+  </Step>
+  <Step>
+    **安装路由 skill。** 一个内置 skill 教会 Claude Code 何时该调用 taskflow 工具，这样你不必记住它们的名字。
+  </Step>
+  <Step>
+    **保持零运行时依赖。** MCP 服务器在 Node 内置能力上通过 stdio 讲 JSON-RPC 2.0——不需要 `@modelcontextprotocol/sdk`，taskflow 因此保持了零依赖承诺。
+  </Step>
+</Steps>
+
+如果 Claude Code 会话已经在运行，重启它以加载新插件。
+
+## 验证安装
+
+在运行任何东西之前，确认插件及其 MCP 服务器都干净地注册了：
+
+```bash title="验证插件和 MCP 服务器"
+claude plugin list   # 应出现 claude-taskflow@taskflow，enabled
+claude mcp list      # 应出现 taskflow，enabled
+```
+
+如果任一缺失，说明 `plugin install` 步骤未完成——重新运行并检查错误。
+
+## 运行你的第一个 flow
+
+在 Claude Code 上，你不通过斜杠命令调用 taskflow——你通过 MCP 工具调用它。模型在路由 skill 的引导下决定何时调用。所以最自然的开始方式就是直接描述工作。
+
+### 直接问
+
+在 Claude Code 会话中试试这些：
+
+```text title="用自然语言描述工作"
+> List my saved taskflows.
+> Verify this flow, then run it: {name:"review-changes", phases:[...]}
+> Run the "review-changes" taskflow with dir set to src.
+```
+
+skill 会把请求路由到正确的工具。如果当前项目保存了一个 flow，模型会带保存的名称调用 `taskflow_run`；如果你粘贴了内联定义，它则传递定义。
+
+### 直接调用工具
+
+如果你想显式调用——在脚本里或你确切知道结构时很有用——工具是 `taskflow_run`。它接受保存的 flow `name` 或内联 `define`：
+
+```json title="通过 taskflow_run 运行保存的 flow"
+{
+  "name": "review-changes",
+  "args": { "dir": "src" }
+}
+```
+
+```json title="通过 taskflow_run 运行内联 flow"
+{
+  "define": {
+    "name": "quick-review",
+    "phases": [
+      {
+        "id": "discover",
+        "type": "agent",
+        "agent": "scout",
+        "task": "List changed source files under src/. Output ONLY a JSON array of {path} objects.",
+        "output": "json"
+      },
+      {
+        "id": "review-each",
+        "type": "map",
+        "over": "{steps.discover.json}",
+        "as": "file",
+        "agent": "security-reviewer",
+        "task": "Review {file.path} for security risks. Return one paragraph.",
+        "dependsOn": ["discover"],
+        "concurrency": 4
+      },
+      {
+        "id": "summarize",
+        "type": "reduce",
+        "from": ["review-each"],
+        "agent": "writer",
+        "task": "Combine these reviews into one prioritized summary:\n{steps.review-each.output}",
+        "dependsOn": ["review-each"],
+        "final": true
+      }
+    ]
+  }
+}
+```
+
+两种形式运行同一个 DAG。工具只返回最终输出——`discover`、`review-each` 和 `summarize` 的中间 transcript 留在运行时内，永远不会进入你的上下文。
+
+<Callout type="info">
+  只有标记了 `final: true` 的阶段会被返回。其余一切在设计上就是上下文隔离的。
+</Callout>
+
+## 在花费 token 之前检查 flow
+
+在运行 DAG 之前，你可以让 Claude Code 静态校验它。这能捕获环、悬空的 `dependsOn`、未知的阶段引用以及格式错误的配置——全部零 token 成本：
+
+```json title="通过 taskflow_verify 校验 flow"
+{
+  "name": "review-changes"
+}
+```
+
+或者把 DAG 渲染成图来目测其形状：
+
+```json title="通过 taskflow_compile 把 flow 编译成图"
+{
+  "name": "review-changes"
+}
+```
+
+`taskflow_compile` 返回按拓扑层分组的 DAG 文本大纲，外加一个内联 SVG 图像（供能渲染图像的客户端使用）。
+
+## subagent 如何运行
+
+每个阶段的 subagent 作为隔离的 `claude -p` 会话运行——一个真正的 Claude Code headless 进程，不是 pi 进程。服务器从其**启动 cwd** 发现已保存的 flow 和 agent，所以你在哪个项目启动它决定了哪些 flow 可见。
+
+### 权限映射
+
+Claude Code 在 headless（`-p`）模式下没有 OS 级沙箱——一个工具调用要么被白名单允许，要么被拒绝。运行时把每个阶段的工具白名单映射到一个权限模式：
+
+| 阶段工具 | 权限模式 | 含义 |
+|---|---|---|
+| 只读（无 `write`/`edit`/`bash`） | `--allowedTools Read,Grep,Glob,WebFetch,WebSearch` | 变更类工具被直接拒绝。注意没有只读 shell——`Bash` 不会授予只读阶段。 |
+| 变更（或无白名单） | `--permission-mode bypassPermissions` | subagent 可以运行任何工具。只运行你信任的 flow，在一个你能 `git reset` 的仓库里。 |
+
+<Callout type="warn">
+  变更阶段以 `bypassPermissions` 运行，没有 OS 沙箱兜底。对涉及文件系统的 flow，优先使用一次性 worktree（`cwd: "worktree"`），并只运行你信任的 flow。
+</Callout>
+
+## 长时运行的 flow
+
+关于在 Claude Code 上运行 taskflow，你需要知道一件事：**`taskflow_run` 是同步的。** 工具调用在**整个 DAG 完成**之前不会返回——每个阶段、每个 subagent。对三阶段审查这没问题；对五十个文件的扇出加末尾的 tournament，可能要花一阵子。
+
+如果一个 flow 确实很大，考虑把它拆成几个较小的 `taskflow_run` 调用，让每个都能及时返回，或者从普通 shell 在后台运行：
+
+```bash title="在后台运行 flow"
+claude -p "run the nightly-audit taskflow" &
+```
+
+然后用 `taskflow_peek` 事后检查运行：
+
+```json title="通过 taskflow_peek 查看某阶段的存储输出"
+{
+  "runId": "run_2026-07-04_abc123",
+  "phaseId": "summarize"
+}
+```
+
+省略 `phaseId` 可列出每个阶段及其状态和输出大小。输出会被硬截断（默认 4000 字符），所以 peek 永远不会淹没你的上下文。
+
+<Callout type="warn">
+  `taskflow_peek` 是 taskflow 上下文隔离的唯一有意例外。它把中间输出拉进你的对话——只用于调试，不要作为正常流程的一部分。
+</Callout>
+
+## MCP 模式下的审批
+
+MCP 驱动的运行是非交互的，所以 `approval` 阶段会**自动拒绝**（fail-open）。在你通过 `taskflow_*` 工具运行的 flow 中，优先使用 `gate`（agent 审查）；`approval` 只用在人工交互运行的 flow 中。
+
+## 工具参考
+
+以下是插件暴露的完整 MCP 接口：
+
+| 工具 | 用途 |
+|---|---|
+| `taskflow_run` | 运行保存的 flow（按 `name`）或内联定义（按 `define`）。返回最终输出 + 一个 `runId`。 |
+| `taskflow_list` | 列出从 cwd 可发现的保存 flow，附带库元数据（如有）。 |
+| `taskflow_show` | 显示保存 flow 的定义及其库 sidecar 元数据。 |
+| `taskflow_save` | 把 flow 保存到库，可选 `purpose`、`tags`、`notes`。 |
+| `taskflow_search` | 在编写前搜索库。返回排序后的可复用 flow。 |
+| `taskflow_verify` | 静态校验 flow（环、引用、配置），零成本。 |
+| `taskflow_compile` | 把 DAG 渲染为文本大纲 + 内联 SVG。 |
+| `taskflow_peek` | 查看某次运行中某阶段的存储输出，用于事后调试。 |
+
+<Callout type="tip">
+  你很少需要记住这些。内置 skill 会告诉 Claude Code 哪个工具适合请求——"verify this flow"、"show me the diagram"、"run it" 都能自动正确路由。
+</Callout>
+
+## 备选：手动注册 MCP 服务器
+
+如果你不想用插件，可以安装包并自行注册它的 `claude-taskflow-mcp` bin：
+
+```bash title="手动注册 MCP"
+pnpm add -g claude-taskflow
+claude mcp add taskflow -- claude-taskflow-mcp
+```
+
+验证注册：
+
+```bash title="验证手动注册"
+claude mcp list   # taskflow … enabled
+```
+
+服务器的行为与插件版完全相同——只是不带路由 skill，也没有一键更新路径。
+
+## 卸载
+
+如果你需要从某台机器移除 taskflow：
+
+```bash title="移除 taskflow 插件"
+claude plugin uninstall claude-taskflow@taskflow   # 如果以插件形式安装
+claude mcp remove taskflow                          # 如果手动注册
+```
+
+这会取消注册 MCP 服务器并移除 skill。磁盘上任何已保存的 flow 定义都不受影响。
+
+## 下一步
+
+<Cards>
+  <Card title="快速开始" href="/zh-cn/docs/getting-started">
+    五分钟速览（如果你还没看过）。
+  </Card>
+  <Card title="阶段" href="/zh-cn/docs/concepts/phases">
+    可组合成 DAG 的十个构建块。
+  </Card>
+  <Card title="在 Codex 上使用 taskflow" href="/zh-cn/docs/guides/codex">
+    同一个运行时，接入 OpenAI Codex。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/guides/opencode.mdx
+++ b/website/content/docs/zh-cn/guides/opencode.mdx
@@ -1,0 +1,251 @@
+---
+title: 在 OpenCode 上使用 taskflow
+description: 在 OpenCode 上将 taskflow 注册为 MCP 服务器，编排多阶段工作流。
+---
+
+[OpenCode](https://opencode.ai) 是 taskflow 的天然宿主：它本身就以 subagent 的方式思考，而 taskflow 给这些 subagent 提供了一个声明式图来运行。在 OpenCode 上，taskflow 以零依赖 MCP 服务器的形式暴露，`taskflow_*` 工具出现在会话中，每个阶段的 subagent 作为隔离的 `opencode run` 进程运行。
+
+本页带你走完整个流程：注册 MCP 服务器、确认它已就绪、通过工具调用运行一个 flow，并理解权限与模型解析模型。
+
+## 安装
+
+OpenCode 没有基于 git 的插件市场，所以你直接注册 MCP 服务器——用 CLI 或编辑 `opencode.json`。
+
+### 方式 A：CLI
+
+```bash title="通过 CLI 注册 MCP 服务器"
+opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
+```
+
+### 方式 B：编辑 opencode.json
+
+```jsonc title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "taskflow": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "opencode-taskflow", "opencode-taskflow-mcp"],
+      "enabled": true
+    }
+  },
+  "skills": {
+    "paths": ["./node_modules/opencode-taskflow/plugin/skills"]
+  }
+}
+```
+
+`command` 通过 `npx` 运行（一个版本锁定的 `opencode-taskflow`），服务器按需拉取并启动——无需全局安装其他东西，锁定绑定了确切运行的代码。
+
+<Callout type="info">
+  `skills.paths` 条目是可选的。OpenCode 会自动发现 `**/SKILL.md` skill（包括 Claude Code 的 `.claude/skills`），而 taskflow 工具是自描述的，所以路由 skill 只是帮助 OpenCode 在合适时机调用它们。一个可直接复制的 `opencode.json` 随包的 `plugin/` 目录提供。
+</Callout>
+
+## 验证安装
+
+在运行任何东西之前，确认 MCP 服务器干净地注册了：
+
+```bash title="验证 MCP 服务器"
+opencode mcp list   # 应出现 taskflow，enabled
+```
+
+如果缺失，说明 `mcp add` 步骤未完成——重新运行并检查错误。
+
+## 运行你的第一个 flow
+
+在 OpenCode 上，你不通过斜杠命令调用 taskflow——你通过 MCP 工具调用它。模型在路由 skill 的引导下决定何时调用。所以最自然的开始方式就是直接描述工作。
+
+### 直接问
+
+在 OpenCode 会话中试试这些：
+
+```text title="用自然语言描述工作"
+> List my saved taskflows.
+> Verify this flow, then run it: {name:"review-changes", phases:[...]}
+> Run the "review-changes" taskflow with dir set to src.
+```
+
+skill 会把请求路由到正确的工具。如果当前项目保存了一个 flow，模型会带保存的名称调用 `taskflow_run`；如果你粘贴了内联定义，它则传递定义。
+
+### 直接调用工具
+
+如果你想显式调用——在脚本里或你确切知道结构时很有用——工具是 `taskflow_run`。它接受保存的 flow `name` 或内联 `define`：
+
+```json title="通过 taskflow_run 运行保存的 flow"
+{
+  "name": "review-changes",
+  "args": { "dir": "src" }
+}
+```
+
+```json title="通过 taskflow_run 运行内联 flow"
+{
+  "define": {
+    "name": "quick-review",
+    "phases": [
+      {
+        "id": "discover",
+        "type": "agent",
+        "agent": "scout",
+        "task": "List changed source files under src/. Output ONLY a JSON array of {path} objects.",
+        "output": "json"
+      },
+      {
+        "id": "review-each",
+        "type": "map",
+        "over": "{steps.discover.json}",
+        "as": "file",
+        "agent": "security-reviewer",
+        "task": "Review {file.path} for security risks. Return one paragraph.",
+        "dependsOn": ["discover"],
+        "concurrency": 4
+      },
+      {
+        "id": "summarize",
+        "type": "reduce",
+        "from": ["review-each"],
+        "agent": "writer",
+        "task": "Combine these reviews into one prioritized summary:\n{steps.review-each.output}",
+        "dependsOn": ["review-each"],
+        "final": true
+      }
+    ]
+  }
+}
+```
+
+两种形式运行同一个 DAG。工具只返回最终输出——`discover`、`review-each` 和 `summarize` 的中间 transcript 留在运行时内，永远不会进入你的上下文。
+
+<Callout type="info">
+  只有标记了 `final: true` 的阶段会被返回。其余一切在设计上就是上下文隔离的。
+</Callout>
+
+## 在花费 token 之前检查 flow
+
+在运行 DAG 之前，你可以让 OpenCode 静态校验它。这能捕获环、悬空的 `dependsOn`、未知的阶段引用以及格式错误的配置——全部零 token 成本：
+
+```json title="通过 taskflow_verify 校验 flow"
+{
+  "name": "review-changes"
+}
+```
+
+或者把 DAG 渲染成图来目测其形状：
+
+```json title="通过 taskflow_compile 把 flow 编译成图"
+{
+  "name": "review-changes"
+}
+```
+
+`taskflow_compile` 返回按拓扑层分组的 DAG 文本大纲，外加一个内联 SVG 图像（供能渲染图像的客户端使用）。
+
+## subagent 如何运行
+
+每个阶段的 subagent 作为隔离的 `opencode run` 进程运行——一个真正的 OpenCode 会话，不是 pi 进程。服务器从其**启动 cwd** 发现已保存的 flow 和 agent，所以你在哪个项目启动它决定了哪些 flow 可见。
+
+### 权限映射
+
+OpenCode 没有按运行的 tool-whitelist 标志，但它支持通过 `OPENCODE_CONFIG_CONTENT` 环境变量注入的按进程配置。运行时把每个阶段的工具白名单映射到一个权限策略：
+
+| 阶段工具 | 权限策略 | 含义 |
+|---|---|---|
+| 只读（无 `write`/`edit`/`bash`） | 注入一个**拒绝** bash/write/edit 的策略 | 被拒绝的工具调用会被真正拒绝（而非仅未批准）。这是真正的强制，更接近只读 OS 沙箱而非咨询式白名单。 |
+| 变更（或无白名单） | `opencode run --auto` | 自动批准每个权限——workspace-write 的类比。只运行你信任的 flow，最好在一次性 worktree（`cwd: "worktree"`）中。 |
+
+<Callout type="warn">
+  变更阶段以 `--auto` 运行，自动批准每个权限。对涉及文件系统的 flow，优先使用一次性 worktree（`cwd: "worktree"`），并只运行你信任的 flow。
+</Callout>
+
+### 模型解析
+
+OpenCode 模型 id 是 `provider/model`（如 `anthropic/claude-sonnet-4-5`）。因为合法的 OpenCode id 包含斜杠，运行时**不会**复用 codex/claude 的"包含 `/` ⇒ 丢弃"规则。它只丢弃明显不是 OpenCode 模型的 id：
+
+- 未解析的 role 占位符（`{{fast}}`）
+- pi 的 thinking 后缀（`…:xhigh`）
+- 多段 openrouter 路径（`openrouter/vendor/model`，≥ 2 个斜杠）
+
+被丢弃的 id 会回退到 OpenCode 配置的默认模型。
+
+## 长时运行的 flow
+
+关于在 OpenCode 上运行 taskflow，你需要知道一件事：**`taskflow_run` 是同步的。** 工具调用在**整个 DAG 完成**之前不会返回——每个阶段、每个 subagent。对三阶段审查这没问题；对五十个文件的扇出加末尾的 tournament，可能要花一阵子。
+
+如果一个 flow 确实很大，考虑把它拆成几个较小的 `taskflow_run` 调用，让每个都能及时返回，或者从普通 shell 在后台运行：
+
+```bash title="在后台运行 flow"
+opencode run "run the nightly-audit taskflow" &
+```
+
+然后用 `taskflow_peek` 事后检查运行：
+
+```json title="通过 taskflow_peek 查看某阶段的存储输出"
+{
+  "runId": "run_2026-07-04_abc123",
+  "phaseId": "summarize"
+}
+```
+
+省略 `phaseId` 可列出每个阶段及其状态和输出大小。输出会被硬截断（默认 4000 字符），所以 peek 永远不会淹没你的上下文。
+
+<Callout type="warn">
+  `taskflow_peek` 是 taskflow 上下文隔离的唯一有意例外。它把中间输出拉进你的对话——只用于调试，不要作为正常流程的一部分。
+</Callout>
+
+## MCP 模式下的审批
+
+MCP 驱动的运行是非交互的，所以 `approval` 阶段会**自动拒绝**（fail-open）。在你通过 `taskflow_*` 工具运行的 flow 中，优先使用 `gate`（agent 审查）；`approval` 只用在人工交互运行的 flow 中。
+
+## 工具参考
+
+以下是服务器暴露的完整 MCP 接口：
+
+| 工具 | 用途 |
+|---|---|
+| `taskflow_run` | 运行保存的 flow（按 `name`）或内联定义（按 `define`）。返回最终输出 + 一个 `runId`。 |
+| `taskflow_list` | 列出从 cwd 可发现的保存 flow，附带库元数据（如有）。 |
+| `taskflow_show` | 显示保存 flow 的定义及其库 sidecar 元数据。 |
+| `taskflow_save` | 把 flow 保存到库，可选 `purpose`、`tags`、`notes`。 |
+| `taskflow_search` | 在编写前搜索库。返回排序后的可复用 flow。 |
+| `taskflow_verify` | 静态校验 flow（环、引用、配置），零成本。 |
+| `taskflow_compile` | 把 DAG 渲染为文本大纲 + 内联 SVG。 |
+| `taskflow_peek` | 查看某次运行中某阶段的存储输出，用于事后调试。 |
+
+<Callout type="tip">
+  你很少需要记住这些。内置 skill 会告诉 OpenCode 哪个工具适合请求——"verify this flow"、"show me the diagram"、"run it" 都能自动正确路由。
+</Callout>
+
+## 备选：从仓库检出运行
+
+如果你不想安装包，从本仓库检出构建，并让 OpenCode 指向构建好的 bin：
+
+```bash title="从检出注册"
+pnpm run build
+opencode mcp add taskflow -- node /abs/path/to/taskflow/packages/opencode-taskflow/dist/mcp/bin.js
+```
+
+服务器的行为与 `npx` 版本完全相同。
+
+## 卸载
+
+如果你需要从某台机器移除 taskflow：
+
+```bash title="移除 taskflow MCP 服务器"
+opencode mcp remove taskflow    # 或删除 opencode.json 中的 mcp.taskflow 条目
+```
+
+磁盘上任何已保存的 flow 定义都不受影响。
+
+## 下一步
+
+<Cards>
+  <Card title="快速开始" href="/zh-cn/docs/getting-started">
+    五分钟速览（如果你还没看过）。
+  </Card>
+  <Card title="阶段" href="/zh-cn/docs/concepts/phases">
+    可组合成 DAG 的十个构建块。
+  </Card>
+  <Card title="在 Claude Code 上使用 taskflow" href="/zh-cn/docs/guides/claude-code">
+    同一个运行时，接入 Claude Code。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/meta.json
+++ b/website/content/docs/zh-cn/meta.json
@@ -10,6 +10,8 @@
     "concepts/interpolation",
     "concepts/verification",
     "concepts/context-isolation",
+    "concepts/shared-context-tree",
+    "concepts/workspace-isolation",
     "concepts/resume",
     "---语法参考---",
     "syntax/flow-definition",

--- a/website/content/docs/zh-cn/meta.json
+++ b/website/content/docs/zh-cn/meta.json
@@ -19,11 +19,13 @@
     "syntax/control-flow",
     "syntax/caching",
     "syntax/budget",
+    "syntax/scorers",
     "---指南---",
     "guides/pi",
     "guides/codex",
     "guides/dynamic-planning",
     "guides/tournament",
+    "guides/background-runs",
     "guides/code-audit-case-study",
     "guides/headline-tournament-case-study",
     "guides/migration-planner-case-study",
@@ -33,6 +35,7 @@
     "---参考---",
     "reference/shorthand",
     "reference/commands",
+    "reference/incremental-recompute",
     "community"
   ]
 }

--- a/website/content/docs/zh-cn/meta.json
+++ b/website/content/docs/zh-cn/meta.json
@@ -23,6 +23,7 @@
     "---指南---",
     "guides/pi",
     "guides/codex",
+    "guides/agents-and-model-roles",
     "guides/dynamic-planning",
     "guides/tournament",
     "guides/background-runs",

--- a/website/content/docs/zh-cn/meta.json
+++ b/website/content/docs/zh-cn/meta.json
@@ -23,6 +23,8 @@
     "---指南---",
     "guides/pi",
     "guides/codex",
+    "guides/claude-code",
+    "guides/opencode",
     "guides/agents-and-model-roles",
     "guides/dynamic-planning",
     "guides/tournament",

--- a/website/content/docs/zh-cn/reference/incremental-recompute.mdx
+++ b/website/content/docs/zh-cn/reference/incremental-recompute.mdx
@@ -1,0 +1,511 @@
+---
+title: 增量重算
+description: FlowIR 编译、观测读集、过期检测与最小重算。
+---
+
+taskflow 的增量重算是一个**成本非对称的响应式系统**：廉价的效果（计算哪些内容*会*失效）几乎免费运行；昂贵的效果（真正重新运行一个 LLM 阶段）则被显式确认所把关。本页是其工作原理的精确参考。
+
+该系统分为四层：**FlowIR 编译**（对 flow 定义做内容寻址）、**依赖追踪**（声明读集 + 观测读集）、**过期检测**（传递性前沿计算）、**最小重算**（强制重跑种子，其余全部复用）。每一层在可能时都是纯函数，绝不向运行过程抛出异常，并在其前置条件不满足时安全降级。
+
+<Callout type="info">
+  整个重算工具集 —— `/tf ir`、`/tf provenance`、`/tf why-stale`、`/tf recompute` —— 都**不消耗任何 token**。只有 `recompute --apply` 会消耗 token，而且即便如此，也只花在输入确实发生变化的那些阶段上。
+</Callout>
+
+## FlowIR 编译
+
+每次运行都以将 flow 定义编译为**内容寻址的中间表示**（FlowIR）作为开端。这次编译是跨运行记忆化的基础：两个结构相同的 flow 会产生相同的哈希，因此一次运行中的某个阶段可以在另一次运行中被复用。
+
+### 编译接缝
+
+编译通过 `compileTaskflowToIR(def)` 路由，它返回一个 `TaskflowIR`：
+
+```typescript
+interface TaskflowIR {
+  ir?: FlowIR;                    // The compiled IR (nodes with inject/emits)
+  meta: TaskflowIRMeta;           // Compile-time metadata (declared deps, sidecar)
+  hash?: string;                  // Content fingerprint (32-hex SHA-256)
+  warnings: CompileWarning[];     // Non-fatal advisories
+  errors: CompileError[];         // Hard compile errors (none in the stub)
+  usedFallbackHash: boolean;      // True when the hash is flowDefHash (not IR-canonical)
+}
+```
+
+编译是**纯函数 + 异步**的（使用 Web Crypto 做哈希），且**永不抛出异常** —— 哈希失败时 `hash` 保持未设置，缓存降级为仅基于 flowName 的旧式键（该次运行的跨运行复用被禁用）。
+
+### 内容寻址
+
+`hash` 当前由 `flowDefHash(def)` 生成，它将脱糖后的定义序列化为**规范 JSON**（递归按键排序、无空白、丢弃 `undefined`），并用 SHA-256（前 16 字节，小写十六进制）对其哈希。这是 vendored 的 overstory 哈希契约 —— 与 overstory 的 `hashIR` 算法逐字节一致。
+
+```typescript
+// Canonical JSON: keys sorted by UTF-16 code units, arrays preserve order
+function canonicalJson(value: unknown): string;
+
+// SHA-256 of canonical serialization, first 16 bytes hex
+async function hashCanonical(canonical: string): Promise<string>;
+
+// Content fingerprint of the desugared Taskflow definition
+async function flowDefHash(def: Taskflow): Promise<string>;
+```
+
+<Callout type="warn">
+  在当前的桩实现中，`usedFallbackHash` **始终为 true**：该哈希是定义指纹，而非 IR 规范哈希。只有当真正的 overstory 编译器被 vendored 之后，它才会翻转为 `false`。调用方绝不能把桩哈希误当成规范哈希。
+</Callout>
+
+### 阶段级子指纹
+
+`phaseFingerprint(def, phaseId)` 只对阶段本身 + 其传递依赖闭包生成一个**结构性子指纹**。把它折进缓存键（而不是整 flow 哈希）意味着：编辑阶段 B 只会让 B 及其传递依赖者失效 —— 相互独立的兄弟阶段 A 仍然命中缓存。
+
+该指纹在哈希前会**剥离策略字段**：`cache`、`retry`、`concurrency` 和 `final` 不影响阶段的 subagent 输出，只影响执行机制或结果选择。把它们算进去会在无实质改动的配置变更上造成虚假的缓存失效。
+
+#### 可靠性门控
+
+阶段级失效只有在某个阶段的真实依赖被静态 `dependsOn ∪ from` 闭包完整捕获时才是可靠的。有三种情况会破坏这一保证，因此 `phaseFingerprint` 对它们返回 `undefined`，调用方退回到整 flow 的 `flowDefHash`（安全，= pre-M6 行为）：
+
+1. **Shared Context Tree**（`def.contextSharing === true` 或闭包中任一成员 `shareContext === true`）：共享阶段可以读取其声明依赖之外的兄弟黑板写入，因此静态闭包欠近似真实读集。
+2. **闭包中的 `flow` 阶段**（`type === "flow"`）：`flow` 阶段的子结构在运行时才解析（内联 `def`）或从已保存的 flow（`use`）读取，这里无法静态可见。
+3. **`join: "any"` 阶段**（`phase.join === "any"`）：校验豁免它“`{steps.X}` 必须出现在 `dependsOn` 中”的检查，因此它可能读取其静态闭包之外的阶段。
+
+### 编译期声明依赖
+
+编译还会合成一个**声明依赖平面**（M2）：对每个阶段，`collectRefs(phase)` 扫描 `task`、`when`、`until`、`eval`、`score.target`、`score.judge.task`、`branches[].task`、`with.*` 和 `context[]` 字段中的 `{steps.X.*}` 插值引用。这些构成该阶段的声明读集；其写集为 `[phase.id]`（1:1 投影）。
+
+```typescript
+interface DeclaredDeps {
+  reads: string[];  // Upstream step ids statically referenced
+  writes: string[]; // Step ids this phase emits (currently [phase.id])
+}
+
+interface TaskflowIRMeta {
+  sourceFlowName: string;
+  declaredDeps: Record<string, DeclaredDeps>;  // Per-phase declared footprint
+  sidecar: Record<string, unknown>;             // Pi-taskflow-specific fields (round-trip)
+}
+```
+
+声明平面会持久化到 `RunState.declaredDeps` 以便审计/溯源，但**重算会从 `def` 重新派生它**，因此旧运行（H1 之前、没有持久化 declaredDeps）也能获得 union 语义。
+
+## 依赖追踪
+
+taskflow 在**两个平面**上追踪依赖：*声明*平面（编译期、静态）和*观测*平面（运行期、动态）。过期检测使用它们的**并集**，因此一个“声明但未被观测到”的边（例如一个从未触发的 `when` 引用）仍然会传播过期。
+
+### 观测读集（M3）
+
+每个已完成阶段都记录一个**观测 readSet** —— 不是它*声明*依赖的内容（`dependsOn`），而是它在插值时刻*真正读取*的内容。每个条目都带有它消费时对应的**版本**（= 被读阶段的 `inputHash`），这样后续的过期检查就能判断上游是否已经移动。
+
+```typescript
+interface PhaseState {
+  // ...
+  reads?: Array<{
+    stepId: string;      // The upstream phase id
+    version?: string;    // The upstream's inputHash when this phase read it
+  }>;
+}
+```
+
+这就是 overstory “observed readSet@version” 的护城河：没有其他编排器记录一个结果**真正**依赖了什么。一个插值 `{steps.scout.output}` 和 `{steps.analyst.output}` 的阶段有两条读记录；一个没有插值引用的阶段则没有。
+
+<Callout type="tip">
+  使用 `/tf provenance <runId>` 查看一次运行的观测读集。这是“这个阶段到底消费了什么”的真实依据。
+</Callout>
+
+### 声明读集（M2）
+
+声明平面在编译期由 `collectRefs(phase)` 派生。它捕获阶段*可能*读取的每一个 `{steps.X.*}` 引用，包括可能永不触发（因为条件为假）的 `when` 守卫里的引用，以及可能只在后续迭代才求值的 `until` 收敛检查里的引用。
+
+```typescript
+// Fold a run's PhaseStates into a read map (drops phases with no reads)
+function readMapOf(phases: Record<string, PhaseState>): ReadMap;
+
+// Build a declared ReadMap from a flow definition (collectRefs per phase)
+function declaredReadMapOfDef(def: Taskflow): ReadMap;
+```
+
+`ReadMap` 是 `Map<phaseId, readonly string[]>` —— 阶段 id 到它读取的上游 stepId 列表。观测平面和声明平面都使用这个形状。
+
+### Union 语义
+
+当把 `declared` 提供给 `computeStaleFrontier` 或 `dependentsOf` 时，依赖者集合是观测依赖者（来自 `reads`）与声明依赖者（来自 `declared`）的**并集**。这确保：
+
+- 一个从未触发（因为条件为假）的 `when` 引用仍然算作依赖 —— 如果被引用的阶段变化，被守卫的阶段即便没有观测到这次读取，也会被标记为过期。
+- 一个只在第 3 次迭代才求值的 `until` 收敛检查，仍会从其引用传播过期，即使第 1、2 次迭代并未观测到它们。
+- 旧运行（H1 之前、没有持久化 declaredDeps）同样获得 union 语义，因为重算会从 `def` 重新派生声明平面。
+
+## 过期检测
+
+`/tf why-stale` 解释一个被缓存的运行为何过期：哪个阶段变了，以及还有什么被传递性失效。该计算是**纯的、确定性的、零 token 的** —— 它读取持久化的 `RunState` 并遍历依赖图。
+
+### 过期前沿
+
+`computeStaleFrontier(reads, seeds, declared?)` 返回当 `seeds` 变化时过期的阶段的**传递闭包**。一个读者只要（观测地或声明地）读取了任意一个过期阶段，它就过期（union 语义：存疑时按有依赖处理）。前沿包含种子本身。
+
+```typescript
+function computeStaleFrontier(
+  reads: ReadMap,           // Observed read map
+  seeds: Iterable<string>,  // Phases assumed to have changed
+  declared?: ReadMap        // Declared read map (union when provided)
+): Set<string>;
+```
+
+算法是对读图的 BFS：把种子入队，然后对每个种子找出它的依赖者（通过 `dependentsOf`），把它们入队，循环往复。每个阶段至多入队一次（visited 集合），因此病态读图中的环也能终止。复杂度为 O(phases + read-edges)。
+
+### 解释过期
+
+`formatWhyStale(runId, flowName, reads, seeds, declared?)` 渲染人类可读的解释：
+
+- **无种子**：展示完整的观测依赖图（谁读了谁），仅声明的边标注 `(declared)`。
+- **有种子**：展示过期前沿，每个过期阶段列出导致它过期的上游（即它的“为什么”）。种子标记为 `(changed — seed)`；下游阶段列出其过期读取。
+
+```bash
+/tf why-stale abc123 scout
+```
+
+```text title="why-stale 输出"
+why-stale — run abc123 · flow "review-changes"
+
+Assuming changed: scout
+
+Stale frontier (transitive, 3 phases):
+  ■ scout  (changed — seed)
+  ■ analyst  ← reads scout
+  ■ summary  ← reads analyst
+```
+
+<Callout type="info">
+  前沿是**保守的**：只要阶段*可能*受影响，就标记为过期。真正的重算（带 `--apply`）会检查每个阶段的 `inputHash` —— 如果上游的新输出恰好与旧输出相等，该阶段命中缓存（early cutoff）并被复用。
+</Callout>
+
+## 最小重算
+
+`/tf recompute <runId> <phaseId>` 最小化地重算一个过期阶段：强制重跑种子，然后按拓扑序遍历其过期前沿。缓存免费提供 **early cutoff** —— 一个 `inputHash` 未移动的下游（因为种子的新输出恰好与旧输出相等）会命中其先前结果并被复用，而不是重新执行。
+
+### 默认干跑
+
+重算**默认故障安全**：不带 `--apply` 时，它*不花一个 token* 就算出最坏情况下的前沿，并返回一份描述*将会*发生什么的 `RecomputeReport`。
+
+```bash
+/tf recompute abc123 scout        # Dry-run: what would change?
+/tf recompute abc123 scout --apply  # Real recompute: spend tokens
+```
+
+干跑报告解释每个阶段的结局：
+
+```typescript
+interface RecomputeReport {
+  dryRun: boolean;
+  aborted: boolean;                // True if the user cancelled mid-recompute
+  seeds: readonly string[];        // The phase(s) forced to re-run
+  rerun: readonly string[];        // Phases that were (would be) re-executed
+  reused: readonly string[];       // Phases outside the frontier (untouched)
+  cutoff: readonly string[];       // Frontier phases whose inputHash didn't move
+  decisions: readonly RecomputeDecision[];  // Per-phase WHY
+}
+
+interface RecomputeDecision {
+  phaseId: string;
+  outcome: "rerun" | "cutoff" | "reused" | "failed";
+  reason: string;                  // Human-readable cause
+  causedBy?: readonly string[];    // Upstream phases that caused this outcome
+}
+```
+
+<Callout type="tip">
+  `decisions` 数组是“可解释的响应式”层 —— 就像 React DevTools 告诉你某个组件为何重渲染。用它来理解一个阶段为何被重跑、被截断还是被复用。
+</Callout>
+
+### Early cutoff
+
+Early cutoff 是关键收益：过期前沿中那些在上游重跑后 `inputHash` **未**移动的阶段。这发生在：
+
+- 种子的新输出与旧输出逐字节相同（例如一次未改变渲染文档的重构）。
+- 种子的输出变了，但下游阶段不插值变化的部分（例如 `summary` 读取 `{steps.analyst.output}` 但只用了第一段，而第一段没变）。
+
+Early cutoff 正是让重算比完整重跑更便宜的原因：你只为种子和任何输入确实移动的下游付费；其余全部免费。
+
+### 拓扑序
+
+真正的重算（`--apply`）按**拓扑序**遍历前沿，并尊重 `dependsOn ∪ observed reads ∪ declared reads`（M2 union）。这确保下游在重新评估其缓存键时，总能看到（已刷新的）上游 —— 不会因为基于陈旧上游状态评估而产生虚假的 early cutoff。
+
+自环会被过滤：一个检查 `{steps.thisId.output}` 的 `loop` `until` 不得在调度图中创建自环（topoLayers 会死锁）。
+
+### 安全守卫
+
+对含有未观测依赖的 flow，带 `--apply` 的重算是**被门控**的。观测 readSet 只追踪 `{steps.X.*}` 插值引用；它对以下情况是盲的：
+
+- **Shared Context Tree**（`shareContext`、`contextSharing`、`ctx_read`/`ctx_write`）
+- **子 flow 内部**（`flow` 阶段的 `use` 或内联 `def`）
+- **上下文文件预读**（`context: ["src/**/*.ts"]`）
+- **非 steps 插值**（`{previous.output}`、`{args.*}`、`{item.*}`）
+
+对这样的运行用 `--apply` 重算，可能会静默跳过那些依赖在观测前沿之外发生变化的阶段，然后把一个损坏的运行覆盖回原始运行。运行时会抛出：
+
+```text
+recompute dryRun:false is unsafe for this run: it contains dependencies
+(shareContext, flow/ctx_spawn, context: files, {previous.output}, {args.*}, or {item.*})
+that are not tracked by the observed readSet. Use dryRun:true to inspect
+the frontier, or change the upstream phase and re-run the whole flow.
+```
+
+<Callout type="warn">
+  如果你的 flow 使用了上述任一特性，`--apply` 会被阻止。请用 `dryRun:true` 检查前沿，然后 (a) 改变上游阶段并重跑整个 flow，或 (b) 重构以移除未观测的依赖。
+</Callout>
+
+## 跨运行缓存
+
+跨运行缓存（`CacheStore`）跨运行记忆化阶段结果。一个具有相同 `inputHash`（插值后的 task + flow 定义哈希 + 指纹）的阶段会以 $0.00 复用先前结果。
+
+### 指纹解析
+
+阶段可以声明一个 `cache.fingerprint` 列表，把外部状态折进缓存键。每个条目都被解析为一个确定性字符串：
+
+| Prefix | Resolution | Example |
+|---|---|---|
+| `git:<ref>` | `git rev-parse <ref>` → SHA | `git:HEAD` → `git:HEAD=a1b2c3d...` |
+| `glob:<pattern>` | File list + size + mtime digest | `glob:src/**/*.ts` → `glob:src/**/*.ts=<digest>` |
+| `glob!:<pattern>` | File list + content SHA digest | `glob!:src/**/*.ts` → `glob!:src/**/*.ts=<digest>` |
+| `file:<path>` | File content SHA | `file:package.json` → `file:package.json=<sha>` |
+| `env:<name>` | Environment variable value | `env:NODE_ENV` → `env:NODE_ENV=production` |
+
+未知前缀在校验期被拒绝；运行期防御性编码为 `<unknown>`。缺失的文件、非 git 仓库、不可读路径都会解析为稳定的哨兵值（`<missing>`、`<no-git>`、`<skip>`），以保证键的确定性 —— 资源后续出现只会改变键 → 缓存未命中（安全方向）。
+
+```typescript
+function resolveFingerprint(entries: string[] | undefined, cwd: string): string;
+```
+
+<Callout type="tip">
+  对源代码文件使用 `glob!:`（内容模式）—— 一个 mtime 变了但内容没变的文件（例如 `touch`）不会让缓存失效。对 mtime 有意义的生成文件使用 `glob:`（stat 模式）。
+</Callout>
+
+### 缓存条目形状
+
+```typescript
+interface CacheEntry {
+  key: string;              // The full cache key (inputHash)
+  createdAt: number;        // Unix timestamp
+  output?: string;          // Trimmed phase output
+  json?: unknown;           // Parsed JSON (for output: "json" phases)
+  model?: string;           // Model that produced this result
+  state?: PhaseState;       // Full PhaseState (gate, approval, reads, loop, etc.)
+  flowName?: string;        // Provenance
+  phaseId?: string;
+  runId?: string;
+}
+```
+
+完整的 `PhaseState` 被存储（而不只是 `output`/`json`），这样跨运行复用在语义上等价于运行内恢复 —— 只存输出会丢掉 `gate`、`approval`、`reads`、`loop`、`tournament`、`warnings` 等，破坏重算的可靠性和 gate-block 检测。
+
+### 缓存生命周期
+
+- **TTL**：条目在 `cache.ttl`（解析为毫秒）后过期。默认：无 TTL（条目一直保留直到被驱逐）。
+- **Max age**：硬性兜底 —— 超过 90 天的条目无论 TTL 如何都会被丢弃。
+- **Max entries**：每个缓存目录 1000 条；超出时驱逐最旧的。
+- **Clear**：`/tf cache-clear`（或 `action: "cache-clear"`）移除所有条目。
+
+## 增量闭环
+
+完整的增量工作流是：**编译 → 检查 → 解释 → 重算**。
+
+### 1. 编译 flow
+
+```bash
+/tf ir review-changes
+```
+
+输出：
+
+```text title="/tf ir 输出"
+FlowIR — flow "review-changes"
+  hash: a1b2c3d4e5f6789012345678 (usedFallbackHash: true)
+  nodes: 4
+    ■ scout       kind: agent    inject: []              emits: [scout]
+    ■ analyst     kind: agent    inject: [scout]         emits: [analyst]
+    ■ gate        kind: gate     inject: [analyst]       emits: [gate]       when: {steps.analyst.json.issues}
+    ■ summary     kind: agent    inject: [analyst, gate] emits: [summary]
+  declaredDeps:
+    scout:     reads: []               writes: [scout]
+    analyst:   reads: [scout]          writes: [analyst]
+    gate:      reads: [analyst]        writes: [gate]
+    summary:   reads: [analyst, gate]  writes: [summary]
+```
+
+### 2. 检查溯源
+
+运行后，检查每个阶段实际读取了什么：
+
+```bash
+/tf provenance abc123
+```
+
+```text title="/tf provenance 输出"
+Provenance — run abc123 · flow "review-changes"
+
+  ■ scout
+    reads: (none — root phase)
+    inputHash: 1a2b3c4d5e6f7890
+
+  ■ analyst
+    reads:
+      - scout (version: 1a2b3c4d5e6f7890)
+    inputHash: 2b3c4d5e6f789012
+
+  ■ gate
+    reads:
+      - analyst (version: 2b3c4d5e6f789012)
+    inputHash: 3c4d5e6f78901234
+
+  ■ summary
+    reads:
+      - analyst (version: 2b3c4d5e6f789012)
+      - gate (version: 3c4d5e6f78901234)
+    inputHash: 4d5e6f7890123456
+```
+
+### 3. 解释过期
+
+一周后，summary 看起来过期了。查一下原因：
+
+```bash
+/tf why-stale abc123 scout
+```
+
+```text title="/tf why-stale 输出"
+why-stale — run abc123 · flow "review-changes"
+
+Assuming changed: scout
+
+Stale frontier (transitive, 4 phases):
+  ■ scout  (changed — seed)
+  ■ analyst  ← reads scout
+  ■ gate  ← reads analyst
+  ■ summary  ← reads analyst, gate
+```
+
+### 4. 最小重算
+
+先干跑看看会改变什么：
+
+```bash
+/tf recompute abc123 scout
+```
+
+```text title="/tf recompute 输出 (dry-run)"
+Recompute report (dry-run) — run abc123 · flow "review-changes"
+  seeds: [scout]
+  rerun: [scout, analyst, gate, summary]
+  reused: []
+  cutoff: []
+  decisions:
+    ■ scout     outcome: rerun    reason: forced by recompute request (seed)
+    ■ analyst   outcome: rerun    reason: reads a phase in the stale frontier; may re-run if that upstream's output moves
+                                   causedBy: [scout]
+    ■ gate      outcome: rerun    reason: reads a phase in the stale frontier; may re-run if that upstream's output moves
+                                   causedBy: [analyst]
+    ■ summary   outcome: rerun    reason: reads a phase in the stale frontier; may re-run if that upstream's output moves
+                                   causedBy: [analyst, gate]
+```
+
+应用重算：
+
+```bash
+/tf recompute abc123 scout --apply
+```
+
+```text title="/tf recompute 输出 (applied)"
+Recompute report — run abc123 · flow "review-changes"
+  seeds: [scout]
+  rerun: [scout, analyst, summary]
+  reused: []
+  cutoff: [gate]
+  decisions:
+    ■ scout     outcome: rerun    reason: forced by recompute request (seed)
+    ■ analyst   outcome: rerun    reason: input changed — an upstream's output moved
+                                   causedBy: [scout]
+    ■ gate      outcome: cutoff   reason: input unchanged — upstream(s) re-ran but produced identical output (early cutoff)
+                                   causedBy: [analyst]
+    ■ summary   outcome: rerun    reason: input changed — an upstream's output moved
+                                   causedBy: [analyst, gate]
+```
+
+`gate` 阶段命中了 early cutoff：它的上游（`analyst`）重跑了，但 analyst 的输出（问题列表）没变，所以 gate 的 `inputHash` 未变，复用了先前结果。你只为 3 个阶段付费，而不是 4 个。
+
+## 具体走查
+
+一个从首次运行到增量重算的真实会话：
+
+```bash title="1. 编写并校验一个 flow"
+/tf verify review-changes
+```
+
+verify 在花任何 token 之前就捕获了一个环和一个缺失的 `dependsOn`。修正 JSON。
+
+```bash title="2. 运行 flow"
+/tf run review-changes dir=src
+```
+
+运行完成。运行时会：
+
+- 把 flow 编译为 FlowIR（内容寻址哈希）。
+- 按拓扑序执行阶段。
+- 在插值时刻捕获观测读集。
+- 持久化运行状态（包括 `flowDefHash`、`declaredDeps`、`reads`）。
+
+```bash title="3. 检查编译后的 IR"
+/tf ir review-changes
+```
+
+检查哈希和声明依赖。同一 flow 定义下哈希跨运行稳定。
+
+```bash title="4. 运行后检查溯源"
+/tf runs  # 找到 runId
+/tf provenance <runId>
+```
+
+查看每个阶段实际读取了什么。这是依赖追踪的真实依据。
+
+```bash title="5. 一周后：检查过期"
+/tf why-stale <runId> scout
+```
+
+`scout` 阶段读取了 `src/` 文件；这些文件变了。过期前沿包含 `scout` 及所有传递性读取它的阶段。
+
+```bash title="6. 干跑重算"
+/tf recompute <runId> scout
+```
+
+不花 token 看看会改变什么。报告展示哪些阶段会被重跑、复用或截断。
+
+```bash title="7. 应用重算"
+/tf recompute <runId> scout --apply
+```
+
+只有种子以及输入确实移动的下游阶段会被重新执行。Early cutoff 为那些上游重跑但产出相同结果的阶段节省 token。
+
+```bash title="8. 清理缓存（可选）"
+/tf cache-clear
+```
+
+移除所有跨运行缓存条目。当你想强制全新运行时使用（例如模型升级之后）。
+
+## 命令参考
+
+| Command | Description |
+|---|---|
+| `/tf ir <name>` | 编译为 FlowIR + 内容哈希。零 token。 |
+| `/tf provenance <runId>` | 展示一次运行的观测读集溯源。零 token。 |
+| `/tf why-stale <runId> [phaseId]` | 解释一个被缓存的运行为何过期。零 token。 |
+| `/tf recompute <runId> <phaseId>` | 干跑最小重算。零 token。 |
+| `/tf recompute <runId> <phaseId> --apply` | 应用最小重算。只对重跑阶段消耗 token。 |
+| `/tf cache-clear` | 清理跨运行记忆化缓存。零 token。 |
+
+## 接下来
+
+<Cards>
+  <Card title="命令" href="/zh-cn/docs/reference/commands">
+    Pi 与 MCP 宿主的完整命令参考。
+  </Card>
+  <Card title="缓存" href="/zh-cn/docs/syntax/caching">
+    跨运行记忆化语法：缓存作用域、TTL、指纹。
+  </Card>
+  <Card title="Flow 定义" href="/zh-cn/docs/syntax/flow-definition">
+    FlowIR 所编译自的完整 phases DAG。
+  </Card>
+</Cards>

--- a/website/content/docs/zh-cn/syntax/scorers.mdx
+++ b/website/content/docs/zh-cn/syntax/scorers.mdx
@@ -1,0 +1,617 @@
+---
+title: 评分门控
+description: 零 token 评分器的确定性输出校验、可选的 LLM 裁判与 fail-open 语义。
+---
+
+评分门控（scoring gate）是一个质量检查点：在为 LLM 花费哪怕一个 token 之前，先用一组确定性规则校验上游输出。你只需声明"合格"长什么样——包含某个子串、匹配某个正则、满足某个 JSON schema、长度落在区间内，或者代码能通过编译——taskflow 会以零成本完成每一项检查。当所有检查通过时，门控自动放行；当检查失败时，可选的 LLM 裁判可以决定是让流程继续还是终止它。
+
+你可能会想：*为什么不直接用一个带 LLM 的普通门控？* 因为确定性检查更快、更便宜、也更可预测。一个正则要么匹配、要么不匹配——不存在幻觉风险。评分器在裁判之前运行，所以如果你的检查足够充分，你完全不需要为任何 token 付费。
+
+## 何时使用评分门控
+
+| 如果你的问题是…… | 使用 | 一句话说明 |
+|---|---|---|
+| "输出是否包含某个必需的短语？" | `contains` | 子串搜索。 |
+| "是否匹配某个模式？" | `regex` | 正则表达式，可选取反。 |
+| "是否精确等于这个字符串？" | `exact-match` | 逐字节相等。 |
+| "JSON 是否匹配某个 schema？" | `json-schema` | TypeBox 风格的契约校验。 |
+| "输出长度是否合理？" | `length-range` | 闭区间字符数边界。 |
+| "代码能否通过编译？" | `code-compiles` | 在隔离环境中启动真实编译器。 |
+| "确定性检查失败了，但也许仍然可以接受" | `judge` | LLM 作为裁判的兜底方案。 |
+
+<Callout type="tip">
+  从确定性评分器开始。只有当检查不够充分时才添加裁判——例如主观质量、语气，或无法用模式表达的正确性。
+</Callout>
+
+## 一个贯穿全文的示例
+
+本页剩余部分会构建一个真实的流程：**在发布前校验生成的 API 响应**。你会看到这个门控从单一检查逐步成长为一个带裁判兜底的多评分器门控——每出现一种新需求就引入一种新的评分器类型。
+
+把它保存为 `validate.json`——我们会不断扩展它：
+
+```json title="validate.json — 起始版本"
+{
+  "name": "validate",
+  "phases": [
+    {
+      "id": "generate",
+      "type": "agent",
+      "agent": "executor",
+      "task": "Generate a JSON API response for GET /users. Include status, data, and message fields.",
+      "output": "json"
+    },
+    {
+      "id": "check-response",
+      "type": "gate",
+      "dependsOn": ["generate"],
+      "score": {
+        "scorers": [
+          { "type": "contains", "value": "\"status\"" }
+        ]
+      },
+      "task": "Is this a valid API response? VERDICT: PASS or VERDICT: BLOCK."
+    }
+  ]
+}
+```
+
+## 六种评分器类型
+
+每个评分器都是一个确定性检查，返回 `passed: true` 或 `passed: false` 以及一条可选的 detail 消息。评分器是纯函数（`code-compiles` 除外），并且永不抛出异常——错误的配置会让评分器以一条诊断信息失败，而不是让整个运行崩溃。
+
+### `exact-match`
+
+测试目标字符串是否与 `value` 逐字节相等。
+
+```json title="exact-match 评分器"
+{
+  "type": "exact-match",
+  "value": "PASS"
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `value` | `string` | 是 | 用于比较的字符串。 |
+
+**通过语义：** `target === value`。大小写敏感，不做 trim。
+
+**何时使用：** 精确的哨兵值、固定的状态码、已知的正确输出。
+
+### `contains`
+
+测试目标字符串是否将 `value` 作为子串包含。
+
+```json title="contains 评分器"
+{
+  "type": "contains",
+  "value": "0 errors"
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `value` | `string` | 是 | 要搜索的子串。 |
+
+**通过语义：** `target.includes(value)`。大小写敏感。
+
+**何时使用：** 检查必需的短语、错误计数、状态标记。
+
+<Callout type="info">
+  `contains` 评分器大小写敏感。如果你需要大小写不敏感的匹配，请使用带 `i` 标志的 `regex`：`{"type": "regex", "pattern": "success", "negate": false}`。
+</Callout>
+
+### `regex`
+
+测试目标是否匹配某个 JavaScript 正则表达式。
+
+```json title="regex 评分器"
+{
+  "type": "regex",
+  "pattern": "\"status\"\\s*:\\s*\"success\"",
+  "negate": false
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `pattern` | `string` | 是 | JavaScript RegExp 源码（不带分隔符）。 |
+| `negate` | `boolean` | 否 | 对匹配结果取反。默认为 `false`。 |
+
+**通过语义：** `new RegExp(pattern).test(target)`，当 `negate: true` 时取反。
+
+**错误处理：** 无效的 pattern 会让评分器以一条 detail 消息失败（例如 `"invalid pattern: Invalid regular expression"`）。随后门控回落到裁判或 task——它不会崩溃。
+
+**何时使用：** 模式匹配、格式校验、否定检查（例如"不包含 ERROR"）。
+
+### `json-schema`
+
+将解析后的目标与一个 TypeBox 风格的契约进行校验（与 `expect` 使用的 schema 语言相同）。
+
+```json title="json-schema 评分器"
+{
+  "type": "json-schema",
+  "schema": {
+    "type": "object",
+    "required": ["status", "data"],
+    "properties": {
+      "status": { "enum": ["success", "error"] },
+      "data": { "type": "object" }
+    }
+  }
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `schema` | `object` | 是 | 一个 TypeBox 风格的 JSON schema。 |
+
+**通过语义：** 目标用与 `output: "json"` 相同的宽松 JSON 解析器解析（会提取围栏代码块）。如果解析失败，评分器失败。否则，`contractViolations` 会用 schema 检查解析后的值。
+
+**何时使用：** 校验结构化输出、强制响应形状、检查枚举值。
+
+<Callout type="tip">
+  `json-schema` 评分器使用与 `expect` 契约相同的宽松解析器，所以如果你的 agent 把 JSON 包在代码围栏里，它会自动被提取出来。
+</Callout>
+
+### `length-range`
+
+测试目标的字符数是否落在某个闭区间内。
+
+```json title="length-range 评分器"
+{
+  "type": "length-range",
+  "min": 100,
+  "max": 10000
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `min` | `number` | 至少一个 | 最小字符数（含，`>= 0`）。 |
+| `max` | `number` | 至少一个 | 最大字符数（含，`>= 0`）。 |
+
+**通过语义：** `len >= min && len <= max`。如果只提供 `min`，则没有上限。如果只提供 `max`，则下限为 `0`。
+
+**校验：** 当 `min` 与 `max` 同时存在时，`min` 必须 `<= max`。两者都必须 `>= 0`。
+
+**何时使用：** 对输出大小做合理性检查、防止空响应、限制冗长输出。
+
+### `code-compiles`
+
+在一个隔离的临时目录中启动真实的编译器，检查目标是否能解析或编译通过。
+
+```json title="code-compiles 评分器"
+{
+  "type": "code-compiles",
+  "language": "typescript"
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `language` | `"javascript"` \| `"typescript"` | 是 | 运行哪个编译器。 |
+
+**通过语义：**
+
+- **`javascript`：** 运行 `node --check <file>`。仅做语法检查——不执行、不引入依赖。
+- **`typescript`：** 运行 `npx --no-install tsc --noEmit --skipLibCheck <file>`。要求环境中能解析到 `tsc`。如果不存在，评分器以一条 detail 失败。
+
+**代码提取：** 如果目标恰好包含一个围栏代码块，则编译其正文。多个围栏或没有围栏时，编译原始目标。
+
+**安全模型：** 编译器在隔离的临时目录（`mkdtempSync`，`0700` 权限）中运行，而不是阶段的 working directory。这能阻止它解析仓库中植入的 `node_modules/.bin/tsc` 或访问项目文件。`--no-install` 标志阻止 `npx` 下载包。
+
+**超时：** 每次编译器调用 30 秒。超时会让评分器以一条 detail 失败。
+
+**错误处理：** 编译器不可用、spawn 出错或超时都属于评分器失败（不是崩溃）。随后由门控的 fail-open 路径决定一次失败的检查意味着什么。
+
+**何时使用：** 校验生成的代码、在发布前捕获语法错误、对 TypeScript 输出做类型检查。
+
+<Callout type="warn">
+  `code-compiles` 是唯一的非纯评分器——它会 spawn 子进程。所有其他评分器都是纯的，并在进程内求值。
+</Callout>
+
+## 组合评分器
+
+一个 `score` 块声明一个评分器列表，以及一个 `combine` 模式来决定如何聚合它们的结果。默认是 `all`，要求每个评分器都通过。
+
+### `all`（默认）
+
+每个评分器都必须通过。组合得分为 `1`（全部通过）或 `0`（任一失败）。
+
+```json title="combine: all"
+{
+  "scorers": [
+    { "type": "contains", "value": "\"status\"" },
+    { "type": "regex", "pattern": "\"status\"\\s*:\\s*\"success\"" }
+  ],
+  "combine": "all"
+}
+```
+
+**语义：** `results.every(r => r.passed)`。二元结果。
+
+### `any`
+
+至少一个评分器通过即可。组合得分为 `1`（任一通过）或 `0`（全部失败）。
+
+```json title="combine: any"
+{
+  "scorers": [
+    { "type": "contains", "value": "PASS" },
+    { "type": "contains", "value": "OK" }
+  ],
+  "combine": "any"
+}
+```
+
+**语义：** `results.some(r => r.passed)`。二元结果。
+
+### `weighted`
+
+每个评分器向总分贡献一个加权分数，再与一个阈值比较。
+
+```json title="combine: weighted"
+{
+  "scorers": [
+    { "type": "contains", "value": "\"status\"" },
+    { "type": "json-schema", "schema": { "type": "object" } }
+  ],
+  "combine": "weighted",
+  "weights": [0.3, 0.7],
+  "threshold": 0.5
+}
+```
+
+**字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `weights` | `number[]` | 是 | 与 `scorers` 对齐。每一项都必须 `> 0`。 |
+| `threshold` | `number` | 否 | 组合得分的截止线，范围 `(0, 1]`。默认 `0.5`。 |
+
+**语义：** 每个评分器的得分为 `0`（失败）或 `1`（通过）。组合得分为 `sum(score[i] * weight[i]) / sum(weight[i])`。当存在裁判时，它的权重会被追加到 weights 数组末尾，其得分也并入组合。
+
+**提前截断（early cutoff）：** 当配置了裁判但它还没运行时，仅基于确定性检查的组合得分是一个下界。如果它已经越过阈值，裁判的得分也无法改变结果，于是门控在不花费裁判 token 的情况下自动放行。
+
+<Callout type="info">
+  **权重对齐。** 当没有裁判时，`weights` 必须恰好有 `scorers.length` 项；当存在裁判时，必须有 `scorers.length + 1` 项（最后一项是裁判的权重）。校验会强制这一点。
+</Callout>
+
+## 裁判兜底
+
+当确定性评分器失败时，可选的 LLM 裁判可以决定是否让流程继续。裁判只在评分器未通过时才运行——如果通过了，门控会自动放行，裁判上不花一个 token。
+
+```json title="带裁判兜底的门控"
+{
+  "id": "quality",
+  "type": "gate",
+  "dependsOn": ["generate"],
+  "score": {
+    "scorers": [
+      { "type": "json-schema", "schema": { "type": "object", "required": ["status"] } }
+    ],
+    "judge": {
+      "agent": "reviewer",
+      "task": "Is this a reasonable API response even if it doesn't match the schema exactly?"
+    }
+  }
+}
+```
+
+**裁判字段：**
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `task` | `string` | 是 | 裁判的 prompt。评分器报告会被自动追加。 |
+| `agent` | `string` | 否 | 裁判使用的 agent 名称。默认为门控的 `agent`。 |
+
+**裁判输出解析：** 裁判可以用三种格式响应：
+
+1. **JSON：** `{"score": 0.0-1.0, "verdict": "pass"|"block", "reason": "..."}`
+2. **裸 verdict：** `{"verdict": "pass"}` 或 `{"verdict": "block"}`
+3. **文本标记：** `SCORE: 0.8` 和/或 `VERDICT: PASS`（大小写不敏感，最后匹配的生效）
+
+**Fail-open 语义：** 无法解析的裁判输出以 `score: 1`、`verdict: "pass"` 放行。歧义决不能阻断流程。
+
+**与评分器组合：**
+
+- **`weighted` 模式：** 裁判的得分用 `weights` 中的最后一项权重并入加权组合。阈值决定 verdict。
+- **`all` 或 `any` 模式：** 裁判的 verdict 是权威的。如果裁判说 `pass`，无论评分器结果如何，门控都放行。
+
+<Callout type="tip">
+  裁判的 prompt 会自动包含确定性评分器报告，所以 LLM 能看到究竟哪些检查失败以及为什么。你不需要手动插值这些结果。
+</Callout>
+
+## `target` 字段
+
+默认情况下，评分器评估的是上游阶段的输出——即 `dependsOn` 中列出的阶段产生的文本。你可以用 `target` 字段覆盖它，该字段接受一个插值表达式。
+
+```json title="自定义 target"
+{
+  "id": "check-json",
+  "type": "gate",
+  "dependsOn": ["generate"],
+  "score": {
+    "target": "{steps.generate.json.response}",
+    "scorers": [
+      { "type": "contains", "value": "\"status\"" }
+    ]
+  }
+}
+```
+
+**默认：** `"{previous.output}"`——紧邻的上游阶段的输出。
+
+**插值：** `target` 在评分器运行之前被插值，所以你可以用 `{steps.<id>.json.<field>}` 访问 JSON 字段，或使用任何其他占位符。
+
+## 完整的评分门控
+
+下面是那个贯穿全文的示例，在添加了多个评分器、加权组合和裁判兜底之后的完整版本：
+
+```json title="validate.json — 完整的评分门控"
+{
+  "name": "validate",
+  "phases": [
+    {
+      "id": "generate",
+      "type": "agent",
+      "agent": "executor",
+      "task": "Generate a JSON API response for GET /users. Include status, data, and message fields.",
+      "output": "json"
+    },
+    {
+      "id": "check-response",
+      "type": "gate",
+      "dependsOn": ["generate"],
+      "score": {
+        "target": "{steps.generate.output}",
+        "scorers": [
+          { "type": "contains", "value": "\"status\"", "name": "has-status-field" },
+          { "type": "regex", "pattern": "\"status\"\\s*:\\s*\"success\"", "name": "status-is-success" },
+          { "type": "json-schema", "schema": { "type": "object", "required": ["status", "data"] }, "name": "valid-schema" },
+          { "type": "length-range", "min": 50, "max": 5000, "name": "reasonable-length" }
+        ],
+        "combine": "weighted",
+        "weights": [0.2, 0.3, 0.4, 0.1],
+        "threshold": 0.7,
+        "judge": {
+          "agent": "reviewer",
+          "task": "Is this a reasonable API response even if some checks failed?"
+        }
+      }
+    }
+  ]
+}
+```
+
+这个门控以零 token 评估四个评分器。如果加权组合越过 `0.7`，它自动放行；否则裁判运行并作出决定。
+
+## 评分器命名
+
+每个评分器可以带一个可选的 `name` 字段。如果省略，运行时会生成一个默认标签：`<type>-<index>`（例如 `contains-0`、`regex-1`）。
+
+```json title="具名评分器"
+{
+  "scorers": [
+    { "type": "contains", "value": "PASS", "name": "contains-pass-marker" },
+    { "type": "regex", "pattern": "\\d+", "name": "has-numeric-id" }
+  ]
+}
+```
+
+这些名称会出现在追加到裁判 prompt 的评分器报告中，让 LLM 更容易理解是哪些检查失败了。
+
+## Fail-open 语义
+
+评分门控遵循与 taskflow 其余部分相同的 fail-open 原则：歧义决不能阻断流程。
+
+| 场景 | 行为 |
+|---|---|
+| 无效的正则 pattern | 评分器以 detail 失败；门控回落到裁判或 task。 |
+| 目标不是合法 JSON（对 `json-schema`） | 评分器以 `"target is not valid JSON"` 失败。 |
+| 编译器不可用（对 `code-compiles`） | 评分器以 `"compiler unavailable: <error>"` 失败。 |
+| 编译器超时（对 `code-compiles`） | 评分器以 `"compiler timed out after 30000ms"` 失败。 |
+| 无法解析的裁判输出 | 裁判以 `score: 1`、`verdict: "pass"` 放行。 |
+| `length-range` 中 `min > max` | 在流程定义时即报校验错误。 |
+| 未知的评分器类型 | 在流程定义时即报校验错误。 |
+
+<Callout type="warn">
+  评分器失败不等于门控失败。只有当组合（评分器 + 裁判）未能越过阈值时，门控才会 block。如果你希望失败的评分器总是 block，请使用 `combine: "all"` 并省略裁判。
+</Callout>
+
+## 在下游访问评分器结果
+
+门控的结构化结果以 `PhaseState.json` 暴露，可通过插值访问：
+
+| 路径 | 值 |
+|---|---|
+| `{steps.<gate>.json.verdict}` | `"pass"` 或 `"block"` |
+| `{steps.<gate>.json.combined}` | 组合得分（`[0, 1]` 中的数字） |
+| `{steps.<gate>.json.results}` | `{name, type, passed, score, detail?}` 数组 |
+| `{steps.<gate>.json.threshold}` | 阈值（仅 `weighted` 模式） |
+| `{steps.<gate>.json.judge}` | `{score, reason?}`（仅当裁判运行过时） |
+
+```json title="在下游使用评分器结果"
+{
+  "id": "report",
+  "type": "agent",
+  "dependsOn": ["check-response"],
+  "task": "The gate verdict was {steps.check-response.json.verdict} with a combined score of {steps.check-response.json.combined}. Summarize."
+}
+```
+
+## 与 `eval` 和 `task` 的交互
+
+一个门控可以同时拥有 `eval`、`score` 和 `task` 字段。它们按如下顺序运行：
+
+1. **`eval`**（如果存在）：零 token 的机器检查。如果全部通过，门控自动放行。如果任一失败，继续到第 2 步。
+2. **`score`**（如果存在）：确定性评分器。如果它们通过（依据 `combine` 和 `threshold`），门控自动放行。如果它们失败且配置了裁判，裁判运行。如果它们失败且没有配置裁判，继续到第 3 步。
+3. **`task`**（如果存在）：LLM 门控照常运行，解析一个 `VERDICT:` 标记。
+
+<Callout type="info">
+  同时设置 `eval` 和 `score` 是合法的，但通常冗余——选其一即可。如果两者都存在，`eval` 先运行。当两者同时设置时，校验会发出一条警告。
+</Callout>
+
+## 安全限制
+
+`code-compiles` 评分器是唯一会 spawn 子进程的评分器。它在严格的隔离下运行：
+
+- **隔离的临时目录：** 用 `mkdtempSync` 创建（原子操作，`0700` 权限）。关闭了共享 `/tmp` 上可预测名称的符号链接/TOCTOU 竞争。
+- **无项目访问：** 编译器以临时目录为 working directory 运行，而不是阶段的 `cwd`。它无法解析仓库中植入的 `node_modules/.bin/tsc`。
+- **无网络：** `npx --no-install` 阻止下载包。编译器只能检查来自标准库的语法和类型。
+- **超时：** 每次调用 30 秒墙上时间上限。超时会用 `SIGKILL` 杀掉进程。
+- **清理：** 临时目录在 `finally` 块中用 `rmSync({recursive: true, force: true})` 移除。尽力清理——删除失败会被吞掉。
+
+所有其他评分器都是纯的，在进程内运行，没有文件系统或网络访问。
+
+## 字段参考
+
+### `score` 对象
+
+| 字段 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `target` | `string` | `"{previous.output}"` | 被评分字符串的插值引用。 |
+| `scorers` | `Scorer[]` | — | **必需。** 非空的评分器数组。 |
+| `combine` | `"all"` \| `"any"` \| `"weighted"` | `"all"` | 如何聚合评分器结果。 |
+| `weights` | `number[]` | — | `weighted` 必需。与 `scorers` 对齐（裁判再 +1）。 |
+| `threshold` | `number` | `0.5` | `weighted` 的组合得分截止线。必须在 `(0, 1]` 内。 |
+| `judge` | `object` | — | 可选的 LLM-as-judge 兜底。`{agent?, task}`。 |
+
+### 评分器对象
+
+每个评分器都有这些公共字段：
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `type` | `string` | 是 | 六种评分器类型之一。 |
+| `name` | `string` | 否 | 结果标签。默认为 `<type>-<index>`。 |
+
+按类型的字段：
+
+| 类型 | 字段 |
+|---|---|
+| `exact-match` | `value`（必需 string） |
+| `contains` | `value`（必需 string） |
+| `regex` | `pattern`（必需 string），`negate`（可选 boolean） |
+| `json-schema` | `schema`（必需 object） |
+| `length-range` | `min` 和/或 `max`（至少一个必需，两者都 `>= 0`） |
+| `code-compiles` | `language`（必需：`"javascript"` 或 `"typescript"`） |
+
+**校验：** 在某个评分器上设置了其类型会忽略的字段，属于形状错误。例如，`{type: "contains", negate: true}` 会被拒绝——静默丢弃 `negate` 会让作者以为取反生效了。
+
+### 门控 verdict 语法
+
+一个门控阶段（无论是否有 `score`）按如下语法把输出解析为 verdict：
+
+**JSON 格式：**
+
+```json
+{"continue": true}  → pass
+{"continue": false} → block
+{"pass": true}      → pass
+{"pass": false}     → block
+{"verdict": "PASS"} → pass
+{"verdict": "BLOCK"} → block
+{"verdict": "pass"} → pass (case-insensitive)
+{"verdict": "block"} → block
+{"verdict": "anything-else"} → pass (fail-open)
+```
+
+**文本格式：**
+
+```
+VERDICT: PASS    → pass
+VERDICT: BLOCK   → block
+VERDICT: FAIL    → block
+VERDICT: STOP    → block
+VERDICT: OK      → pass
+VERDICT: REJECT  → block
+VERDICT: HALT    → block
+```
+
+- 大小写不敏感。
+- 最后一次出现生效（如果输出包含多行 `VERDICT:`）。
+- 同时支持 `:` 和 `=` 分隔符：`VERDICT=PASS` 也可用。
+
+**Fail-open：** 歧义输出（没有 JSON、没有 `VERDICT:` 标记）放行。门控绝不会意外丢失你的工作成果。
+
+### Tournament 胜者语法
+
+tournament 裁判按如下语法选出获胜变体：
+
+**JSON 格式：**
+
+```json
+{"winner": 2}     → variant 2
+{"best": 3}       → variant 3
+{"choice": 1}     → variant 1
+```
+
+**文本格式：**
+
+```
+WINNER: 2         → variant 2
+WINNER: #3        → variant 3 (hash prefix optional)
+WINNER=1          → variant 1 (supports = separator)
+```
+
+- 从 1 开始的索引。
+- 最后一次出现生效。
+- 钳制到 `[1, variant-count]`：verdict 为 `0` 会变成 `1`，verdict 为 `99` 会变成最后一个变体。
+
+**Fail-open：** 无法解析的 verdict 默认为变体 `1`，原因为 `"no parseable winner; defaulted to variant 1"`。tournament 绝不会丢失你的工作成果。
+
+### 常见错误
+
+<details>
+<summary>校验错误</summary>
+
+| 错误 | 原因 | 修复 |
+|---|---|---|
+| `score.scorers: must be a non-empty array` | `scorers` 为空或缺失。 | 至少添加一个评分器。 |
+| `score.scorers[i].type: must be one of ...` | 未知的评分器类型。 | 使用六种受支持类型之一。 |
+| `score.scorers[i].value: required string for 'contains'` | 缺少必需字段。 | 添加该字段。 |
+| `score.scorers[i].negate: not applicable to 'contains'` | 在错误的评分器类型上设置了字段。 | 移除该字段或改用其他评分器。 |
+| `score.weights: required array for combine:"weighted"` | `weighted` 模式缺少 weights。 | 添加与评分器对齐的 `weights`。 |
+| `score.weights: expected N entries, got M` | 权重数量不匹配。 | 调整数组长度。如果存在裁判，再增加一个权重。 |
+| `score.threshold: must be a number in (0, 1]` | 无效的 threshold。 | 使用 `(0, 1]` 范围内的值。 |
+| `score.judge.task: required non-empty string` | 裁判缺少 task。 | 添加一个 `task` 字符串。 |
+
+</details>
+
+<details>
+<summary>运行时错误（评分器失败）</summary>
+
+| 错误 | 原因 | 行为 |
+|---|---|---|
+| `invalid pattern: <message>` | `regex` 评分器中的正则无效。 | 评分器失败；门控回落到裁判或 task。 |
+| `target is not valid JSON` | 对非 JSON 目标使用 `json-schema` 评分器。 | 评分器失败；门控回落。 |
+| `compiler unavailable: <error>` | 找不到 `tsc` 或 `node`。 | 评分器失败；门控回落。 |
+| `compiler timed out after 30000ms` | 编译器超过时间上限。 | 评分器失败；门控回落。 |
+| `length N outside [min, max]` | 目标长度超出范围。 | 评分器失败；门控回落。 |
+
+</details>
+
+## 下一步
+
+<Cards>
+  <Card title="阶段类型" href="/zh-cn/docs/syntax/phase-types">
+    taskflow 的十个构建块，包括 gate 类型。
+  </Card>
+  <Card title="控制流" href="/zh-cn/docs/syntax/control-flow">
+    深入了解 `when`、`join`、`retry` 与门控。
+  </Card>
+</Cards>


### PR DESCRIPTION
## Summary

Closes the docs deep-audit's "all problems solved" mandate for the advanced-features batch. Adds 7 new documentation pages (en + zh-cn), fixes a title collision (M6), and achieves full i18n parity.

## What's added

**New pages (en + zh-cn, full translations):**
- \`guides/agents-and-model-roles\` — 18 built-in agents, three-layer discovery, six model roles, \`/tf init\`, custom agents & overrides
- \`guides/claude-code\` — plugin install, MCP verify, permission mapping (\`bypassPermissions\`/\`allowedTools\`), long-running flows, tool reference
- \`guides/opencode\` — MCP server registration (CLI + opencode.json), permission policy injection, model id resolution rules, tool reference
- \`guides/background-runs\` — detached execution, stale PID detection, auto-reject approvals
- \`reference/incremental-recompute\` — FlowIR compilation, observed read-sets, stale-frontier detection, minimal recompute with early cutoff
- \`syntax/scorers\` — six deterministic scorer types, combine modes (all/any/weighted), judge fallback, fail-open semantics

**Fixes:**
- M6: renamed \`concepts/phases\` title from "Phase Types" → "Phases" (en) / "阶段类型" → "阶段" (zh-cn) to disambiguate from \`syntax/phase-types\` (the reference page) — eliminates duplicate sidebar titles
- Fixed broken \`/en/docs/syntax/contracts\` link in scorers → \`flow-definition\` (which documents \`expect\`)

## Verification
- \`npm run typecheck\` passes
- i18n parity: en and zh-cn MDX file trees are identical; both meta.json files have matching page entries
- No broken internal Card hrefs (verified via script)
- All host-guide facts sourced from engine \`docs/claude-mcp.md\` and \`docs/opencode-mcp.md\`; agent facts sourced from \`packages/taskflow-core/src/agents.ts\`

## Notes
- Local build (\`npm run build\`) fails due to \`next/font/google\` network access; CI handles the build. Typecheck used locally per project convention.
- Squash merge requested.