### PR TITLE
fix(website): split npm ci from postinstall to avoid npm crash

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -42,7 +42,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: website
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Generate MDX source
+        working-directory: website
+        run: npm run prepare-source
 
       - name: Build
         working-directory: website


### PR DESCRIPTION
Follow-up to #45. The first `deploy-website` run after the pnpm-migration fix failed:

```
npm error Exit handler never called!
npm error This is an error with npm itself.
```

during `npm ci` (8 minutes, no output, then an internal npm crash — likely the `postinstall: fumadocs-mdx` handler tripping npm's exit machinery).

## Fix

Split the install into three visible steps so a crash is diagnosable and npm's postinstall handler is bypassed:

| Step | Command |
|---|---|
| Install dependencies | `npm ci --ignore-scripts` |
| Generate MDX source | `npm run prepare-source` (`fumadocs-mdx`, ~10ms) |
| Build | `npm run build` (`next build`) |

## Verified locally

`npm ci --ignore-scripts` + `npm run prepare-source` + `TASKFLOW_BASE_PATH=/taskflow npm run build` all succeed; the build emits static HTML for en + zh-cn.