### PR TITLE
fix(release): verify replay against release commit

### DIFF
--- a/.github/workflows/publish-charterarc-experimental.yml
+++ b/.github/workflows/publish-charterarc-experimental.yml
@@ -181,4 +181,4 @@ jobs:
           PUBLISH_REPOSITORY_URL: "https://github.com/heggria/taskflow"
           PUBLISH_WORKFLOW_PATH: ".github/workflows/publish-charterarc-experimental.yml"
           PUBLISH_REF: ${{ env.PUBLISH_REF }}
-          GITHUB_SHA: ${{ env.PUBLISH_SHA }}
+          PUBLISH_COMMIT: ${{ env.PUBLISH_SHA }}

--- a/packages/charterarc/test/experimental-release.test.ts
+++ b/packages/charterarc/test/experimental-release.test.ts
@@ -51,7 +51,9 @@ test("experimental release: package and workflow cannot promote latest", async (
 	assert.match(workflow, /verify-published-package\.mjs[^\n]*packages\/charterarc[^\n]*\$tarball/);
 	assert.match(workflow, /PUBLISH_WORKFLOW_PATH:\s*["']?\.github\/workflows\/publish-charterarc-experimental\.yml/);
 	assert.match(workflow, /PUBLISH_REF:\s*\$\{\{ env\.PUBLISH_REF \}\}/);
-	assert.match(workflow, /GITHUB_SHA:\s*\$\{\{ env\.PUBLISH_SHA \}\}/);
+	assert.match(workflow, /PUBLISH_COMMIT:\s*\$\{\{ env\.PUBLISH_SHA \}\}/);
+	const verifier = await read("scripts/verify-published-package.mjs");
+	assert.match(verifier, /process\.env\.PUBLISH_COMMIT \?\? process\.env\.GITHUB_SHA/);
 	assert.match(
 		workflow,
 		/if \[ "\$latest" = "\$version" \]; then[\s\S]*npm dist-tag rm "\$name" latest/,

--- a/scripts/verify-published-package.mjs
+++ b/scripts/verify-published-package.mjs
@@ -125,7 +125,7 @@ async function main() {
 		expectedRepository,
 		expectedWorkflowPath,
 		expectedRef,
-		expectedSha: process.env.GITHUB_SHA,
+		expectedSha: process.env.PUBLISH_COMMIT ?? process.env.GITHUB_SHA,
 	});
 	if (errors.length) throw new Error(`${spec} failed published-package verification:\n- ${errors.join("\n- ")}`);
 	process.stdout.write(`verified ${spec}: owner + provenance + integrity (${basename(packageDir)})\n`);


### PR DESCRIPTION
## Summary
- pass the immutable tagged release commit through a dedicated `PUBLISH_COMMIT` variable
- keep `GITHUB_SHA` as the manual workflow commit instead of attempting to override a reserved GitHub variable
- lock the replay contract with the CharterArc release test

## Incident
The first experimental publication correctly carries provenance for `c60d6c91`, but the manual repair workflow compared it with the current `main` workflow SHA because GitHub does not allow `GITHUB_SHA` to be overridden. This prevented the workflow from removing the accidentally-created `latest` dist-tag.

## Verification
- `git diff --check`
- Ruby YAML parse
- focused release and publish-verification tests: 9/9
- `pnpm run check:charterarc`: 50/50

After this PR is squash-merged, the existing experimental publication will be re-verified against its immutable tag commit and `latest` will be removed only when it still points to that experimental version.