### PR TITLE
docs(charterarc): record third consumer activation

### DIFF
--- a/docs/internal/charterarc-autonomous-goal.md
+++ b/docs/internal/charterarc-autonomous-goal.md
@@ -314,7 +314,7 @@ Each must exercise at least two observed routes or one route plus a meaningful
 Module boundary. Local ignored dependencies and frozen integration branches do
 not count as adoption.
 
-**Activation status: 2/3; M2 remains 0/3.** The overstory, llm-arena, and
+**Activation status: 3/3; M2 remains 0/3.** The overstory, llm-arena, and
 cli-lab declarations retain two, four, and two independently selectable Flows
 at commits `6fb2077`, `7fc6bda`, and `50806e6`. Each passed 7/7 consumer
 acceptance checks from a fresh archive after installing
@@ -322,16 +322,19 @@ acceptance checks from a fresh archive after installing
 repository checks ran on the healthy no-Run path. Overstory and llm-arena were
 then fast-forwarded to those exact commits on their clean `main` branches,
 repeated 7/7 acceptance, and returned `satisfied` with no Run while Grok was
-forced unavailable. cli-lab passed the same archive gate, but its heavily dirty
-user worktree was deliberately left untouched and its consumer branch remains
-pending activation. Their acceptance also drives actual observer
-classifiers through distinct drift routes instead of proving only static map
-shape. An executable, deliberately favorable plain-Taskflow dispatcher matches
+forced unavailable. cli-lab was later fast-forwarded to its exact consumer
+commit after a path-intersection audit proved that the five added CharterArc
+files did not overlap its heavily dirty user worktree. Its ignored local
+dependencies were installed from the public registry without lifecycle scripts;
+7/7 acceptance, `cli-lab doctor`, and a missing-Grok healthy zero-Run invocation
+passed while the user's WIP remained untouched. Their acceptance also drives
+actual observer classifiers through distinct drift routes instead of proving
+only static map shape. An executable, deliberately favorable plain-Taskflow dispatcher matches
 the same route, binding, two model calls, Run result, and re-observation. It is
 215 physical lines before each consumer's domain-specific observer and route
 map; the three migrated declaration deltas total 75 net lines. This supports a
 local product-difference claim, not a mathematical minimum: a team could write
-or share a smaller competing helper. Publication and two main-branch keep
+or share a smaller competing helper. Publication and three main-branch keep
 decisions remove the earlier artifact and activation blockers, but M2 still
 requires all three repositories plus a later ordinary, non-CharterArc project
 change observed through each retained declaration. No such post-activation

--- a/docs/internal/charterarc-cycle-metrics.md
+++ b/docs/internal/charterarc-cycle-metrics.md
@@ -91,8 +91,8 @@ After every retained external repository has one eligible baseline, alternate el
 - M4 counted sample: 12/20 candidate cycles across 4 local Projects; final eligibility requires M2
 - Retained integration experiments: 3/3 local consumer branches
 - Public-registry clean install: 3/3 at `charterarc@0.2.7-experimental.0`; 7/7 acceptance each
-- Activated retained mains: 2/3; overstory and llm-arena are retained on `main`
-- Pending activation candidates: 1/3; cli-lab remains isolated to protect unrelated user WIP
+- Activated retained mains: 3/3; overstory, llm-arena, and cli-lab are retained on `main`
+- Pending activation candidates: 0/3
 - Active external adoption: 0/3; M2 is unproven
 - Observation window: not started; no retained consumer has yet observed a later ordinary project change
 - Eligible comparative cohort: 0 CharterArc / 0 baseline; M4 value verdict unavailable
@@ -101,7 +101,7 @@ After every retained external repository has one eligible baseline, alternate el
 - Twenty-seven Grok Runs were executed; twenty-six reported 363 turns and $8.7856512
 - Twenty-four fully reported rows total 2,175,058 input, 133,822 output, and 10,226,176 cache-read tokens
 - Three additional zero-model Taskflow attempts failed closed during verification or startup; none is a Grok Run or an M4 cycle
-- Pending next refresh: the next natural non-CharterArc change in each activated consumer; cli-lab activation only after its user worktree is clean
+- Pending next refresh: the next natural non-CharterArc change in each activated consumer
 
 ## Cycles
 
@@ -144,6 +144,7 @@ After every retained external repository has one eligible baseline, alternate el
 | 2026-08-03-multiflow-consumer-migration | three consumer branches | no | accepted | 0 | 0 | — | one deterministic artifact set; fresh archives; 7/7 acceptance each; real healthy observers and two actual routes | multi-Flow branches retained; npm publish and merges still pending | n/a/n/a | — | — | — | existing Project/Flow maps; no new runtime concept | 0/0/0 |
 | 2026-08-03-plain-taskflow-baseline | CharterArc plus three consumer branches | no | accepted | 0 | 0 | — | executable Taskflow-only dispatcher; route/binding/Run/re-observation parity; two identical model calls; 50/50 CharterArc checks | local product difference supported; M2 remains 0/3 | n/a/n/a | — | — | — | test-only baseline; no new runtime concept | 0/0/0 |
 | 2026-08-03-experimental-publish-activation | CharterArc plus three consumers | no | narrowed | 2 | — | — | SLSA/integrity/ref/SHA/owner verified; registry.npmjs.org install; 7/7 x3 archives; 7/7 x2 retained mains; direct healthy zero-Run x2 | overstory and llm-arena activated; cli-lab WIP untouched; await later ordinary changes | n/a/n/a | — | — | — | npm experimental artifact; no stable concept | 0/0/0 |
+| 2026-08-03-cli-lab-main-activation | cli-lab | no | accepted | 0 | 0 | — | exact fast-forward; activation/WIP path intersection empty; public dependencies installed under ignored node_modules with scripts disabled; 7/7 acceptance; doctor; missing-Grok healthy zero-Run | all 3 mains activated; await later ordinary changes | n/a/n/a | — | — | — | no new concept | 0/0/0 |
 
 ### Timing evidence
 

--- a/docs/internal/charterarc-refactor.md
+++ b/docs/internal/charterarc-refactor.md
@@ -734,6 +734,16 @@ activation and removes the distribution blocker; it does not establish active
 adoption until all three are retained and later ordinary project changes pass
 through their Projects. M2 and the four-week window therefore remain at zero.
 
+A later exact path-intersection audit proved that cli-lab's candidate added only
+five `.charterarc` / `.grok` files and overlapped none of the user's modified or
+untracked WIP. Its `main` branch was therefore fast-forwarded to `50806e6`
+without touching that WIP. The pinned public dependencies were installed only
+under ignored `.charterarc/node_modules` with lifecycle scripts disabled and
+without changing a tracked lockfile. The activated main then passed 7/7 consumer
+acceptance, `cli-lab doctor`, and a missing-Grok healthy invocation with no Run.
+Activation is now 3/3, but M2 remains 0/3 until each retained Project observes a
+later ordinary non-CharterArc change.
+
 ## Declarative multi-Flow reset
 
 The North-Star reset removed the old single-Flow compatibility form rather than
@@ -765,9 +775,9 @@ All three retained consumer branches then migrated without a model Run:
 Each declaration points to `charterarc@0.2.7-experimental.0`. The original
 deterministic local-tarball gate passed from archive-only checkouts with no
 pre-existing root or CharterArc dependencies; the later public-registry gate
-repeated 7/7 for all three against the exact npm artifact. Overstory and
-llm-arena now retain those declarations on `main`; cli-lab remains isolated on
-its consumer branch to protect unrelated user WIP. M2 is still 0/3 because no
+repeated 7/7 for all three against the exact npm artifact. All three now retain
+those declarations on `main`; cli-lab was activated only after the later exact
+path-intersection audit described above. M2 is still 0/3 because no
 post-activation ordinary project change has passed through these Projects, and
 the four-week window has not started.
 
@@ -812,8 +822,8 @@ the irreducible domain observer and route map in each repository, with no extra
 model or human review step.
 
 This passes the local product-difference and handwritten-glue condition. It
-does not prove active adoption. The prerelease is public and two clean consumer
-mains retain it, while cli-lab remains pending; none has yet processed a later
+does not prove active adoption. The prerelease is public and all three consumer
+mains retain it; none has yet processed a later
 ordinary project change. M2 remains `0/3`, and the four-week window has not
 started. A shared observer or repository adapter remains rejected until
 repeated retained consumers expose the same removable domain judgment.

--- a/packages/charterarc/test/self-dogfood.test.ts
+++ b/packages/charterarc/test/self-dogfood.test.ts
@@ -388,12 +388,13 @@ test("longitudinal evidence: measures M4 without turning evidence into runtime s
 	assert.match(goal, /executable, deliberately favorable plain-Taskflow dispatcher/i);
 	assert.match(metrics, /2026-08-03-plain-taskflow-baseline/);
 	assert.match(metrics, /M2 remains 0\/3/);
-	assert.match(goal, /Activation status: 2\/3; M2 remains 0\/3/);
+	assert.match(goal, /Activation status: 3\/3; M2 remains 0\/3/);
 	assert.match(goal, /directly from `registry\.npmjs\.org`/);
 	assert.match(metrics, /Public-registry clean install: 3\/3/);
-	assert.match(metrics, /Activated retained mains: 2\/3/);
-	assert.match(metrics, /Pending activation candidates: 1\/3/);
+	assert.match(metrics, /Activated retained mains: 3\/3/);
+	assert.match(metrics, /Pending activation candidates: 0\/3/);
 	assert.match(metrics, /2026-08-03-experimental-publish-activation/);
+	assert.match(metrics, /2026-08-03-cli-lab-main-activation/);
 	const refactor = await readFile(
 		path.join(root, "docs/internal/charterarc-refactor.md"),
 		"utf8",


### PR DESCRIPTION
## Summary

- record cli-lab as the third activated CharterArc consumer
- keep active M2 adoption at 0/3 until later ordinary project changes occur
- keep the longitudinal M4 observation window explicitly unstarted

## Verification

- `pnpm run check:charterarc` (50/50)
- cli-lab consumer acceptance (7/7)
- `uv run cli-lab doctor`
- healthy run with a deliberately missing Grok binary returns satisfied with no Run

No model was invoked and no runtime surface changed.