### PR TITLE
feat(agents): introduce four semantic model roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to taskflow are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [0.2.5] — 2026-07-27
+
+### Changed
+
+- **Four responsibility-based model roles.** The built-in agent roster now uses `steward`, `expert`, `builder`, and `scout` instead of coupling workflow responsibilities to six model capability labels. The recommended OpenRouter bindings are Claude Fable 5 for long-horizon goal stewardship, Claude Opus 5 for deep specialist judgment, Claude Sonnet 5 for default implementation and review, and Claude Haiku 4.5 for fast reconnaissance and mechanically checkable work.
+- **Role ownership is separate from expertise and authority.** Planning/final synthesis use `steward`; analysis, critique, plan gates, risk, and security use `expert`; implementation, UI, review, testing, docs, and recovery use `builder`; discovery, trivial execution, and mechanical verification use `scout`. Tool permissions, phase side effects, gates, budgets, and approvals remain runtime/agent concerns rather than model-tier concerns.
+
+### Compatibility
+
+- **Existing 0.2.4 model-role settings remain valid.** The legacy `fast`, `strong`, `thinker`, `arbiter`, `vision`, and `reasoner` keys are preserved. Until a new semantic role is configured, each built-in agent falls back to the exact legacy key it used in 0.2.4; new keys always take precedence. User and project agents that still reference legacy keys continue to resolve them normally.
+
+### Documentation
+
+- Updated generated host skills plus English and Chinese agent/model-role guides for the four-role contract, current defaults, upgrade behavior, and model-neutral rebinding guidance.
+
 ## [0.2.4] — 2026-07-20
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,8 +81,8 @@ the matching annotated tag:
 ```sh
 git switch main
 git pull --ff-only origin main
-git tag -a v0.2.3 -m "Release v0.2.3"
-git push origin v0.2.3
+git tag -a v0.2.5 -m "Release v0.2.5"
+git push origin v0.2.5
 ```
 
 `.github/workflows/publish.yml` then performs the complete release transaction:
@@ -140,6 +140,6 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (published MCP package)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.3 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.5 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow-monorepo",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Monorepo for taskflow-core, taskflow-mcp-core, taskflow-hosts, taskflow-dsl, pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, grok-taskflow, and the documentation website.",
   "type": "module",

--- a/packages/claude-taskflow/package.json
+++ b/packages/claude-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Run taskflow on Claude Code: a Claude subagent runner plus an MCP server (and a plug-and-play Claude Code plugin) that exposes the taskflow_* tools to Claude Code users.",
   "keywords": [
     "claude",

--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/claude-taskflow/plugin/.mcp.json
+++ b/packages/claude-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "claude-taskflow@0.2.4", "claude-taskflow-mcp"]
+      "args": ["-y", "-p", "claude-taskflow@0.2.5", "claude-taskflow-mcp"]
     }
   }
 }

--- a/packages/claude-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/configuration.md
@@ -335,8 +335,10 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 ```jsonc
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "subagents": {
     "globalThinking": "medium"              // fallback thinking for all subagents
@@ -345,7 +347,11 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 }
 ```
 
-- `modelRoles` — maps `{{role}}` references in agent frontmatter to actual model identifiers.
+- `modelRoles` — maps the semantic `{{steward}}`, `{{expert}}`,
+  `{{builder}}`, and `{{scout}}` responsibilities in agent frontmatter to
+  concrete model identifiers. Legacy role keys from 0.2.4 remain valid for
+  custom agents and as exact built-in fallbacks until the corresponding new
+  role is configured.
 - `subagents.globalThinking` (or top-level `defaultThinkingLevel`) — global
   thinking fallback.
 

--- a/packages/claude-taskflow/test/mcp-server.test.ts
+++ b/packages/claude-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("claude mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-claude");
-	assert.equal(res.result.serverInfo.version, "0.2.4");
+	assert.equal(res.result.serverInfo.version, "0.2.5");
 });
 
 test("claude mcp: tools/list exposes the same taskflow tools as codex", async () => {

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Run taskflow on OpenAI Codex: a Codex subagent runner plus an MCP server (and a plug-and-play Codex plugin) that exposes the taskflow_* tools to Codex users.",
   "keywords": [
     "codex",

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.2.4", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.2.5", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
@@ -332,8 +332,10 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 ```jsonc
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "subagents": {
     "globalThinking": "medium"              // fallback thinking for all subagents
@@ -342,7 +344,11 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 }
 ```
 
-- `modelRoles` — maps `{{role}}` references in agent frontmatter to actual model identifiers.
+- `modelRoles` — maps the semantic `{{steward}}`, `{{expert}}`,
+  `{{builder}}`, and `{{scout}}` responsibilities in agent frontmatter to
+  concrete model identifiers. Legacy role keys from 0.2.4 remain valid for
+  custom agents and as exact built-in fallbacks until the corresponding new
+  role is configured.
 - `subagents.globalThinking` (or top-level `defaultThinkingLevel`) — global
   thinking fallback.
 

--- a/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
+++ b/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
@@ -79,7 +79,7 @@ send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "
 const init = await waitFor(1, "initialize");
 assert.equal(init.result.protocolVersion, "2025-06-18");
 assert.equal(init.result.serverInfo.name, "taskflow-codex");
-assert.equal(init.result.serverInfo.version, "0.2.4");
+assert.equal(init.result.serverInfo.version, "0.2.5");
 ok(`initialize → ${JSON.stringify(init.result.serverInfo)}`);
 
 // notification must NOT produce a response

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -51,7 +51,7 @@ test("mcp: initialize returns the protocol version + serverInfo codex expects", 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-codex");
-	assert.equal(res.result.serverInfo.version, "0.2.4");
+	assert.equal(res.result.serverInfo.version, "0.2.5");
 });
 
 test("mcp: tools/list exposes the taskflow tools with schemas", async () => {

--- a/packages/grok-taskflow/package.json
+++ b/packages/grok-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Run taskflow on Grok Build: a Grok subagent runner plus an MCP server (and a plug-and-play Grok plugin) that exposes the taskflow_* tools to Grok Build users.",
   "keywords": [
     "grok",

--- a/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
+++ b/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/grok-taskflow/plugin/.mcp.json
+++ b/packages/grok-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "grok-taskflow@0.2.4", "grok-taskflow-mcp"],
+      "args": ["-y", "-p", "grok-taskflow@0.2.5", "grok-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/grok-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/grok-taskflow/plugin/skills/taskflow/configuration.md
@@ -338,8 +338,10 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 ```jsonc
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "subagents": {
     "globalThinking": "medium"              // fallback thinking for all subagents
@@ -348,7 +350,11 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 }
 ```
 
-- `modelRoles` — maps `{{role}}` references in agent frontmatter to actual model identifiers.
+- `modelRoles` — maps the semantic `{{steward}}`, `{{expert}}`,
+  `{{builder}}`, and `{{scout}}` responsibilities in agent frontmatter to
+  concrete model identifiers. Legacy role keys from 0.2.4 remain valid for
+  custom agents and as exact built-in fallbacks until the corresponding new
+  role is configured.
 - `subagents.globalThinking` (or top-level `defaultThinkingLevel`) — global
   thinking fallback.
 

--- a/packages/grok-taskflow/test/mcp-server.test.ts
+++ b/packages/grok-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("grok mcp: initialize returns the protocol version + serverInfo", async () 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-grok");
-	assert.equal(res.result.serverInfo.version, "0.2.4");
+	assert.equal(res.result.serverInfo.version, "0.2.5");
 });
 
 test("grok mcp: tools/list exposes the same taskflow tools as other hosts", async () => {

--- a/packages/opencode-taskflow/package.json
+++ b/packages/opencode-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Run taskflow on OpenCode: an OpenCode subagent runner plus an MCP server (and an opencode.json config scaffold) that exposes the taskflow_* tools to OpenCode users.",
   "keywords": [
     "opencode",

--- a/packages/opencode-taskflow/plugin/opencode.json
+++ b/packages/opencode-taskflow/plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "taskflow": {
       "type": "local",
-      "command": ["npx", "-y", "-p", "opencode-taskflow@0.2.4", "opencode-taskflow-mcp"],
+      "command": ["npx", "-y", "-p", "opencode-taskflow@0.2.5", "opencode-taskflow-mcp"],
       "enabled": true
     }
   },

--- a/packages/opencode-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/configuration.md
@@ -332,8 +332,10 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 ```jsonc
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "subagents": {
     "globalThinking": "medium"              // fallback thinking for all subagents
@@ -342,7 +344,11 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 }
 ```
 
-- `modelRoles` — maps `{{role}}` references in agent frontmatter to actual model identifiers.
+- `modelRoles` — maps the semantic `{{steward}}`, `{{expert}}`,
+  `{{builder}}`, and `{{scout}}` responsibilities in agent frontmatter to
+  concrete model identifiers. Legacy role keys from 0.2.4 remain valid for
+  custom agents and as exact built-in fallbacks until the corresponding new
+  role is configured.
 - `subagents.globalThinking` (or top-level `defaultThinkingLevel`) — global
   thinking fallback.
 

--- a/packages/opencode-taskflow/test/mcp-server.test.ts
+++ b/packages/opencode-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("opencode mcp: initialize returns the protocol version + serverInfo", async
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-opencode");
-	assert.equal(res.result.serverInfo.version, "0.2.4");
+	assert.equal(res.result.serverInfo.version, "0.2.5");
 });
 
 test("opencode mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-taskflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
   "keywords": [
     "pi-package",

--- a/packages/pi-taskflow/skills/taskflow/advanced.md
+++ b/packages/pi-taskflow/skills/taskflow/advanced.md
@@ -385,7 +385,8 @@ taskflow { action: "version" }
 
 ## `init` — model roles setup
 
-`action: "init"` manages the `modelRoles` map (`{{fast}}` / `{{strong}}` / …
+`action: "init"` manages the `modelRoles` map (`{{steward}}` /
+`{{expert}}` / `{{builder}}` / `{{scout}}`
 placeholders in agent frontmatter → real model ids):
 
 - `mode: "show"` (default) — read-only report of current roles.
@@ -393,5 +394,5 @@ placeholders in agent frontmatter → real model ids):
   `force: true`** (destructive: overwrites `modelRoles` in settings.json).
 - `mode: "interactive"` — requires a UI session (`/tf init` is the human path).
 
-If phases fail with `Model metadata for {{fast}} not found`, roles are
+If phases fail with `Model metadata for {{scout}} not found`, roles are
 unconfigured — run `/tf init`.

--- a/packages/pi-taskflow/skills/taskflow/configuration.md
+++ b/packages/pi-taskflow/skills/taskflow/configuration.md
@@ -326,8 +326,10 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 ```jsonc
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "subagents": {
     "globalThinking": "medium"              // fallback thinking for all subagents
@@ -343,7 +345,11 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 }
 ```
 
-- `modelRoles` — maps `{{role}}` references in agent frontmatter to actual model identifiers.
+- `modelRoles` — maps the semantic `{{steward}}`, `{{expert}}`,
+  `{{builder}}`, and `{{scout}}` responsibilities in agent frontmatter to
+  concrete model identifiers. Legacy role keys from 0.2.4 remain valid for
+  custom agents and as exact built-in fallbacks until the corresponding new
+  role is configured.
 - `subagents.globalThinking` (or top-level `defaultThinkingLevel`) — global
   thinking fallback.
 - `taskflow.piChild.resourceProfile` is a **Host authority**, never a Flow DSL

--- a/packages/pi-taskflow/src/init.ts
+++ b/packages/pi-taskflow/src/init.ts
@@ -38,47 +38,31 @@ export interface InitRole {
 
 export const INIT_ROLES: readonly InitRole[] = [
 	{
-		role: "fast",
+		role: "steward",
 		description:
-			"Cheap & quick — high-volume, low-stakes tasks (executor, scout, recover, verifier, doc-writer, test-engineer)",
-		defaultModel: "openrouter/deepseek/deepseek-v4-flash",
-	},
-	{
-		role: "strong",
-		description:
-			"Balanced — planning, review, moderate complexity (planner, reviewer, executor-code)",
-		defaultModel: "openrouter/xiaomi/mimo-v2.5-pro",
-	},
-	{
-		role: "thinker",
-		description:
-			"Deep analysis — requirements, ambiguity detection, critique (analyst, critic)",
-		defaultModel: "openrouter/deepseek/deepseek-v4-pro",
+			"Goal stewardship — long-horizon planning, cross-phase coherence, final synthesis (planner, final-arbiter)",
+		defaultModel: "openrouter/anthropic/claude-fable-5",
 		preferReasoning: true,
-		sort: (a, b) => (a.reasoning === b.reasoning ? 0 : a.reasoning ? -1 : 1),
 	},
 	{
-		role: "arbiter",
+		role: "expert",
 		description:
-			"Final judgment — tiebreak, plan quality gates (plan-arbiter, final-arbiter)",
-		defaultModel: "openrouter/qwen/qwen3.7-max",
+			"Deep specialist judgment — analysis, critique, risk, security, plan gates (analyst, critic, plan-arbiter, risk-reviewer, security-reviewer)",
+		defaultModel: "openrouter/anthropic/claude-opus-5",
 		preferReasoning: true,
-		sort: (a, b) => (a.reasoning === b.reasoning ? 0 : a.reasoning ? -1 : 1),
 	},
 	{
-		role: "vision",
+		role: "builder",
 		description:
-			"Multimodal — UI work, design reading, Figma analysis (executor-ui, visual-explorer)",
-		defaultModel: "minimax/MiniMax-M3",
-		filter: (m) => m.input.includes("image"),
-	},
-	{
-		role: "reasoner",
-		description:
-			"Cautious reasoning — security, risk review, sensitive changes (risk-reviewer, security-reviewer)",
-		defaultModel: "z-ai/glm-5.1",
+			"Versatile default — implementation, UI, review, tests, docs, recovery (executor, executor-code, executor-ui, reviewer, test-engineer, doc-writer, visual-explorer, recover)",
+		defaultModel: "openrouter/anthropic/claude-sonnet-5",
 		preferReasoning: true,
-		sort: (a, b) => (a.reasoning === b.reasoning ? 0 : a.reasoning ? -1 : 1),
+	},
+	{
+		role: "scout",
+		description:
+			"Fast reconnaissance — discovery, extraction, classification, mechanical verification (scout, executor-fast, verifier)",
+		defaultModel: "openrouter/anthropic/claude-haiku-4.5",
 	},
 ];
 

--- a/packages/pi-taskflow/test/init.test.ts
+++ b/packages/pi-taskflow/test/init.test.ts
@@ -140,6 +140,18 @@ test("INIT_ROLES: every role has non-empty description AND non-empty defaultMode
 	}
 });
 
+test("INIT_ROLES: exposes four semantic roles with pinned Claude defaults", () => {
+	assert.deepEqual(
+		INIT_ROLES.map(({ role, defaultModel }) => ({ role, defaultModel })),
+		[
+			{ role: "steward", defaultModel: "openrouter/anthropic/claude-fable-5" },
+			{ role: "expert", defaultModel: "openrouter/anthropic/claude-opus-5" },
+			{ role: "builder", defaultModel: "openrouter/anthropic/claude-sonnet-5" },
+			{ role: "scout", defaultModel: "openrouter/anthropic/claude-haiku-4.5" },
+		],
+	);
+});
+
 // ---------------------------------------------------------------------------
 // RECOMMENDED_DEFAULTS
 // ---------------------------------------------------------------------------
@@ -249,20 +261,16 @@ test("buildRoleOptions: includes separator, Custom, and Back entries", () => {
 	assert.ok(options.includes("Back to action menu"), "Back");
 });
 
-test("buildRoleOptions: vision role filters out text-only models", () => {
-	const visionRole = INIT_ROLES.find((r) => r.role === "vision")!;
-	const options = buildRoleOptions(visionRole, sampleModels, {});
-	// DeepSeek V4 Flash and V4 Pro are text-only, should be filtered
-	assert.ok(!options.some((o) => o.includes("v4-flash")), "text-only v4-flash filtered");
-	assert.ok(!options.some((o) => o.includes("v4-pro")), "text-only v4-pro filtered");
-	// Claude Sonnet and MiniMax M3 should be present
-	assert.ok(options.some((o) => o.includes("claude-sonnet-4-6")), "image model present");
-	assert.ok(options.some((o) => o.includes("MiniMax-M3")), "image model present");
+test("buildRoleOptions: semantic roles do not hard-code modality filters", () => {
+	const builderRole = INIT_ROLES.find((r) => r.role === "builder")!;
+	const options = buildRoleOptions(builderRole, sampleModels, {});
+	assert.ok(options.some((o) => o.includes("v4-flash")), "text-only model remains configurable");
+	assert.ok(options.some((o) => o.includes("claude-sonnet-4-6")), "image model remains configurable");
 });
 
-test("buildRoleOptions: thinker role sorts reasoning=true models first", () => {
-	const thinkerRole = INIT_ROLES.find((r) => r.role === "thinker")!;
-	const options = buildRoleOptions(thinkerRole, sampleModels, {});
+test("buildRoleOptions: expert role sorts reasoning=true models first", () => {
+	const expertRole = INIT_ROLES.find((r) => r.role === "expert")!;
+	const options = buildRoleOptions(expertRole, sampleModels, {});
 	// The first real option (before separator) should be a reasoning model
 	const firstOption = options[0];
 	assert.ok(firstOption.includes("reasoning ✓"), `first option should be reasoning: ${firstOption}`);
@@ -566,11 +574,11 @@ test("formatRolesReport: populated current shows all roles", () => {
 // ---------------------------------------------------------------------------
 
 test("formatDiffReport: shows all diff statuses", () => {
-	const before: Record<string, string> = { fast: "a/b", stale: "x/y" };
-	const after: Record<string, string> = { fast: "a/b", strong: "new/model" };
+	const before: Record<string, string> = { steward: "a/b", stale: "x/y" };
+	const after: Record<string, string> = { steward: "a/b", expert: "new/model" };
 	// Fill other roles with same value
 	for (const r of INIT_ROLES) {
-		if (r.role !== "fast" && r.role !== "strong") {
+		if (r.role !== "steward" && r.role !== "expert") {
 			before[r.role] = r.defaultModel;
 			after[r.role] = r.defaultModel;
 		}
@@ -775,6 +783,7 @@ test("runInteractiveInit: Esc on custom input → falls back to current, not can
 test("runInteractiveInit: 'Use recommended defaults' with stale keys → preserves stale keys", async () => {
 	const current: Record<string, string> = {
 		fast: "openrouter/anthropic/claude-sonnet-4-6",
+		steward: "openrouter/anthropic/claude-opus-4.8",
 		"old-role-1": "openrouter/x/y", // stale (not in INIT_ROLES)
 	};
 	const ui = createMockUI(["Use recommended defaults"]);
@@ -790,8 +799,10 @@ test("runInteractiveInit: 'Use recommended defaults' with stale keys → preserv
 	if (result.kind === "saved") {
 		// Stale key preserved
 		assert.equal(result.chosen["old-role-1"], "openrouter/x/y");
-		// Existing role overridden by recommended default
-		assert.equal(result.chosen.fast, RECOMMENDED_DEFAULTS.fast);
+		// Legacy role keys are retained for custom agents and built-in fallback.
+		assert.equal(result.chosen.fast, "openrouter/anthropic/claude-sonnet-4-6");
+		// Existing current role is overridden by the recommended default.
+		assert.equal(result.chosen.steward, RECOMMENDED_DEFAULTS.steward);
 	}
 });
 

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, and grok-taskflow.",
   "keywords": [
     "taskflow",

--- a/packages/taskflow-core/src/agents.ts
+++ b/packages/taskflow-core/src/agents.ts
@@ -170,6 +170,8 @@ export interface AgentConfig {
 	description: string;
 	tools?: string[];
 	model?: string;
+	/** 0.2.4 role used only when the current semantic role is not configured. */
+	legacyModelRole?: string;
 	thinking?: string;
 	systemPrompt: string;
 	source: "user" | "project" | "built-in";
@@ -235,6 +237,9 @@ function loadAgentsFromDir(dir: string, source: "user" | "project" | "built-in")
 				description: String(frontmatter.description),
 				tools: tools && tools.length > 0 ? tools : undefined,
 				model: frontmatter.model === undefined ? undefined : String(frontmatter.model),
+				...(frontmatter["legacy-model-role"] === undefined
+					? {}
+					: { legacyModelRole: String(frontmatter["legacy-model-role"]) }),
 				thinking: frontmatter.thinking === undefined ? undefined : String(frontmatter.thinking),
 				systemPrompt: body,
 				source,
@@ -300,11 +305,15 @@ export function discoverAgents(
 		for (const a of projectAgents) agentMap.set(a.name, a);
 	}
 
-	// Resolve {{role}} model references (e.g. {{fast}} → openrouter/deepseek/v4-flash)
+	// Resolve {{role}} model references (e.g. {{builder}} → Claude Sonnet).
 	// Clone before mutating, consistent with the overrides block above.
 	if (modelRoles) {
 		for (const [name, agent] of agentMap.entries()) {
-			const resolved = resolveModelRole(agent.model, modelRoles);
+			const resolved = resolveModelRole(
+				agent.model,
+				modelRoles,
+				agent.legacyModelRole,
+			);
 			if (resolved !== agent.model) {
 				const mutated: AgentConfig = { ...agent };
 				mutated.model = resolved;
@@ -324,20 +333,31 @@ export interface SubagentSettings {
 
 /**
  * Resolve `{{roleName}}` model references against a role→model mapping.
- * E.g. `{{fast}}` → `openrouter/deepseek/deepseek-v4-flash` if modelRoles.fast is set.
- * Returns undefined if the value is not a role reference or the role is unmapped.
- */
-/**
- * Resolve `{{roleName}}` model references against a role→model mapping.
- * E.g. `{{fast}}` → `openrouter/deepseek/deepseek-v4-flash` if modelRoles.fast is set.
+ * E.g. `{{builder}}` → `openrouter/anthropic/claude-sonnet-5`.
+ *
+ * Built-in agents renamed their six capability-specific roles to four semantic
+ * responsibilities in 0.2.5. If a user has not run `/tf init` since upgrading,
+ * fall back to the exact legacy role carried in the agent's migration metadata.
+ * New role keys always win. Synced built-in copies retain the metadata, while
+ * ordinary user/project agents keep exact-key resolution unless they opt in.
+ *
  * Returns undefined if the value is not a role reference or the role is unmapped.
  * @internal
  */
-function resolveModelRole(model: string | undefined, roles?: Record<string, string>): string | undefined {
+function resolveModelRole(
+	model: string | undefined,
+	roles?: Record<string, string>,
+	legacyModelRole?: string,
+): string | undefined {
 	if (!model || !roles) return model;
 	const match = model.match(/^\{\{(\w+)\}\}$/);
 	if (!match) return model;
-	return roles[match[1]] ?? undefined;
+	const role = match[1];
+	const direct = roles[role];
+	if (direct !== undefined) return direct;
+
+	if (legacyModelRole) return roles[legacyModelRole] ?? undefined;
+	return undefined;
 }
 
 /** Read subagent overrides from ~/.pi/agent/settings.json (shared with the subagent extension). */

--- a/packages/taskflow-core/src/agents/analyst.md
+++ b/packages/taskflow-core/src/agents/analyst.md
@@ -2,7 +2,8 @@
 name: analyst
 description: Analyze requirements, ambiguity, and hidden constraints
 tools: read, grep, find, ls, bash
-model: "{{thinker}}"
+model: "{{expert}}"
+legacy-model-role: thinker
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/critic.md
+++ b/packages/taskflow-core/src/agents/critic.md
@@ -2,7 +2,8 @@
 name: critic
 description: Challenges planner and main-agent conclusions before risky decisions
 tools: read, grep, find, ls
-model: "{{thinker}}"
+model: "{{expert}}"
+legacy-model-role: thinker
 thinking: xhigh
 ---
 

--- a/packages/taskflow-core/src/agents/doc-writer.md
+++ b/packages/taskflow-core/src/agents/doc-writer.md
@@ -2,7 +2,8 @@
 name: doc-writer
 description: Author and edit documentation FILES on disk (README, guides, changelogs, docs)
 tools: read, grep, find, ls, bash, edit, write
-model: "{{fast}}"
+model: "{{builder}}"
+legacy-model-role: fast
 thinking: off
 ---
 

--- a/packages/taskflow-core/src/agents/executor-code.md
+++ b/packages/taskflow-core/src/agents/executor-code.md
@@ -2,7 +2,8 @@
 name: executor-code
 description: Full-capability code executor for complex multi-file changes
 tools: read, grep, find, ls, bash, edit, write
-model: "{{strong}}"
+model: "{{builder}}"
+legacy-model-role: strong
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/executor-fast.md
+++ b/packages/taskflow-core/src/agents/executor-fast.md
@@ -2,7 +2,8 @@
 name: executor-fast
 description: Fast executor for scanning, command runs, summaries, and low-risk small edits
 tools: read, grep, find, ls, bash, edit, write
-model: "{{fast}}"
+model: "{{scout}}"
+legacy-model-role: fast
 thinking: off
 ---
 

--- a/packages/taskflow-core/src/agents/executor-ui.md
+++ b/packages/taskflow-core/src/agents/executor-ui.md
@@ -2,7 +2,8 @@
 name: executor-ui
 description: UI-focused executor for frontend component, layout, and styling changes
 tools: read, grep, find, ls, bash, edit, write
-model: "{{vision}}"
+model: "{{builder}}"
+legacy-model-role: vision
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/executor.md
+++ b/packages/taskflow-core/src/agents/executor.md
@@ -2,7 +2,8 @@
 name: executor
 description: Implement planned code changes
 tools: read, grep, find, ls, bash, edit, write
-model: "{{fast}}"
+model: "{{builder}}"
+legacy-model-role: fast
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/final-arbiter.md
+++ b/packages/taskflow-core/src/agents/final-arbiter.md
@@ -2,7 +2,8 @@
 name: final-arbiter
 description: Makes final decisions when multiple plans, critiques, or reviews conflict
 tools: read, grep, find, ls
-model: "{{arbiter}}"
+model: "{{steward}}"
+legacy-model-role: arbiter
 thinking: xhigh
 ---
 

--- a/packages/taskflow-core/src/agents/plan-arbiter.md
+++ b/packages/taskflow-core/src/agents/plan-arbiter.md
@@ -2,7 +2,8 @@
 name: plan-arbiter
 description: Reviews and challenges implementation plans before execution on complex tasks
 tools: read, grep, find, ls
-model: "{{arbiter}}"
+model: "{{expert}}"
+legacy-model-role: arbiter
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/planner.md
+++ b/packages/taskflow-core/src/agents/planner.md
@@ -2,7 +2,8 @@
 name: planner
 description: Creates concrete implementation plans, risk analysis, and acceptance criteria without editing files
 tools: read, grep, find, ls
-model: "{{strong}}"
+model: "{{steward}}"
+legacy-model-role: strong
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/recover.md
+++ b/packages/taskflow-core/src/agents/recover.md
@@ -2,7 +2,8 @@
 name: recover
 description: Continue from a compact handoff — finds latest SESSION_STATE_*.md and HANDOFF_*.md in .agent/, then acts on Next Actions
 tools: read, grep, find, ls, bash, edit, write
-model: "{{fast}}"
+model: "{{builder}}"
+legacy-model-role: fast
 thinking: low
 ---
 

--- a/packages/taskflow-core/src/agents/reviewer.md
+++ b/packages/taskflow-core/src/agents/reviewer.md
@@ -2,7 +2,8 @@
 name: reviewer
 description: Reviews code, plans, architecture risk, and test gaps without editing files
 tools: read, grep, find, ls, bash
-model: "{{strong}}"
+model: "{{builder}}"
+legacy-model-role: strong
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/risk-reviewer.md
+++ b/packages/taskflow-core/src/agents/risk-reviewer.md
@@ -2,7 +2,8 @@
 name: risk-reviewer
 description: Engineering risk review for backend, data, and infrastructure changes
 tools: read, grep, find, ls, bash
-model: "{{reasoner}}"
+model: "{{expert}}"
+legacy-model-role: reasoner
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/scout.md
+++ b/packages/taskflow-core/src/agents/scout.md
@@ -2,7 +2,8 @@
 name: scout
 description: Fast codebase recon that returns compressed context for handoff to other agents
 tools: read, grep, find, ls, bash
-model: "{{fast}}"
+model: "{{scout}}"
+legacy-model-role: fast
 thinking: off
 ---
 

--- a/packages/taskflow-core/src/agents/security-reviewer.md
+++ b/packages/taskflow-core/src/agents/security-reviewer.md
@@ -2,7 +2,8 @@
 name: security-reviewer
 description: Review changes for security vulnerabilities and trust-boundary issues
 tools: read, grep, find, ls, bash
-model: "{{reasoner}}"
+model: "{{expert}}"
+legacy-model-role: reasoner
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/test-engineer.md
+++ b/packages/taskflow-core/src/agents/test-engineer.md
@@ -2,7 +2,8 @@
 name: test-engineer
 description: Design and implement test strategy for a change
 tools: read, grep, find, ls, bash, edit, write
-model: "{{fast}}"
+model: "{{builder}}"
+legacy-model-role: fast
 thinking: high
 ---
 

--- a/packages/taskflow-core/src/agents/verifier.md
+++ b/packages/taskflow-core/src/agents/verifier.md
@@ -2,7 +2,8 @@
 name: verifier
 description: Runs validation commands, reproduces failures, and checks logs without editing files
 tools: read, grep, find, ls, bash
-model: "{{fast}}"
+model: "{{scout}}"
+legacy-model-role: fast
 thinking: off
 ---
 

--- a/packages/taskflow-core/src/agents/visual-explorer.md
+++ b/packages/taskflow-core/src/agents/visual-explorer.md
@@ -2,7 +2,8 @@
 name: visual-explorer
 description: Analyzes Figma design metadata, tokens, and specs from text-based context
 tools: read, grep, find, ls
-model: "{{vision}}"
+model: "{{builder}}"
+legacy-model-role: vision
 thinking: high
 ---
 

--- a/packages/taskflow-core/test/agents.test.ts
+++ b/packages/taskflow-core/test/agents.test.ts
@@ -30,7 +30,14 @@ function makeTmpDir(prefix = "agents-test-"): string {
 function writeAgent(
 	dir: string,
 	filename: string,
-	fields: { name?: string; description?: string; model?: string; thinking?: string; tools?: string },
+	fields: {
+		name?: string;
+		description?: string;
+		model?: string;
+		"legacy-model-role"?: string;
+		thinking?: string;
+		tools?: string;
+	},
 	body = "",
 ): string {
 	fs.mkdirSync(dir, { recursive: true });
@@ -644,19 +651,100 @@ test("F-001: defense-in-depth — exotic frontmatter shapes do not abort discove
 
 test("modelRoles: resolves {{role}} references from settings", () => {
 	const agentsDir = path.join(userAgentDir, "agents");
-	writeAgent(agentsDir, "fast.md", { name: "fast-agent", description: "fast", model: "{{fast}}" });
-	writeAgent(agentsDir, "strong.md", { name: "strong-agent", description: "strong", model: "{{strong}}" });
+	writeAgent(agentsDir, "scout.md", { name: "scout-agent", description: "scout", model: "{{scout}}" });
+	writeAgent(agentsDir, "builder.md", { name: "builder-agent", description: "builder", model: "{{builder}}" });
 	writeAgent(agentsDir, "literal.md", { name: "literal-agent", description: "literal", model: "openai/gpt-4o" });
 	writeAgent(agentsDir, "nomodel.md", { name: "nomodel-agent", description: "no model" });
 
-	const roles = { fast: "openrouter/deepseek/v4-flash", strong: "anthropic/claude-sonnet-4-20250514" };
+	const roles = {
+		scout: "openrouter/anthropic/claude-haiku-4.5",
+		builder: "openrouter/anthropic/claude-sonnet-5",
+	};
 	const { agents } = discoverAgents(projectCwd, "user", roles);
 
 	const byName = Object.fromEntries(agents.map(a => [a.name, a.model]));
-	assert.equal(byName["fast-agent"], "openrouter/deepseek/v4-flash");
-	assert.equal(byName["strong-agent"], "anthropic/claude-sonnet-4-20250514");
+	assert.equal(byName["scout-agent"], "openrouter/anthropic/claude-haiku-4.5");
+	assert.equal(byName["builder-agent"], "openrouter/anthropic/claude-sonnet-5");
 	assert.equal(byName["literal-agent"], "openai/gpt-4o");
 	assert.equal(byName["nomodel-agent"], undefined);
+});
+
+test("modelRoles: built-ins fall back to their exact 0.2.4 role mappings", () => {
+	const builtInDir = path.join(tmpRoot, "built-ins");
+	process.env[BUILTIN_DIR_ENV] = builtInDir;
+	const cases = [
+		["analyst", "expert", "thinker", "legacy-thinker"],
+		["plan-arbiter", "expert", "arbiter", "legacy-arbiter"],
+		["risk-reviewer", "expert", "reasoner", "legacy-reasoner"],
+		["executor-ui", "builder", "vision", "legacy-vision"],
+		["executor-code", "builder", "strong", "legacy-strong"],
+		["executor", "builder", "fast", "legacy-fast"],
+		["planner", "steward", "strong", "legacy-strong"],
+		["final-arbiter", "steward", "arbiter", "legacy-arbiter"],
+		["scout", "scout", "fast", "legacy-fast"],
+	] as const;
+	for (const [name, role, legacyRole] of cases) {
+		writeAgent(builtInDir, `${name}.md`, {
+			name,
+			description: name,
+			model: `{{${role}}}`,
+			"legacy-model-role": legacyRole,
+		});
+	}
+
+	const { agents } = discoverAgents(projectCwd, "user", {
+		fast: "legacy-fast",
+		strong: "legacy-strong",
+		thinker: "legacy-thinker",
+		arbiter: "legacy-arbiter",
+		vision: "legacy-vision",
+		reasoner: "legacy-reasoner",
+	});
+	const byName = Object.fromEntries(agents.map((agent) => [agent.name, agent.model]));
+	for (const [name, , , expected] of cases) assert.equal(byName[name], expected, name);
+});
+
+test("modelRoles: current semantic role wins over a built-in legacy fallback", () => {
+	const builtInDir = path.join(tmpRoot, "built-ins");
+	process.env[BUILTIN_DIR_ENV] = builtInDir;
+	writeAgent(builtInDir, "analyst.md", {
+		name: "analyst",
+		description: "built-in analyst",
+		model: "{{expert}}",
+		"legacy-model-role": "thinker",
+	});
+
+	const { agents } = discoverAgents(projectCwd, "user", {
+		expert: "current-opus",
+		thinker: "legacy-thinker",
+	});
+	assert.equal(agents[0].model, "current-opus");
+});
+
+test("modelRoles: a synced project copy retains its explicit legacy fallback", () => {
+	const projectAgentsDir = path.join(projectCwd, ".pi", "agents");
+	writeAgent(projectAgentsDir, "executor.md", {
+		name: "executor",
+		description: "synced executor",
+		model: "{{builder}}",
+		"legacy-model-role": "fast",
+	});
+
+	const { agents } = discoverAgents(projectCwd, "project", { fast: "legacy-fast" });
+	assert.equal(agents[0].source, "project");
+	assert.equal(agents[0].model, "legacy-fast");
+});
+
+test("modelRoles: user overrides never inherit a built-in legacy fallback", () => {
+	const agentsDir = path.join(userAgentDir, "agents");
+	writeAgent(agentsDir, "analyst.md", {
+		name: "analyst",
+		description: "user analyst",
+		model: "{{expert}}",
+	});
+
+	const { agents } = discoverAgents(projectCwd, "user", { thinker: "legacy-thinker" });
+	assert.equal(agents[0].model, undefined);
 });
 
 test("modelRoles: unmapped role resolves to undefined", () => {

--- a/packages/taskflow-dsl/package.json
+++ b/packages/taskflow-dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-dsl",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Compile-time TypeScript DSL frontend for taskflow: erase .tf.ts runes to Taskflow JSON, then FlowIR via taskflow-core.",
   "keywords": [
     "taskflow",

--- a/packages/taskflow-hosts/package.json
+++ b/packages/taskflow-hosts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-hosts",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Shared host-runner collection for taskflow — the codex, claude, opencode, and grok SubagentRunner implementations + their argv builders and event-stream parsers. The per-host MCP servers, plugin scaffolds, and bins live in codex-taskflow / claude-taskflow / opencode-taskflow / grok-taskflow; this package holds just the runners so a new host can be added in one place.",
   "homepage": "https://github.com/heggria/taskflow#readme",
   "author": "heggria <bshengtao@gmail.com>",

--- a/packages/taskflow-mcp-core/package.json
+++ b/packages/taskflow-mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow-mcp-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Host-neutral MCP server for taskflow: a dependency-free stdio JSON-RPC server exposing the taskflow_* tools, plus the DAG SVG/outline renderer. Shared by the codex/claude/opencode/grok adapters — depends only on taskflow-core.",
   "keywords": [
     "taskflow",

--- a/skills-src/taskflow/advanced.md
+++ b/skills-src/taskflow/advanced.md
@@ -503,7 +503,8 @@ taskflow_version {}
 
 ## `init` — model roles setup
 
-`action: "init"` manages the `modelRoles` map (`{{fast}}` / `{{strong}}` / …
+`action: "init"` manages the `modelRoles` map (`{{steward}}` /
+`{{expert}}` / `{{builder}}` / `{{scout}}`
 placeholders in agent frontmatter → real model ids):
 
 - `mode: "show"` (default) — read-only report of current roles.
@@ -511,6 +512,6 @@ placeholders in agent frontmatter → real model ids):
   `force: true`** (destructive: overwrites `modelRoles` in settings.json).
 - `mode: "interactive"` — requires a UI session (`/tf init` is the human path).
 
-If phases fail with `Model metadata for {{fast}} not found`, roles are
+If phases fail with `Model metadata for {{scout}} not found`, roles are
 unconfigured — run `/tf init`.
 <!-- /host:pi -->

--- a/skills-src/taskflow/configuration.md
+++ b/skills-src/taskflow/configuration.md
@@ -404,8 +404,10 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 ```jsonc
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "subagents": {
     "globalThinking": "medium"              // fallback thinking for all subagents
@@ -423,7 +425,11 @@ Taskflow shares the subagent settings file at `~/.pi/agent/settings.json`:
 }
 ```
 
-- `modelRoles` — maps `{{role}}` references in agent frontmatter to actual model identifiers.
+- `modelRoles` — maps the semantic `{{steward}}`, `{{expert}}`,
+  `{{builder}}`, and `{{scout}}` responsibilities in agent frontmatter to
+  concrete model identifiers. Legacy role keys from 0.2.4 remain valid for
+  custom agents and as exact built-in fallbacks until the corresponding new
+  role is configured.
 - `subagents.globalThinking` (or top-level `defaultThinkingLevel`) — global
   thinking fallback.
 <!-- host:pi -->

--- a/website/content/docs/en/guides/agents-and-model-roles.mdx
+++ b/website/content/docs/en/guides/agents-and-model-roles.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents and Model Roles
-description: How taskflow discovers agents from three layers, maps them to six model roles, and resolves the right agent for each phase.
+description: How taskflow discovers agents from three layers, maps them to four semantic model roles, and resolves the right agent for each phase.
 ---
 
 Every phase in a taskflow runs as a subagent — an isolated LLM process with its own context window, system prompt, and tool set. That isolation is what keeps intermediate transcripts out of your conversation: only the final phase output comes back.
@@ -65,10 +65,10 @@ These agents analyze requirements, create plans, and challenge assumptions befor
 
 | Agent | Role | Thinking | Purpose |
 |---|---|---|---|
-| `analyst` | `{{thinker}}` | high | Analyze requirements, surface ambiguity, identify hidden constraints. Read-only. |
-| `critic` | `{{thinker}}` | xhigh | Challenge plans and conclusions, find contradictions before commitment. Read-only. |
-| `planner` | `{{strong}}` | high | Create concrete implementation plans with file-level detail. Read-only. |
-| `plan-arbiter` | `{{arbiter}}` | high | Review and challenge plans before execution begins. Read-only. |
+| `analyst` | `{{expert}}` | high | Analyze requirements, surface ambiguity, identify hidden constraints. Read-only. |
+| `critic` | `{{expert}}` | xhigh | Challenge plans and conclusions, find contradictions before commitment. Read-only. |
+| `planner` | `{{steward}}` | high | Create concrete implementation plans with file-level detail. Read-only. |
+| `plan-arbiter` | `{{expert}}` | high | Review and challenge plans before execution begins. Read-only. |
 
 The `analyst` runs first in complex pipelines to clarify requirements. The `planner` turns those requirements into actionable plans. The `critic` and `plan-arbiter` act as quality gates — they push back on weak plans before expensive execution begins.
 
@@ -78,10 +78,10 @@ These agents write code. They differ in scope and complexity.
 
 | Agent | Role | Thinking | Purpose |
 |---|---|---|---|
-| `executor` | `{{fast}}` | high | Default executor for 1–4 files with a clear plan. |
-| `executor-fast` | `{{fast}}` | off | Trivial changes: ≤2 files, ≤50 lines, no architecture decisions. |
-| `executor-code` | `{{strong}}` | high | Complex multi-file changes: ≥5 files, cross-module, structural refactors. |
-| `executor-ui` | `{{vision}}` | high | UI/frontend changes: components, styling, layout, responsive design. |
+| `executor` | `{{builder}}` | high | Default executor for 1–4 files with a clear plan. |
+| `executor-fast` | `{{scout}}` | off | Trivial changes: ≤2 files, ≤50 lines, no architecture decisions. |
+| `executor-code` | `{{builder}}` | high | Complex multi-file changes: ≥5 files, cross-module, structural refactors. |
+| `executor-ui` | `{{builder}}` | high | UI/frontend changes: components, styling, layout, responsive design. |
 
 The default `executor` handles most work. Use `executor-fast` for mechanical cleanups, `executor-code` for structural refactors, and `executor-ui` when you need vision capabilities to understand design intent.
 
@@ -91,10 +91,10 @@ These agents review code, assess risk, and verify outcomes. None of them edit fi
 
 | Agent | Role | Thinking | Purpose |
 |---|---|---|---|
-| `reviewer` | `{{strong}}` | high | General code review: quality, architecture, test coverage. |
-| `risk-reviewer` | `{{reasoner}}` | high | Backend/infrastructure risk: data integrity, concurrency, migrations. |
-| `security-reviewer` | `{{reasoner}}` | high | Security vulnerabilities: auth, injection, secrets, trust boundaries. |
-| `final-arbiter` | `{{arbiter}}` | xhigh | Resolve conflicts when multiple reviewers disagree. Tiebreaker. |
+| `reviewer` | `{{builder}}` | high | General code review: quality, architecture, test coverage. |
+| `risk-reviewer` | `{{expert}}` | high | Backend/infrastructure risk: data integrity, concurrency, migrations. |
+| `security-reviewer` | `{{expert}}` | high | Security vulnerabilities: auth, injection, secrets, trust boundaries. |
+| `final-arbiter` | `{{steward}}` | xhigh | Resolve conflicts when multiple reviewers disagree. Tiebreaker. |
 
 The `reviewer` handles general quality. The `risk-reviewer` and `security-reviewer` specialize in high-stakes domains and defer to each other at domain boundaries. The `final-arbiter` breaks ties when reviews conflict.
 
@@ -104,44 +104,46 @@ These agents handle auxiliary tasks: testing, documentation, exploration, and re
 
 | Agent | Role | Thinking | Purpose |
 |---|---|---|---|
-| `test-engineer` | `{{fast}}` | high | Design and implement test strategies, detect flaky patterns. |
-| `verifier` | `{{fast}}` | off | Run validation commands, reproduce failures, check logs. Read-only. |
-| `scout` | `{{fast}}` | off | Fast codebase exploration, return structured findings for other agents. |
-| `doc-writer` | `{{fast}}` | off | Author and edit documentation files (READMEs, guides, changelogs). |
-| `visual-explorer` | `{{vision}}` | high | Analyze Figma designs, extract colors, tokens, and component specs. |
-| `recover` | `{{fast}}` | low | Resume work after context compaction, pick up from handoff files. |
+| `test-engineer` | `{{builder}}` | high | Design and implement test strategies, detect flaky patterns. |
+| `verifier` | `{{scout}}` | off | Run validation commands, reproduce failures, check logs. Read-only. |
+| `scout` | `{{scout}}` | off | Fast codebase exploration, return structured findings for other agents. |
+| `doc-writer` | `{{builder}}` | off | Author and edit documentation files (READMEs, guides, changelogs). |
+| `visual-explorer` | `{{builder}}` | high | Analyze Figma designs, extract colors, tokens, and component specs. |
+| `recover` | `{{builder}}` | low | Resume work after context compaction, pick up from handoff files. |
 
 The `scout` does quick recon so other agents don't have to re-read everything. The `test-engineer` and `verifier` handle validation. The `visual-explorer` parses design files. The `recover` agent picks up work after a context window reset.
 
 ## Model roles
 
-Each built-in agent specifies a model role in its frontmatter — not a concrete model ID, but a role name wrapped in double braces: `{{fast}}`, `{{strong}}`, `{{thinker}}`, `{{arbiter}}`, `{{vision}}`, or `{{reasoner}}`.
+Each built-in agent specifies a model role in its frontmatter — not a concrete model ID, but one of four semantic responsibilities wrapped in double braces: `{{steward}}`, `{{expert}}`, `{{builder}}`, or `{{scout}}`.
 
-This indirection exists because different users have different models available. A role is a semantic contract ("this agent needs fast, cheap inference") that gets resolved to a concrete model based on your configuration.
+This indirection exists because different users have different models available. A role describes the responsibility an agent carries, while the concrete model is a replaceable binding. Model vendors can add or rename tiers without changing your flow definitions.
 
-### The six roles
+### The four roles
 
 | Role | Semantic contract | Default model | Used by |
 |---|---|---|---|
-| `{{fast}}` | Cheap and quick, high-volume low-stakes | `openrouter/deepseek/deepseek-v4-flash` | `executor`, `executor-fast`, `scout`, `verifier`, `doc-writer`, `test-engineer`, `recover` |
-| `{{strong}}` | Balanced capability, moderate complexity | `openrouter/xiaomi/mimo-v2.5-pro` | `planner`, `reviewer`, `executor-code` |
-| `{{thinker}}` | Deep reasoning, high thinking budget | `openrouter/deepseek/deepseek-v4-pro` | `analyst`, `critic` |
-| `{{arbiter}}` | High-stakes judgment, tie-breaking | `openrouter/qwen/qwen3.7-max` | `plan-arbiter`, `final-arbiter` |
-| `{{vision}}` | Multimodal, image understanding | `minimax/MiniMax-M3` | `executor-ui`, `visual-explorer` |
-| `{{reasoner}}` | Cautious reasoning, security-sensitive | `z-ai/glm-5.1` | `risk-reviewer`, `security-reviewer` |
+| `{{steward}}` | Own the goal, long-horizon plan, cross-phase coherence, and final synthesis | `openrouter/anthropic/claude-fable-5` | `planner`, `final-arbiter` |
+| `{{expert}}` | Deep specialist reasoning and high-stakes local judgment | `openrouter/anthropic/claude-opus-5` | `analyst`, `critic`, `plan-arbiter`, `risk-reviewer`, `security-reviewer` |
+| `{{builder}}` | Versatile default for implementation, review, UI, tests, docs, and recovery | `openrouter/anthropic/claude-sonnet-5` | `executor`, `executor-code`, `executor-ui`, `reviewer`, `test-engineer`, `doc-writer`, `visual-explorer`, `recover` |
+| `{{scout}}` | Fast, high-volume reconnaissance and mechanically checkable work | `openrouter/anthropic/claude-haiku-4.5` | `scout`, `executor-fast`, `verifier` |
 
-The defaults work well out of the box. But you might want to swap them — for example, if you have a Claude Pro subscription and want to use `anthropic/claude-3.5-sonnet` for `{{strong}}` instead of the default.
+The defaults form a capability ladder, but the role names are deliberately model-neutral. If a future model is simply a better daily driver, rebind `{{builder}}`; add a new role only when the work carries a genuinely new responsibility.
+
+<Callout type="info">
+  Upgrading from 0.2.4 does not invalidate existing settings. The legacy `fast`, `strong`, `thinker`, `arbiter`, `vision`, and `reasoner` keys are preserved, and built-in agents use their exact former key until you configure the corresponding new role. New role keys always take precedence. Custom agents that still reference a legacy key continue to resolve it normally.
+</Callout>
 
 ### How roles are resolved
 
 When a phase spawns a subagent, the runtime checks the agent's `model` field. If it matches the pattern `{{roleName}}`, the runtime looks up that role in your settings and substitutes the concrete model ID. If no mapping exists, the model field is left empty and the host's default model is used.
 
 ```text
-Agent frontmatter:  model: "{{strong}}"
+Agent frontmatter:  model: "{{builder}}"
                        ↓
-settings.json:      modelRoles: { "strong": "anthropic/claude-3.5-sonnet" }
+settings.json:      modelRoles: { "builder": "openrouter/anthropic/claude-sonnet-5" }
                        ↓
-Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
+Subagent spawns with: model: "openrouter/anthropic/claude-sonnet-5"
 ```
 
 An agent with a literal model ID (no braces) bypasses role resolution entirely. This is useful for custom agents that must always use a specific model.
@@ -151,7 +153,7 @@ An agent with a literal model ID (no braces) bypasses role resolution entirely. 
 The `/tf init` command walks you through role configuration interactively. It reads your current settings, shows you the available models from your provider's registry, and writes your choices back atomically.
 
 <Callout type="tip">
-  Run `/tf init` the first time you install taskflow. The recommended defaults work well for most users, but you may want to swap the `vision` role to a different multimodal model or the `arbiter` role to a stronger reasoning model.
+  Run `/tf init` after installing or upgrading taskflow. Use `scout` for cheap breadth, keep `builder` as the default, and reserve `expert` and `steward` for work whose risk or time horizon justifies them.
 </Callout>
 
 ### The action menu
@@ -159,7 +161,7 @@ The `/tf init` command walks you through role configuration interactively. It re
 When you run `/tf init`, you see an action menu:
 
 1. **Use recommended defaults** — Apply the default models from the table above.
-2. **Configure each role** — Walk through all six roles one by one.
+2. **Configure each role** — Walk through all four roles one by one.
 3. **Edit one role** — Change a single role without touching the others.
 4. **Configure taskflow preferences** — Adjust built-in agent settings.
 5. **Show current roles** — Display your current configuration without changes.
@@ -177,12 +179,10 @@ All configuration is saved to `~/.pi/agent/settings.json` (or the path set by `T
 ```json title="settings.json"
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro",
-    "thinker": "openrouter/deepseek/deepseek-v4-pro",
-    "arbiter": "openrouter/qwen/qwen3.7-max",
-    "vision": "minimax/MiniMax-M3",
-    "reasoner": "z-ai/glm-5.1"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "taskflow": {
     "builtInAgents": true,
@@ -221,7 +221,7 @@ Every agent file has three parts: YAML frontmatter between `---` delimiters, a b
 name: code-reviewer
 description: Review code for quality and best practices
 tools: read, grep, find, ls, bash
-model: "{{strong}}"
+model: "{{builder}}"
 thinking: high
 ---
 
@@ -243,7 +243,7 @@ Be specific and actionable. Don't just say "this could be better" — explain wh
 | `name` | Yes | Unique identifier, used to reference the agent in flows. Use hyphens. |
 | `description` | Yes | Brief description shown in agent listings and picker UIs. |
 | `tools` | No | Comma-separated tool list: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`. Defaults to all tools if omitted. |
-| `model` | No | Model ID or role reference (e.g., `openai/gpt-4o` or `"{{strong}}"`). Falls back to the host's default model. |
+| `model` | No | Model ID or role reference (e.g., `openai/gpt-4o` or `"{{builder}}"`). Falls back to the host's default model. |
 | `thinking` | No | Thinking level: `off`, `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `ultra`. Falls back to `globalThinking`; unsupported values fail closed. Host mappings differ. |
 
 <Callout type="info">
@@ -259,7 +259,7 @@ To override a built-in agent, create a custom agent with the same name in your u
 name: executor
 description: Custom executor with project-specific conventions
 tools: read, grep, find, ls, bash, edit, write
-model: "{{strong}}"
+model: "{{builder}}"
 thinking: high
 ---
 
@@ -341,7 +341,7 @@ These overrides apply only to this phase invocation. The agent's frontmatter set
 
 | Override | Effect |
 |---|---|
-| `model` | Replace the agent's model for this phase. Accepts a role (`"{{strong}}"`) or a literal model ID. |
+| `model` | Replace the agent's model for this phase. Accepts a role (`"{{builder}}"`) or a literal model ID. |
 | `thinking` | Override thinking with a supported value. Codex maps it to `model_reasoning_effort` (`max`/`ultra` → `xhigh`). |
 | `tools` | Requested capability set. Pi uses a whitelist; Codex maps read-only vs mutating sets to sandbox profiles rather than enforcing exact names. |
 
@@ -427,7 +427,7 @@ Create a specialized agent for your domain, then reference it in flows:
 name: api-designer
 description: Design RESTful APIs following OpenAPI 3.0 spec
 tools: read, grep, find, ls, write
-model: "{{strong}}"
+model: "{{builder}}"
 thinking: high
 ---
 

--- a/website/content/docs/en/guides/opencode.mdx
+++ b/website/content/docs/en/guides/opencode.mdx
@@ -165,7 +165,7 @@ Children inherit only platform/proxy/CA, OpenCode configuration, and supported p
 
 OpenCode model ids are `provider/model` (e.g. `anthropic/claude-sonnet-4-5`). Because a valid OpenCode id contains a slash, the runner does **not** reuse the codex/claude "contains `/` ⇒ drop" rule. It drops only ids that clearly aren't OpenCode models:
 
-- An unresolved role placeholder (`{{fast}}`)
+- An unresolved role placeholder (`{{scout}}`)
 - A pi thinking suffix (`…:xhigh`)
 - A multi-segment openrouter path (`openrouter/vendor/model`, ≥ 2 slashes)
 

--- a/website/content/docs/en/guides/pi.mdx
+++ b/website/content/docs/en/guides/pi.mdx
@@ -162,15 +162,13 @@ You'll get a picker that walks you through each role and recommends sensible def
 
 | Role | Purpose | Typical agents |
 |---|---|---|
-| `fast` | Cheap & quick — high-volume, low-stakes work. | executor, scout, verifier, doc-writer |
-| `strong` | Balanced planning and review. | planner, reviewer, executor-code |
-| `thinker` | Deep analysis and ambiguity detection. | analyst, critic |
-| `arbiter` | Final judgment and tiebreaks. | plan-arbiter, final-arbiter |
-| `vision` | Multimodal — UI work, design reading. | executor-ui, visual-explorer |
-| `reasoner` | Cautious reasoning — security and risk. | risk-reviewer, security-reviewer |
+| `steward` | Goal ownership, long-horizon planning, final synthesis. | planner, final-arbiter |
+| `expert` | Deep specialist reasoning and high-stakes judgment. | analyst, critic, plan-arbiter, risk-reviewer, security-reviewer |
+| `builder` | Versatile default execution, review, UI, tests, and docs. | executor, executor-code, executor-ui, reviewer, test-engineer, doc-writer |
+| `scout` | Fast reconnaissance and mechanically checkable work. | scout, executor-fast, verifier |
 
 <Callout type="tip">
-  If you skip this step, taskflow will hint that roles are unconfigured and agents will fall back to the default model. It works, but you're leaving cost and quality on the table — `fast` roles on a cheap model save a lot of tokens over time.
+  If you skip this step, taskflow will hint that roles are unconfigured and agents will fall back to the host's default model. Keep `builder` as the normal path, use `scout` for cheap breadth, and reserve `expert`/`steward` for work that justifies them.
 </Callout>
 
 The configuration is written to your Pi `settings.json` under `modelRoles`. You can re-run `/tf init` any time to change a single role or accept the recommended defaults.

--- a/website/content/docs/zh-cn/guides/agents-and-model-roles.mdx
+++ b/website/content/docs/zh-cn/guides/agents-and-model-roles.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents 与 Model Roles
-description: taskflow 如何从三层发现 agents、将它们映射到六个 model roles，并为每个 phase 解析出正确的 agent。
+description: taskflow 如何从三层发现 agents、将它们映射到四个语义 model roles，并为每个 phase 解析出正确的 agent。
 ---
 
 taskflow 中的每个 phase 都作为 subagent 运行——一个独立的 LLM 进程，拥有自己的 context window、system prompt 和工具集。正是这种隔离让中间的 transcript 不进入你的对话：只有最终的 phase 输出会返回。
@@ -65,10 +65,10 @@ taskflow 内置了 18 个 agent，按四类组织。每个 agent 都是一个带
 
 | Agent | Role | Thinking | 用途 |
 |---|---|---|---|
-| `analyst` | `{{thinker}}` | high | 分析需求，暴露歧义，识别隐藏约束。只读。 |
-| `critic` | `{{thinker}}` | xhigh | 挑战计划和结论，在承诺之前发现矛盾。只读。 |
-| `planner` | `{{strong}}` | high | 创建带文件级细节的具体实现计划。只读。 |
-| `plan-arbiter` | `{{arbiter}}` | high | 在执行开始之前审查并挑战计划。只读。 |
+| `analyst` | `{{expert}}` | high | 分析需求，暴露歧义，识别隐藏约束。只读。 |
+| `critic` | `{{expert}}` | xhigh | 挑战计划和结论，在承诺之前发现矛盾。只读。 |
+| `planner` | `{{steward}}` | high | 创建带文件级细节的具体实现计划。只读。 |
+| `plan-arbiter` | `{{expert}}` | high | 在执行开始之前审查并挑战计划。只读。 |
 
 `analyst` 在复杂流水线中率先运行以澄清需求。`planner` 把这些需求转化为可执行的计划。`critic` 和 `plan-arbiter` 充当质量门控——它们在昂贵的执行开始之前对薄弱的计划推回。
 
@@ -78,10 +78,10 @@ taskflow 内置了 18 个 agent，按四类组织。每个 agent 都是一个带
 
 | Agent | Role | Thinking | 用途 |
 |---|---|---|---|
-| `executor` | `{{fast}}` | high | 默认 executor，用于有清晰计划的 1–4 文件改动。 |
-| `executor-fast` | `{{fast}}` | off | 琐碎改动：≤2 文件、≤50 行、不涉及架构决策。 |
-| `executor-code` | `{{strong}}` | high | 复杂的多文件改动：≥5 文件、跨模块、结构性重构。 |
-| `executor-ui` | `{{vision}}` | high | UI/前端改动：组件、样式、布局、响应式设计。 |
+| `executor` | `{{builder}}` | high | 默认 executor，用于有清晰计划的 1–4 文件改动。 |
+| `executor-fast` | `{{scout}}` | off | 琐碎改动：≤2 文件、≤50 行、不涉及架构决策。 |
+| `executor-code` | `{{builder}}` | high | 复杂的多文件改动：≥5 文件、跨模块、结构性重构。 |
+| `executor-ui` | `{{builder}}` | high | UI/前端改动：组件、样式、布局、响应式设计。 |
 
 默认的 `executor` 处理大部分工作。机械清理用 `executor-fast`，结构性重构用 `executor-code`，当你需要视觉能力来理解设计意图时用 `executor-ui`。
 
@@ -91,10 +91,10 @@ taskflow 内置了 18 个 agent，按四类组织。每个 agent 都是一个带
 
 | Agent | Role | Thinking | 用途 |
 |---|---|---|---|
-| `reviewer` | `{{strong}}` | high | 通用代码审查：质量、架构、测试覆盖。 |
-| `risk-reviewer` | `{{reasoner}}` | high | 后端/基础设施风险：数据完整性、并发、迁移。 |
-| `security-reviewer` | `{{reasoner}}` | high | 安全漏洞：认证、注入、密钥、信任边界。 |
-| `final-arbiter` | `{{arbiter}}` | xhigh | 在多个审查者意见冲突时裁决。决胜者。 |
+| `reviewer` | `{{builder}}` | high | 通用代码审查：质量、架构、测试覆盖。 |
+| `risk-reviewer` | `{{expert}}` | high | 后端/基础设施风险：数据完整性、并发、迁移。 |
+| `security-reviewer` | `{{expert}}` | high | 安全漏洞：认证、注入、密钥、信任边界。 |
+| `final-arbiter` | `{{steward}}` | xhigh | 在多个审查者意见冲突时裁决。决胜者。 |
 
 `reviewer` 处理通用质量。`risk-reviewer` 和 `security-reviewer` 专注于高风险领域，并在领域边界处互相推让。`final-arbiter` 在审查冲突时打破平局。
 
@@ -104,44 +104,46 @@ taskflow 内置了 18 个 agent，按四类组织。每个 agent 都是一个带
 
 | Agent | Role | Thinking | 用途 |
 |---|---|---|---|
-| `test-engineer` | `{{fast}}` | high | 设计和实现测试策略，检测不稳定模式。 |
-| `verifier` | `{{fast}}` | off | 运行校验命令，复现失败，检查日志。只读。 |
-| `scout` | `{{fast}}` | off | 快速代码库探索，为其他 agent 返回结构化发现。 |
-| `doc-writer` | `{{fast}}` | off | 编写和编辑文档文件（README、指南、changelog）。 |
-| `visual-explorer` | `{{vision}}` | high | 分析 Figma 设计，提取颜色、token 和组件规格。 |
-| `recover` | `{{fast}}` | low | 在 context compaction 之后恢复工作，从交接文件接续。 |
+| `test-engineer` | `{{builder}}` | high | 设计和实现测试策略，检测不稳定模式。 |
+| `verifier` | `{{scout}}` | off | 运行校验命令，复现失败，检查日志。只读。 |
+| `scout` | `{{scout}}` | off | 快速代码库探索，为其他 agent 返回结构化发现。 |
+| `doc-writer` | `{{builder}}` | off | 编写和编辑文档文件（README、指南、changelog）。 |
+| `visual-explorer` | `{{builder}}` | high | 分析 Figma 设计，提取颜色、token 和组件规格。 |
+| `recover` | `{{builder}}` | low | 在 context compaction 之后恢复工作，从交接文件接续。 |
 
 `scout` 做快速侦察，让其他 agent 不必重新读取所有内容。`test-engineer` 和 `verifier` 处理验证。`visual-explorer` 解析设计文件。`recover` agent 在 context window 重置之后接续工作。
 
 ## Model roles
 
-每个内置 agent 在其 frontmatter 中指定一个 model role——不是具体的模型 ID，而是用双花括号包裹的角色名：`{{fast}}`、`{{strong}}`、`{{thinker}}`、`{{arbiter}}`、`{{vision}}` 或 `{{reasoner}}`。
+每个内置 agent 在其 frontmatter 中指定一个 model role——不是具体的模型 ID，而是用双花括号包裹的四种语义责任之一：`{{steward}}`、`{{expert}}`、`{{builder}}` 或 `{{scout}}`。
 
-这种间接存在是因为不同用户可用的模型不同。一个 role 是一个语义契约（"这个 agent 需要快速、廉价的推理"），它会在运行时根据你的配置解析为具体的模型 ID。
+这种间接层存在是因为不同用户可用的模型不同。role 描述 agent 承担的责任，具体模型只是可替换的绑定。模型厂商增加或重命名档位时，不需要修改 flow 定义。
 
-### 六个 roles
+### 四个 roles
 
 | Role | 语义契约 | 默认模型 | 使用者 |
 |---|---|---|---|
-| `{{fast}}` | 便宜且快速，高吞吐低风险 | `openrouter/deepseek/deepseek-v4-flash` | `executor`、`executor-fast`、`scout`、`verifier`、`doc-writer`、`test-engineer`、`recover` |
-| `{{strong}}` | 均衡能力，中等复杂度 | `openrouter/xiaomi/mimo-v2.5-pro` | `planner`、`reviewer`、`executor-code` |
-| `{{thinker}}` | 深度推理，高 thinking 预算 | `openrouter/deepseek/deepseek-v4-pro` | `analyst`、`critic` |
-| `{{arbiter}}` | 高风险判断，决胜 | `openrouter/qwen/qwen3.7-max` | `plan-arbiter`、`final-arbiter` |
-| `{{vision}}` | 多模态，图像理解 | `minimax/MiniMax-M3` | `executor-ui`、`visual-explorer` |
-| `{{reasoner}}` | 谨慎推理，安全敏感 | `z-ai/glm-5.1` | `risk-reviewer`、`security-reviewer` |
+| `{{steward}}` | 守住目标、长周期计划、跨阶段一致性与最终综合 | `openrouter/anthropic/claude-fable-5` | `planner`、`final-arbiter` |
+| `{{expert}}` | 深度专业推理与高风险局部判断 | `openrouter/anthropic/claude-opus-5` | `analyst`、`critic`、`plan-arbiter`、`risk-reviewer`、`security-reviewer` |
+| `{{builder}}` | 实现、审查、UI、测试、文档与恢复的通用默认执行者 | `openrouter/anthropic/claude-sonnet-5` | `executor`、`executor-code`、`executor-ui`、`reviewer`、`test-engineer`、`doc-writer`、`visual-explorer`、`recover` |
+| `{{scout}}` | 快速、高吞吐侦察与可机械验证的工作 | `openrouter/anthropic/claude-haiku-4.5` | `scout`、`executor-fast`、`verifier` |
 
-默认值开箱即用效果良好。但你可能想替换它们——例如，如果你有 Claude Pro 订阅，想把 `{{strong}}` 换成 `anthropic/claude-3.5-sonnet`。
+默认绑定构成能力阶梯，但 role 名刻意保持模型中立。未来如果出现更好的日常执行模型，只需重新绑定 `{{builder}}`；只有工作责任真的新增时才新增 role。
+
+<Callout type="info">
+  从 0.2.4 升级不会让现有设置失效。旧的 `fast`、`strong`、`thinker`、`arbiter`、`vision`、`reasoner` 键会保留；在新 role 尚未配置时，内置 agent 会精确回退到自己原来的键。新 role 始终优先。仍引用旧键的自定义 agent 也会继续正常解析。
+</Callout>
 
 ### Roles 如何解析
 
 当一个 phase 生成一个 subagent 时，运行时会检查 agent 的 `model` 字段。如果它匹配 `{{roleName}}` 模式，运行时会查找该 role 的设置并替换为具体的模型 ID。如果不存在映射，则 model 字段留空，并使用宿主的默认模型。
 
 ```text
-Agent frontmatter:  model: "{{strong}}"
+Agent frontmatter:  model: "{{builder}}"
                        ↓
-settings.json:      modelRoles: { "strong": "anthropic/claude-3.5-sonnet" }
+settings.json:      modelRoles: { "builder": "openrouter/anthropic/claude-sonnet-5" }
                        ↓
-Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
+Subagent spawns with: model: "openrouter/anthropic/claude-sonnet-5"
 ```
 
 带有字面模型 ID（无花括号）的 agent 完全绕过 role 解析。这对于必须始终使用特定模型的自定义 agent 很有用。
@@ -151,7 +153,7 @@ Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
 `/tf init` 命令会交互式地引导你完成 role 配置。它读取你当前的设置，从你的 provider registry 显示可用模型，并以原子方式写回你的选择。
 
 <Callout type="tip">
-  首次安装 taskflow 时运行 `/tf init`。推荐的默认值对大多数用户效果良好，但你可能想把 `vision` role 换成另一个多模态模型，或把 `arbiter` role 换成更强的推理模型。
+  安装或升级 taskflow 后运行 `/tf init`。用 `scout` 承担便宜的广度工作，以 `builder` 为默认；只有风险或时间跨度值得时才使用 `expert` 和 `steward`。
 </Callout>
 
 ### 操作菜单
@@ -159,7 +161,7 @@ Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
 当你运行 `/tf init` 时，会看到一个操作菜单：
 
 1. **使用推荐默认值** —— 应用上表中的默认模型。
-2. **逐个配置 role** —— 依次遍历全部六个 role。
+2. **逐个配置 role** —— 依次遍历全部四个 role。
 3. **编辑单个 role** —— 只改一个 role，不动其他。
 4. **配置 taskflow 偏好** —— 调整内置 agent 设置。
 5. **显示当前 roles** —— 不做改动地显示当前配置。
@@ -177,12 +179,10 @@ Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
 ```json title="settings.json"
 {
   "modelRoles": {
-    "fast": "openrouter/deepseek/deepseek-v4-flash",
-    "strong": "openrouter/xiaomi/mimo-v2.5-pro",
-    "thinker": "openrouter/deepseek/deepseek-v4-pro",
-    "arbiter": "openrouter/qwen/qwen3.7-max",
-    "vision": "minimax/MiniMax-M3",
-    "reasoner": "z-ai/glm-5.1"
+    "steward": "openrouter/anthropic/claude-fable-5",
+    "expert": "openrouter/anthropic/claude-opus-5",
+    "builder": "openrouter/anthropic/claude-sonnet-5",
+    "scout": "openrouter/anthropic/claude-haiku-4.5"
   },
   "taskflow": {
     "builtInAgents": true,
@@ -221,7 +221,7 @@ Subagent spawns with: model: "anthropic/claude-3.5-sonnet"
 name: code-reviewer
 description: Review code for quality and best practices
 tools: read, grep, find, ls, bash
-model: "{{strong}}"
+model: "{{builder}}"
 thinking: high
 ---
 
@@ -243,7 +243,7 @@ Be specific and actionable. Don't just say "this could be better" — explain wh
 | `name` | 是 | 唯一标识符，用于在 flow 中引用该 agent。使用连字符。 |
 | `description` | 是 | 简短描述，显示在 agent 列表和选择器 UI 中。 |
 | `tools` | 否 | 逗号分隔的工具列表：`read`、`write`、`edit`、`bash`、`grep`、`find`、`ls`。省略时默认为全部工具。 |
-| `model` | 否 | 模型 ID 或 role 引用（如 `openai/gpt-4o` 或 `"{{strong}}"`）。回退到宿主默认模型。 |
+| `model` | 否 | 模型 ID 或 role 引用（如 `openai/gpt-4o` 或 `"{{builder}}"`）。回退到宿主默认模型。 |
 | `thinking` | 否 | Thinking 级别：`off`、`none`、`minimal`、`low`、`medium`、`high`、`xhigh`、`max` 或 `ultra`。回退到 `globalThinking`；非法值 fail-closed。各宿主映射不同。 |
 
 <Callout type="info">
@@ -259,7 +259,7 @@ Be specific and actionable. Don't just say "this could be better" — explain wh
 name: executor
 description: Custom executor with project-specific conventions
 tools: read, grep, find, ls, bash, edit, write
-model: "{{strong}}"
+model: "{{builder}}"
 thinking: high
 ---
 
@@ -341,7 +341,7 @@ Phase 可以覆盖 agent 的 model、thinking 级别和工具访问，而无需�
 
 | 覆盖 | 效果 |
 |---|---|
-| `model` | 替换该 phase 的 agent 模型。接受 role（`"{{strong}}"`）或字面模型 ID。 |
+| `model` | 替换该 phase 的 agent 模型。接受 role（`"{{builder}}"`）或字面模型 ID。 |
 | `thinking` | 用受支持值覆盖 thinking。Codex 映射到 `model_reasoning_effort`（`max`/`ultra` → `xhigh`）。 |
 | `tools` | 请求能力集合。Pi 使用白名单；Codex 仅映射只读/可写 sandbox，而不严格执行工具名。 |
 
@@ -427,7 +427,7 @@ Phase 可以覆盖 agent 的 model、thinking 级别和工具访问，而无需�
 name: api-designer
 description: Design RESTful APIs following OpenAPI 3.0 spec
 tools: read, grep, find, ls, write
-model: "{{strong}}"
+model: "{{builder}}"
 thinking: high
 ---
 

--- a/website/content/docs/zh-cn/guides/opencode.mdx
+++ b/website/content/docs/zh-cn/guides/opencode.mdx
@@ -165,7 +165,7 @@ OpenCode 没有按运行的 tool-whitelist 标志，但它支持通过 `OPENCODE
 
 OpenCode 模型 id 是 `provider/model`（如 `anthropic/claude-sonnet-4-5`）。因为合法的 OpenCode id 包含斜杠，运行时**不会**复用 codex/claude 的"包含 `/` ⇒ 丢弃"规则。它只丢弃明显不是 OpenCode 模型的 id：
 
-- 未解析的 role 占位符（`{{fast}}`）
+- 未解析的 role 占位符（`{{scout}}`）
 - pi 的 thinking 后缀（`…:xhigh`）
 - 多段 openrouter 路径（`openrouter/vendor/model`，≥ 2 个斜杠）
 

--- a/website/content/docs/zh-cn/guides/pi.mdx
+++ b/website/content/docs/zh-cn/guides/pi.mdx
@@ -162,15 +162,13 @@ taskflow 自带十八个内置 agent（scout、security-reviewer、writer 等等
 
 | 角色 | 用途 | 典型 agent |
 |---|---|---|
-| `fast` | 便宜且快速——大体积、低风险的工作。 | executor, scout, verifier, doc-writer |
-| `strong` | 平衡的规划和审查。 | planner, reviewer, executor-code |
-| `thinker` | 深度分析和歧义检测。 | analyst, critic |
-| `arbiter` | 最终判断和裁决。 | plan-arbiter, final-arbiter |
-| `vision` | 多模态——UI 工作、设计阅读。 | executor-ui, visual-explorer |
-| `reasoner` | 谨慎推理——安全和风险。 | risk-reviewer, security-reviewer |
+| `steward` | 目标守护、长周期规划与最终综合。 | planner, final-arbiter |
+| `expert` | 深度专业推理与高风险判断。 | analyst, critic, plan-arbiter, risk-reviewer, security-reviewer |
+| `builder` | 通用默认执行、审查、UI、测试与文档。 | executor, executor-code, executor-ui, reviewer, test-engineer, doc-writer |
+| `scout` | 快速侦察与可机械验证的工作。 | scout, executor-fast, verifier |
 
 <Callout type="tip">
-  如果你跳过这一步，taskflow 会提示角色未配置，agent 会回退到默认模型。它能用，但你把成本和质量留在桌上了——`fast` 角色用一个便宜模型，时间长了能省很多 token。
+  如果你跳过这一步，taskflow 会提示角色未配置，agent 会回退到宿主默认模型。以 `builder` 为常规路径，用 `scout` 承担便宜的广度工作，只在确有必要时使用 `expert`/`steward`。
 </Callout>
 
 配置写到你的 Pi `settings.json` 里的 `modelRoles` 下。你可以随时重新运行 `/tf init` 来改单个角色，或接受推荐的默认值。


### PR DESCRIPTION
## Summary

- replace six capability-labelled built-in model roles with four stable responsibilities: `steward`, `expert`, `builder`, and `scout`
- bind the recommended defaults to Claude Fable 5, Opus 5, Sonnet 5, and Haiku 4.5
- preserve exact 0.2.4 role fallback for built-in and synced built-in agents while giving new role keys precedence
- update all nine package versions, host plugin pins, generated skills, bilingual docs, release notes, and tests for 0.2.5

## Validation

- `pnpm test` (2027 tests passed)
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test:pack` (9 packages, 24 explicit imports, 68 wildcard exports, 5 bins)
- `pnpm run build:website` (123 static pages)
- `node scripts/build-skills.mjs --check`
- `git diff --check`

## Compatibility

Existing `fast`, `strong`, `thinker`, `arbiter`, `vision`, and `reasoner` mappings remain usable. A built-in agent uses its exact former mapping when the corresponding new semantic role has not been configured; custom agents referencing legacy keys continue to resolve unchanged.