### PR TITLE
fix(release): bump codex/claude plugin.json manifests to 0.1.7

### DIFF
--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",


### PR DESCRIPTION
## What & why

The `v0.1.7` tag's `publish.yml` run failed its version-consistency gate: the codex `.codex-plugin/plugin.json` and claude `.claude-plugin/plugin.json` **manifests** were still pinned at `0.1.6`. The release-prep commit bumped the `.mcp.json` npx pins (caught by the cross-adversarial review) but missed these sibling manifests.

The tag was re-pointed at this fix and **0.1.7 is already published to npm + GitHub Release** (all 7 packages). This PR lands the fix on `main` so the default branch matches the published tag.

## Checklist
- [x] All 7 packages + root + both plugin.json manifests + all 3 plugin pins = 0.1.7
- [x] npm publish succeeded (publish.yml run 28934205400)
- [x] GitHub Release v0.1.7 created

No code change beyond the two manifest version fields.