### PR TITLE
fix(release): model npm first-publish latest invariant

### DIFF
--- a/.github/workflows/publish-charterarc-experimental.yml
+++ b/.github/workflows/publish-charterarc-experimental.yml
@@ -146,35 +146,33 @@ jobs:
             fi
           done
 
-          # npm assigns `latest` on a package's first-ever publish even when
-          # `--tag experimental` is explicit. Remove only that exact violating
-          # binding; never disturb a stable `latest` pointing elsewhere.
+          # The public npm registry requires a `latest` key in package metadata,
+          # so a package's first-ever publish receives it even with an explicit
+          # non-latest tag. Observe that one unavoidable bootstrap binding, but
+          # never set, move, or remove `latest` from this experimental workflow.
           dist_tags_json="$(pnpm view "$name" dist-tags --json)"
-          latest="$(node -e '
-            const tags = JSON.parse(process.argv[1]);
-            process.stdout.write(tags.latest ?? "");
-          ' "$dist_tags_json")"
-          if [ "$latest" = "$version" ]; then
-            echo "::notice::Removing npm first-publish latest binding from $name@$version"
-            npm dist-tag rm "$name" latest
-            dist_tags_json="$(pnpm view "$name" dist-tags --json)"
-          fi
+          versions_json="$(pnpm view "$name" versions --json)"
 
-          # Fail closed if this version remains bound to latest, or
-          # experimental is missing.
+          # Fail closed unless experimental points at this version. `latest`
+          # may equal it only for the registry-forced sole-version bootstrap.
           node -e '
             const tags = JSON.parse(process.argv[1]);
-            const version = process.argv[2];
+            const rawVersions = JSON.parse(process.argv[2]);
+            const versions = Array.isArray(rawVersions) ? rawVersions : [rawVersions];
+            const version = process.argv[3];
             if (tags.latest === version) {
-              console.error("::error::experimental publish must not set or move latest to " + version);
-              process.exit(1);
+              if (versions.length !== 1 || versions[0] !== version) {
+                console.error("::error::experimental publish moved latest to " + version);
+                process.exit(1);
+              }
+              console.log("registry-forced first-publish latest=" + version + " observed; no stable promise made");
             }
             if (tags.experimental !== version) {
               console.error("::error::experimental dist-tag is " + (tags.experimental ?? "missing") + ", expected " + version);
               process.exit(1);
             }
             console.log("dist-tags ok: experimental=" + tags.experimental + " latest=" + (tags.latest ?? "unset"));
-          ' "$dist_tags_json" "$version"
+          ' "$dist_tags_json" "$versions_json" "$version"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TRUSTED_OWNERS: "heggria,muyun"

--- a/docs/internal/charterarc-autonomous-goal.md
+++ b/docs/internal/charterarc-autonomous-goal.md
@@ -371,8 +371,14 @@ repeated dead end and a mechanically testable invalidation path.
 Before M4, npm `experimental` dist-tag publication remains permitted in
 principle under the user's earlier authorization, but is currently paused until
 M1 passes and a fresh execution-time publish checklist is explicitly approved.
-It must not set or move `latest`, enter the stable Taskflow release, promise
-stable compatibility, or count as adoption evidence.
+It must never explicitly set or move `latest`, enter the stable Taskflow
+release, promise stable compatibility, or count as adoption evidence. The
+public npm registry requires package metadata to contain `latest`, so it binds
+the sole version on a package's first-ever publication even when `--tag
+experimental` is explicit. That registry-forced first-publish `latest` is an
+observed transport constraint, not a stable release or compatibility promise;
+experimental workflows must leave it untouched and consumers must select the
+exact version or `@experimental`.
 
 Only after M4 may the `latest` dist-tag or a stable compatibility promise be
 proposed. A stable release remains a distinct user-authorized decision.

--- a/packages/charterarc/test/experimental-release.test.ts
+++ b/packages/charterarc/test/experimental-release.test.ts
@@ -48,16 +48,16 @@ test("experimental release: package and workflow cannot promote latest", async (
 	assert.match(workflow, /npm publish[^\n]*\$tarball[^\n]*--provenance/);
 	assert.match(workflow, /npm publish[^\n]*--tag experimental/);
 	assert.doesNotMatch(workflow, /--tag latest|dist-tag (?:add|set)[^\n]*latest/);
+	assert.doesNotMatch(workflow, /dist-tag rm[^\n]*latest/);
 	assert.match(workflow, /verify-published-package\.mjs[^\n]*packages\/charterarc[^\n]*\$tarball/);
 	assert.match(workflow, /PUBLISH_WORKFLOW_PATH:\s*["']?\.github\/workflows\/publish-charterarc-experimental\.yml/);
 	assert.match(workflow, /PUBLISH_REF:\s*\$\{\{ env\.PUBLISH_REF \}\}/);
 	assert.match(workflow, /PUBLISH_COMMIT:\s*\$\{\{ env\.PUBLISH_SHA \}\}/);
 	const verifier = await read("scripts/verify-published-package.mjs");
 	assert.match(verifier, /process\.env\.PUBLISH_COMMIT \?\? process\.env\.GITHUB_SHA/);
-	assert.match(
-		workflow,
-		/if \[ "\$latest" = "\$version" \]; then[\s\S]*npm dist-tag rm "\$name" latest/,
-	);
+	assert.match(workflow, /pnpm view "\$name" versions --json/);
+	assert.match(workflow, /versions\.length !== 1 \|\| versions\[0\] !== version/);
+	assert.match(workflow, /registry-forced first-publish latest=/);
 	assert.match(workflow, /dist-tags/);
 	assert.match(workflow, /experimental/);
 	assert.match(workflow, /latest/);
@@ -72,7 +72,8 @@ test("experimental release: package and workflow cannot promote latest", async (
 
 	const goal = await read("docs/internal/charterarc-autonomous-goal.md");
 	assert.match(goal, /Before M4[\s\S]*npm\s+`experimental` dist-tag/);
-	assert.match(goal, /must not set or move `latest`/);
+	assert.match(goal, /must never explicitly set or move `latest`/);
+	assert.match(goal, /registry-forced first-publish `latest`/);
 	assert.match(goal, /Only after M4[\s\S]*`latest` dist-tag/);
 });
 


### PR DESCRIPTION
## Summary
- model the public npm registry requirement that a package document retains `latest`
- accept `latest === experimental` only for the sole-version first-publish bootstrap
- never set, move, or remove `latest` from the experimental workflow
- record the registry constraint without turning it into a stable compatibility promise

## Evidence
- npm accepted and provenance-verified `charterarc@0.2.7-experimental.0`
- `npm dist-tag rm charterarc latest` returned HTTP 400
- public registry metadata documents `latest` as a required package key
- live predicate passes only because this is the sole published version

## Verification
- `git diff --check`
- Ruby workflow YAML parse
- focused experimental release tests: 2/2
- `pnpm run check:charterarc`: 50/50
- live registry predicate: PASS

This is a transport-layer exception only. Consumers remain pinned to the exact version or `@experimental`; no stable release or compatibility promise is introduced.