### PR TITLE
docs(charterarc): record experimental activation evidence

### DIFF
--- a/docs/internal/charterarc-autonomous-goal.md
+++ b/docs/internal/charterarc-autonomous-goal.md
@@ -314,26 +314,28 @@ Each must exercise at least two observed routes or one route plus a meaningful
 Module boundary. Local ignored dependencies and frozen integration branches do
 not count as adoption.
 
-The three existing consumer branches remain pending activation candidates.
-They must migrate from the thin fixed-Flow wrapper and pass a clean registry
-install before any merge can count.
-
-**Status: migrated but not activated.** The overstory, llm-arena, and cli-lab
-consumer branches now retain two, four, and two independently selectable Flows
+**Activation status: 2/3; M2 remains 0/3.** The overstory, llm-arena, and
+cli-lab declarations retain two, four, and two independently selectable Flows
 at commits `6fb2077`, `7fc6bda`, and `50806e6`. Each passed 7/7 consumer
-acceptance checks from a fresh archive after installing the same deterministic
-`charterarc@0.2.7-experimental.0` tarball; their real repository checks ran on
-the healthy no-Run path. Their acceptance now also drives actual observer
+acceptance checks from a fresh archive after installing
+`charterarc@0.2.7-experimental.0` directly from `registry.npmjs.org`; their real
+repository checks ran on the healthy no-Run path. Overstory and llm-arena were
+then fast-forwarded to those exact commits on their clean `main` branches,
+repeated 7/7 acceptance, and returned `satisfied` with no Run while Grok was
+forced unavailable. cli-lab passed the same archive gate, but its heavily dirty
+user worktree was deliberately left untouched and its consumer branch remains
+pending activation. Their acceptance also drives actual observer
 classifiers through distinct drift routes instead of proving only static map
 shape. An executable, deliberately favorable plain-Taskflow dispatcher matches
 the same route, binding, two model calls, Run result, and re-observation. It is
 215 physical lines before each consumer's domain-specific observer and route
 map; the three migrated declaration deltas total 75 net lines. This supports a
 local product-difference claim, not a mathematical minimum: a team could write
-or share a smaller competing helper. This is still clean-artifact
-compatibility, not a clean registry install: the version has not been published
-and none of the branches has been merged or chosen for active use. M2 therefore
-remains 0/3.
+or share a smaller competing helper. Publication and two main-branch keep
+decisions remove the earlier artifact and activation blockers, but M2 still
+requires all three repositories plus a later ordinary, non-CharterArc project
+change observed through each retained declaration. No such post-activation
+change exists yet, so M2 remains 0/3 and the four-week window has not started.
 
 ### M3 — Adaptive planning seam
 

--- a/docs/internal/charterarc-cycle-metrics.md
+++ b/docs/internal/charterarc-cycle-metrics.md
@@ -90,16 +90,18 @@ After every retained external repository has one eligible baseline, alternate el
 
 - M4 counted sample: 12/20 candidate cycles across 4 local Projects; final eligibility requires M2
 - Retained integration experiments: 3/3 local consumer branches
-- Pending activation candidates: 3/3; publication and merge are not yet executed
+- Public-registry clean install: 3/3 at `charterarc@0.2.7-experimental.0`; 7/7 acceptance each
+- Activated retained mains: 2/3; overstory and llm-arena are retained on `main`
+- Pending activation candidates: 1/3; cli-lab remains isolated to protect unrelated user WIP
 - Active external adoption: 0/3; M2 is unproven
-- Observation window: not started; no active adopted external branch exists
+- Observation window: not started; no retained consumer has yet observed a later ordinary project change
 - Eligible comparative cohort: 0 CharterArc / 0 baseline; M4 value verdict unavailable
 - Historical human judgment baseline: `—`; no same-protocol source exists
 - Matured accepted changes: 0; seven-day rework and rollback rates unavailable
 - Twenty-seven Grok Runs were executed; twenty-six reported 363 turns and $8.7856512
 - Twenty-four fully reported rows total 2,175,058 input, 133,822 output, and 10,226,176 cache-read tokens
 - Three additional zero-model Taskflow attempts failed closed during verification or startup; none is a Grok Run or an M4 cycle
-- Pending next refresh: none
+- Pending next refresh: the next natural non-CharterArc change in each activated consumer; cli-lab activation only after its user worktree is clean
 
 ## Cycles
 
@@ -141,6 +143,7 @@ After every retained external repository has one eligible baseline, alternate el
 | 2026-08-03-charterarc-experimental-release-ready | CharterArc | no | accepted | 1 | — | — | Flow verify; 42/42; 124 host/release; exact public-dependency tarball install; YAML parse; invalid-Grok healthy no-Run | experimental path prepared; publish and three merges await execution approval | n/a/n/a | 27 | 0.7236296 | 127,270/15,916/1,245,312 | npm `experimental` channel prepared; not published | 0/0/0 |
 | 2026-08-03-multiflow-consumer-migration | three consumer branches | no | accepted | 0 | 0 | — | one deterministic artifact set; fresh archives; 7/7 acceptance each; real healthy observers and two actual routes | multi-Flow branches retained; npm publish and merges still pending | n/a/n/a | — | — | — | existing Project/Flow maps; no new runtime concept | 0/0/0 |
 | 2026-08-03-plain-taskflow-baseline | CharterArc plus three consumer branches | no | accepted | 0 | 0 | — | executable Taskflow-only dispatcher; route/binding/Run/re-observation parity; two identical model calls; 50/50 CharterArc checks | local product difference supported; M2 remains 0/3 | n/a/n/a | — | — | — | test-only baseline; no new runtime concept | 0/0/0 |
+| 2026-08-03-experimental-publish-activation | CharterArc plus three consumers | no | narrowed | 2 | — | — | SLSA/integrity/ref/SHA/owner verified; registry.npmjs.org install; 7/7 x3 archives; 7/7 x2 retained mains; direct healthy zero-Run x2 | overstory and llm-arena activated; cli-lab WIP untouched; await later ordinary changes | n/a/n/a | — | — | — | npm experimental artifact; no stable concept | 0/0/0 |
 
 ### Timing evidence
 

--- a/docs/internal/charterarc-refactor.md
+++ b/docs/internal/charterarc-refactor.md
@@ -709,19 +709,30 @@ unstarted. The probe adds no installer, registry, API, phase, or public concept.
 
 The user then authorized the narrower experimental route: before M4,
 CharterArc may use a semver prerelease on npm's `experimental` dist-tag with no
-stable compatibility promise. `latest` and the stable Taskflow release remain
-outside that authorization. The package is prepared as
-`charterarc@0.2.7-experimental.0` behind a dedicated tag-triggered workflow that
-packs and smoke-installs one deterministic tarball, publishes it with
-provenance, verifies the exact registry artifact, and fails if this version is
-bound to `latest`. CharterArc stays outside the stable nine-package release.
+stable compatibility promise. CharterArc stays outside the stable nine-package
+release. After an explicit execution checklist, tag
+`charterarc-v0.2.7-experimental.0` published one deterministic artifact with
+SLSA provenance. A replay rebuilt the tag, matched registry integrity, verified
+the repository, workflow, ref, release commit, and npm owner, and then passed
+the complete packed smoke and CharterArc acceptance.
 
-This is release readiness, not a release: no tag was pushed and npm was not
-mutated. The three retained consumer branches are now classified as pending
-activation candidates, not active adoptions. Publication and each consumer
-merge require a fresh execution-time checklist and explicit approval. M2 and
-the four-week window remain at zero until those events occur and a later
-ordinary project change passes through the retained Project.
+The first publish exposed a registry constraint rather than a product rule:
+the public npm registry requires package metadata to retain `latest` and
+rejected its removal with HTTP 400, even though publication explicitly used
+`--tag experimental`. The workflow now accepts `latest` equal to this version
+only while it is the sole published version; it never sets or moves `latest`.
+Consumers pin the exact prerelease or `@experimental`, and no stable
+compatibility promise exists.
+
+Fresh archive-only checkouts of all three consumer commits then installed the
+exact artifact directly from `registry.npmjs.org` with matching integrity and
+passed 7/7 acceptance apiece. Overstory and llm-arena were fast-forwarded to
+their consumer commits on clean `main` branches and repeated 7/7 plus direct
+healthy, missing-Grok zero-Run observations. cli-lab's archive passed, but its
+dirty user worktree was intentionally not merged. This establishes 2/3
+activation and removes the distribution blocker; it does not establish active
+adoption until all three are retained and later ordinary project changes pass
+through their Projects. M2 and the four-week window therefore remain at zero.
 
 ## Declarative multi-Flow reset
 
@@ -751,12 +762,14 @@ All three retained consumer branches then migrated without a model Run:
 - llm-arena `7fc6bda`: entrypoint, Python, web-lint, and web-build Flows;
 - cli-lab `50806e6`: registry and package-doctor Flows.
 
-Each branch points to `charterarc@0.2.7-experimental.0`. The same deterministic
-local tarballs were installed into archive-only checkouts with no pre-existing
-root or CharterArc dependencies; all three consumers passed 7/7 acceptance
-checks and their real healthy observers started no Grok Run. The tarball source
-was local, not npm, so publication and merge remain pending execution decisions.
-M2 is still 0/3 and the four-week window has not started.
+Each declaration points to `charterarc@0.2.7-experimental.0`. The original
+deterministic local-tarball gate passed from archive-only checkouts with no
+pre-existing root or CharterArc dependencies; the later public-registry gate
+repeated 7/7 for all three against the exact npm artifact. Overstory and
+llm-arena now retain those declarations on `main`; cli-lab remains isolated on
+its consumer branch to protect unrelated user WIP. M2 is still 0/3 because no
+post-activation ordinary project change has passed through these Projects, and
+the four-week window has not started.
 
 The migrations remove model-side prompt branching by choosing a narrower Flow
 before execution, but they do not remove the consumer-specific observation
@@ -799,10 +812,11 @@ the irreducible domain observer and route map in each repository, with no extra
 model or human review step.
 
 This passes the local product-difference and handwritten-glue condition. It
-does not prove active adoption. The package is unpublished, the three branches
-are unmerged, M2 remains `0/3`, and the four-week window has not started. A
-shared observer or repository adapter remains rejected until repeated retained
-consumers expose the same removable domain judgment.
+does not prove active adoption. The prerelease is public and two clean consumer
+mains retain it, while cli-lab remains pending; none has yet processed a later
+ordinary project change. M2 remains `0/3`, and the four-week window has not
+started. A shared observer or repository adapter remains rejected until
+repeated retained consumers expose the same removable domain judgment.
 
 Add a public concept only when multiple retained consumers cannot remain simple
 with `Project / optional Module / Flow-map + Taskflow`.

--- a/packages/charterarc/test/self-dogfood.test.ts
+++ b/packages/charterarc/test/self-dogfood.test.ts
@@ -388,6 +388,12 @@ test("longitudinal evidence: measures M4 without turning evidence into runtime s
 	assert.match(goal, /executable, deliberately favorable plain-Taskflow dispatcher/i);
 	assert.match(metrics, /2026-08-03-plain-taskflow-baseline/);
 	assert.match(metrics, /M2 remains 0\/3/);
+	assert.match(goal, /Activation status: 2\/3; M2 remains 0\/3/);
+	assert.match(goal, /directly from `registry\.npmjs\.org`/);
+	assert.match(metrics, /Public-registry clean install: 3\/3/);
+	assert.match(metrics, /Activated retained mains: 2\/3/);
+	assert.match(metrics, /Pending activation candidates: 1\/3/);
+	assert.match(metrics, /2026-08-03-experimental-publish-activation/);
 	const refactor = await readFile(
 		path.join(root, "docs/internal/charterarc-refactor.md"),
 		"utf8",
@@ -395,6 +401,7 @@ test("longitudinal evidence: measures M4 without turning evidence into runtime s
 	assert.match(refactor, /## Plain Taskflow paired baseline/);
 	assert.match(refactor, /215\s+physical lines/);
 	assert.match(refactor, /570 fewer handwritten lines/);
+	assert.match(refactor, /public npm registry requires package metadata to retain `latest`/);
 	assert.match(refactor, /M2 remains `0\/3`/);
 	assert.doesNotMatch(`${goal}\n${metrics}`, /\bledger\b/i);
 


### PR DESCRIPTION
## Summary
- record the verified experimental npm publication and the registry-forced first-publish `latest` constraint
- record 3/3 clean installs from `registry.npmjs.org` and 7/7 acceptance per archive
- record overstory and llm-arena activation on clean `main` branches
- preserve cli-lab as pending because its user worktree remains dirty
- keep M2 at 0/3 until every retained Project observes a later ordinary project change

## Evidence
- publish workflow: https://github.com/heggria/taskflow/actions/runs/30811765228
- overstory `main`: `6fb2077`, 7/7, direct healthy zero-Run
- llm-arena `main`: `7fc6bda`, 7/7, direct healthy zero-Run
- cli-lab archive: `50806e6`, registry install, 7/7; dirty `main` untouched
- `pnpm run check:charterarc`: 50/50

This PR changes experiment evidence and its immutable fact assertions only; it adds no runtime concept and claims neither M2 nor M4.