### PR TITLE
fix(website): hero code-window no longer overlaps CTA buttons

### DIFF
--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -692,7 +692,7 @@ export default async function HomePage({
 						</a>
 					</div>
 
-					<div className="animate-fade-in animate-fade-in-delay-3 relative z-10 -mt-6 w-full max-w-3xl md:-mt-12">
+					<div className="animate-fade-in animate-fade-in-delay-3 relative z-10 mt-10 w-full max-w-3xl md:mt-14">
 						<figure
 							className="code-window relative w-full overflow-hidden rounded-2xl glass gradient-border"
 							aria-label={t.code.label}


### PR DESCRIPTION
Reported via screenshot: the "Get Started" button was nearly invisible, hidden behind the hero code-preview window.

## Root cause

The `review-changes.json` code preview under the hero CTA row used a negative top margin (`-mt-6` mobile / `md:-mt-12` desktop) to tuck it under the buttons. Because the figure has `position: relative` + `z-10`, it stacks **above** the statically-positioned button row — so instead of subtly peeking behind the buttons, it fully covered them.

At common viewports (768 tablet, 1440 desktop, and even 390 mobile once the row wraps to two lines) the code window's title bar sat directly on top of "Get Started" / "What is taskflow?" / "GitHub", making them barely legible through the glass blur and covering their click targets.

## Fix

Replaced the negative overlap with a plain positive gap (`mt-10` / `md:mt-14`), consistent with the rest of the hero's vertical rhythm (`mt-7`, `mt-10`, `mt-12` elsewhere in the same section).

## Verification

Ran the dev server locally and captured Playwright screenshots before/after at three viewports, both locales:

- 1440×900 (desktop, en) — before: buttons hidden → after: fully visible
- 768×1024 (tablet, en) — after: clean
- 390×844 (mobile, en) — before: "What is taskflow?"/"GitHub" hidden → after: fully visible
- 1440×900 (zh-cn) — clean

`pnpm run build` (Turbopack, 86/86 static pages) still passes.