### PR TITLE
release: v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to taskflow are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [0.1.8] — 2026-07-09
+
+### Fixed
+- **`cwd` no longer accepts interpolation placeholders.** A phase's `cwd` field
+  is a literal path / reserved workspace keyword (`temp` / `dedicated` /
+  `worktree`), not an interpolated one — but the validator silently accepted
+  values like `cwd: "{args.workspace}"`, which would then resolve to a literal
+  directory named `{args.workspace}` at run time (or, worse, be exploitable as
+  a path-injection vector). `validateTaskflow()` now rejects any `cwd` value
+  matching a `{placeholder}` pattern with a clear error pointing at the
+  reserved keywords. (#65)
+
+### Changed
+- **Dependency sweep** (no runtime-API changes — these are CI / dev / website
+  dependencies; the published packages' runtime surface is unchanged):
+  - `pnpm/action-setup` 4 → 6 (#57).
+  - Batched the remaining Dependabot PRs that were stuck behind CI /
+    workflow-scope gates (#66): GitHub Actions `actions/checkout` v4 → v7,
+    `actions/upload-pages-artifact` v3 → v5, `actions/deploy-pages` v4 → v5;
+    dev deps `typescript` ^6 → ^7, `@types/node` ^22 → ^26, `typebox` ^1.3.3 →
+    ^1.3.6, `@biomejs/biome` 2.5.2 → 2.5.3; website deps `fumadocs-core/ui`
+    16.10.7 → 16.11.1, `fumadocs-mdx` 15.0.13 → 15.1.0. Local typecheck + the
+    full 1160-test unit suite remain green.
+
 ## [0.1.7] — 2026-07-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow-monorepo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Monorepo for taskflow-core, taskflow-mcp-core, taskflow-hosts, pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, and the documentation website.",
   "type": "module",

--- a/packages/claude-taskflow/package.json
+++ b/packages/claude-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-taskflow",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Run taskflow on Claude Code: a Claude subagent runner plus an MCP server (and a plug-and-play Claude Code plugin) that exposes the taskflow_* tools to Claude Code users.",
   "keywords": [
     "claude",
@@ -54,8 +54,8 @@
     "access": "public"
   },
   "dependencies": {
-    "taskflow-core": "0.1.7",
-    "taskflow-hosts": "0.1.7",
-    "taskflow-mcp-core": "0.1.7"
+    "taskflow-core": "0.1.8",
+    "taskflow-hosts": "0.1.8",
+    "taskflow-mcp-core": "0.1.8"
   }
 }

--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/claude-taskflow/plugin/.mcp.json
+++ b/packages/claude-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "claude-taskflow@0.1.7", "claude-taskflow-mcp"]
+      "args": ["-y", "-p", "claude-taskflow@0.1.8", "claude-taskflow-mcp"]
     }
   }
 }

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskflow",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Run taskflow on OpenAI Codex: a Codex subagent runner plus an MCP server (and a plug-and-play Codex plugin) that exposes the taskflow_* tools to Codex users.",
   "keywords": [
     "codex",
@@ -54,8 +54,8 @@
     "access": "public"
   },
   "dependencies": {
-    "taskflow-core": "0.1.7",
-    "taskflow-hosts": "0.1.7",
-    "taskflow-mcp-core": "0.1.7"
+    "taskflow-core": "0.1.8",
+    "taskflow-hosts": "0.1.8",
+    "taskflow-mcp-core": "0.1.8"
   }
 }

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.1.7", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.1.8", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/opencode-taskflow/package.json
+++ b/packages/opencode-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-taskflow",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Run taskflow on OpenCode: an OpenCode subagent runner plus an MCP server (and an opencode.json config scaffold) that exposes the taskflow_* tools to OpenCode users.",
   "keywords": [
     "opencode",
@@ -53,8 +53,8 @@
     "access": "public"
   },
   "dependencies": {
-    "taskflow-core": "0.1.7",
-    "taskflow-hosts": "0.1.7",
-    "taskflow-mcp-core": "0.1.7"
+    "taskflow-core": "0.1.8",
+    "taskflow-hosts": "0.1.8",
+    "taskflow-mcp-core": "0.1.8"
   }
 }

--- a/packages/opencode-taskflow/plugin/opencode.json
+++ b/packages/opencode-taskflow/plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "taskflow": {
       "type": "local",
-      "command": ["npx", "-y", "-p", "opencode-taskflow@0.1.7", "opencode-taskflow-mcp"],
+      "command": ["npx", "-y", "-p", "opencode-taskflow@0.1.8", "opencode-taskflow-mcp"],
       "enabled": true
     }
   },

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
   "keywords": [
     "pi-package",
@@ -53,7 +53,7 @@
     "image": "https://raw.githubusercontent.com/heggria/taskflow/main/assets/social-preview.png"
   },
   "dependencies": {
-    "taskflow-core": "0.1.7"
+    "taskflow-core": "0.1.8"
   },
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow, codex-taskflow, claude-taskflow, and opencode-taskflow.",
   "keywords": [
     "taskflow",

--- a/packages/taskflow-hosts/package.json
+++ b/packages/taskflow-hosts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-hosts",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Shared host-runner collection for taskflow — the codex, claude, and opencode SubagentRunner implementations + their argv builders and event-stream parsers. The per-host MCP servers, plugin scaffolds, and bins live in codex-taskflow / claude-taskflow / opencode-taskflow; this package holds just the runners so a new host can be added in one place.",
   "homepage": "https://github.com/heggria/taskflow#readme",
   "type": "module",
@@ -44,7 +44,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "taskflow-core": "0.1.7"
+    "taskflow-core": "0.1.8"
   },
   "devDependencies": {
     "typescript": "^7.0.2"

--- a/packages/taskflow-mcp-core/package.json
+++ b/packages/taskflow-mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-mcp-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Host-neutral MCP server for taskflow: a dependency-free stdio JSON-RPC server exposing the taskflow_* tools, plus the DAG SVG/outline renderer. Shared by the codex/claude/opencode adapters — depends only on taskflow-core.",
   "keywords": [
     "taskflow",
@@ -60,6 +60,6 @@
     "access": "public"
   },
   "dependencies": {
-    "taskflow-core": "0.1.7"
+    "taskflow-core": "0.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,37 +36,37 @@ importers:
   packages/claude-taskflow:
     dependencies:
       taskflow-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-core
       taskflow-hosts:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-hosts
       taskflow-mcp-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-mcp-core
 
   packages/codex-taskflow:
     dependencies:
       taskflow-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-core
       taskflow-hosts:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-hosts
       taskflow-mcp-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-mcp-core
 
   packages/opencode-taskflow:
     dependencies:
       taskflow-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-core
       taskflow-hosts:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-hosts
       taskflow-mcp-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-mcp-core
 
   packages/pi-taskflow:
@@ -84,7 +84,7 @@ importers:
         specifier: '*'
         version: 0.80.3
       taskflow-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-core
       typebox:
         specifier: '*'
@@ -99,7 +99,7 @@ importers:
   packages/taskflow-hosts:
     dependencies:
       taskflow-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-core
     devDependencies:
       typescript:
@@ -109,7 +109,7 @@ importers:
   packages/taskflow-mcp-core:
     dependencies:
       taskflow-core:
-        specifier: 0.1.7
+        specifier: 0.1.8
         version: link:../taskflow-core
 
   website:


### PR DESCRIPTION
## Release v0.1.8

A small **patch release**. No engine API changes — the runtime surface is unchanged.

### What ships

- **`fix(schema)`: `cwd` no longer accepts interpolation placeholders (#65).** The validator silently accepted `cwd: "{args.workspace}"`, which resolved to a literal directory named `{args.workspace}` at run time (and was a path-injection vector). `validateTaskflow()` now rejects any `{placeholder}` in `cwd` with a clear error pointing at the reserved keywords (`temp` / `dedicated` / `worktree`).
- **Dependency sweep (#57, #66)** — CI / dev / website deps only:
  - `pnpm/action-setup` 4 → 6
  - GitHub Actions: `actions/checkout` v4 → v7, `upload-pages-artifact` v3 → v5, `deploy-pages` v4 → v5
  - dev: `typescript` ^6 → ^7, `@types/node` ^22 → ^26, `typebox` ^1.3.3 → ^1.3.6, `@biomejs/biome` 2.5.2 → 2.5.3
  - website: `fumadocs-core/ui` 16.10.7 → 16.11.1, `fumadocs-mdx` 15.0.13 → 15.1.0

### Release prep

- All seven packages + root → `0.1.8` (lockstep)
- `taskflow-core` / `taskflow-hosts` / `taskflow-mcp-core` dependency pins → `0.1.8`
- codex/claude/opencode plugin manifests (`.mcp.json` npx pins + `plugin.json` versions) → `0.1.8`
- Added `## [0.1.8]` CHANGELOG section

### Pre-flight ✅

- typecheck: 0 errors
- unit tests: 1160 / 1160 green
- build: 7 packages OK
- skills drift-guard: green

> After merge, tag `v0.1.8` triggers `.github/workflows/publish.yml` (publishes core → mcp-core → hosts → pi/codex/claude/opencode in order).
