### PR TITLE
fix(website): retry npm ci to dodge 'Exit handler never called!' crash

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -42,7 +42,21 @@ jobs:
 
       - name: Install dependencies
         working-directory: website
-        run: npm ci --ignore-scripts
+        run: |
+          # npm ci intermittently crashes with "Exit handler never called!"
+          # (a known npm bug under runner memory pressure). Retry up to 3 times,
+          # falling back to `npm install` which is more tolerant of lockfile
+          # state. --ignore-scripts avoids running postinstall (prepare-source
+          # runs the build steps explicitly below).
+          for i in 1 2 3; do
+            if npm ci --ignore-scripts; then break; fi
+            echo "npm ci attempt $i failed; retrying in 10s…"
+            sleep 10
+            if [ "$i" = "3" ]; then
+              echo "npm ci failed 3 times; falling back to npm install"
+              npm install --ignore-scripts
+            fi
+          done
 
       - name: Generate MDX source
         working-directory: website


### PR DESCRIPTION
## Problem

The Deploy Website workflow has failed twice in a row with:

```
npm error Exit handler never called!
npm error This is an error with npm itself.
```

This is a known npm bug triggered under GitHub Actions runner memory pressure — `npm ci` downloads for ~8 minutes then segfaults. It is infrastructure-level, not content-level (the docs PR #46 itself passed all checks).

## Fix

Wrap the `npm ci` step in a retry loop (3 attempts with 10s backoff), falling back to `npm install` on final failure (more tolerant of lockfile state). `--ignore-scripts` is preserved so postinstall doesn't run.

This is a minimal, self-contained infra fix — no content changes.

## Verification

- YAML is valid
- Logic: attempt ci → on fail retry → on 3rd fail use `npm install`
