### PR TITLE
fix(pi): make approvals deliberate and reviewable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to taskflow are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [0.2.8] — 2026-08-10
+
+### Fixed
+
+- **Pi approval confirmation.** Approval choices are now selection-only: `A` / `E` / `R`, arrows, and Tab move the pending decision, while Enter confirms it. The dialog starts on Reject, so an accidental Enter fails closed; Escape and Ctrl-C still reject immediately.
+- **Large approval proposals.** Long proposals start collapsed, `V` toggles an inline scrollable preview, and the decision footer remains visible while reviewing. Short proposals remain expanded by default.
+- **Kitty keyboard handling.** Press, repeat, and release events are decoded explicitly so key-release frames cannot trigger a decision and repeated preview keys cannot double-toggle the proposal.
+
+### Changed
+
+- Root, all nine publishable packages, plugin manifests, MCP install pins, and server-version contracts are aligned to **0.2.8**.
+
+### Security
+
+- Force patched transitive versions of **`brace-expansion@5.0.9`** and **`nanoid@3.3.17`** via pnpm overrides; the production dependency audit is clean.
+
 ## [0.2.7] — 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **English** · [简体中文](./README.zh-CN.md)
 
-[Install](#install-on-your-host) · [Quickstart](#60-second-start) · [What's new in 0.2.7](#027-plan-before-spend--close-the-loop) · [0.2 compiler turn](#02-is-the-compiler-turn) · [Docs](https://heggria.github.io/taskflow/en/docs) · [Examples](./examples)
+[Install](#install-on-your-host) · [Quickstart](#60-second-start) · [What's new in 0.2.8](#028-review-then-confirm) · [0.2 compiler turn](#02-is-the-compiler-turn) · [Docs](https://heggria.github.io/taskflow/en/docs) · [Examples](./examples)
 
 </div>
 
@@ -151,6 +151,12 @@ This is real output from a Pi run—not a mock dashboard:
 ```
 
 The layout **is** the DAG. Parallel rails expose concurrency; long edges expose dependencies; the gate explains why downstream work stopped. No separate control plane is required to understand the run.
+
+## 0.2.8: review, then confirm
+
+Pi approvals now separate **selection** from **commit**. Choose Reject, Edit guidance, or Approve with `R` / `E` / `A`, arrows, or Tab; press Enter to confirm. The safe default is Reject, and Escape or Ctrl-C still rejects immediately.
+
+Long proposals start collapsed. Press `V` to open an inline scrollable preview while the decision footer stays visible; short proposals remain open by default. Full notes: [CHANGELOG 0.2.8](./CHANGELOG.md#028--2026-08-10).
 
 ## 0.2.7: plan before spend · close the loop
 
@@ -343,7 +349,7 @@ claude plugin install claude-taskflow@taskflow
 
 ```bash
 opencode mcp add taskflow -- \
-  npx -y -p opencode-taskflow@0.2.7 opencode-taskflow-mcp
+  npx -y -p opencode-taskflow@0.2.8 opencode-taskflow-mcp
 ```
 
 [OpenCode guide →](https://heggria.github.io/taskflow/en/docs/guides/opencode)
@@ -352,7 +358,7 @@ opencode mcp add taskflow -- \
 
 ```bash
 grok mcp add taskflow -- \
-  npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+  npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 Grok Build support is new in 0.2. Its CLI stream does not report token/cost usage, so budget-declaring flows are rejected rather than silently running without enforcement.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 [English](./README.md) · **简体中文**
 
-[安装](#安装到你的宿主) · [快速开始](#60-秒开始) · [0.2.7 新能力](#027-花-token-前先计划--跑完闭环) · [0.2 编译器转身](#02-是编译器转身) · [文档](https://heggria.github.io/taskflow/zh-cn/docs) · [示例](./examples)
+[安装](#安装到你的宿主) · [快速开始](#60-秒开始) · [0.2.8 新能力](#028-先审阅再确认) · [0.2 编译器转身](#02-是编译器转身) · [文档](https://heggria.github.io/taskflow/zh-cn/docs) · [示例](./examples)
 
 </div>
 
@@ -151,6 +151,12 @@ pi install npm:pi-taskflow
 ```
 
 布局**本身就是 DAG**。并行轨道暴露并发，长边暴露依赖，gate 解释下游为什么停止。你不需要另一套控制平面才能看懂运行状态。
+
+## 0.2.8：先审阅，再确认
+
+Pi 审批现在把**选择**和**提交**分开：用 `R` / `E` / `A`、方向键或 Tab 选择拒绝、编辑意见或批准，再按 Enter 确认。默认停在拒绝；Escape 和 Ctrl-C 仍会立即拒绝。
+
+长提案默认折叠，按 `V` 可在原位展开并滚动审阅，决策栏始终可见；短提案默认展开。完整说明：[CHANGELOG 0.2.8](./CHANGELOG.md#028--2026-08-10)。
 
 ## 0.2.7：花 token 前先计划 · 跑完闭环
 
@@ -338,7 +344,7 @@ claude plugin install claude-taskflow@taskflow
 
 ```bash
 opencode mcp add taskflow -- \
-  npx -y -p opencode-taskflow@0.2.7 opencode-taskflow-mcp
+  npx -y -p opencode-taskflow@0.2.8 opencode-taskflow-mcp
 ```
 
 [OpenCode 指南 →](https://heggria.github.io/taskflow/zh-cn/docs/guides/opencode)
@@ -347,7 +353,7 @@ opencode mcp add taskflow -- \
 
 ```bash
 grok mcp add taskflow -- \
-  npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+  npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 Grok Build 支持在 0.2 首次加入。其 CLI stream 不返回 token/cost 用量，因此声明了预算的 flow 会被拒绝，而不是在无法执行预算约束时静默运行。

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,8 +81,8 @@ the matching annotated tag:
 ```sh
 git switch main
 git pull --ff-only origin main
-git tag -a v0.2.7 -m "Release v0.2.7"
-git push origin v0.2.7
+git tag -a v0.2.8 -m "Release v0.2.8"
+git push origin v0.2.8
 ```
 
 `.github/workflows/publish.yml` then performs the complete release transaction:
@@ -140,6 +140,6 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (published MCP package)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```

--- a/docs/claude-mcp.md
+++ b/docs/claude-mcp.md
@@ -35,7 +35,7 @@ Verify:
 
 ```sh
 claude plugin list   # → claude-taskflow@taskflow  installed, enabled
-claude mcp list      # → taskflow … (npx -y -p claude-taskflow@0.2.7 claude-taskflow-mcp)
+claude mcp list      # → taskflow … (npx -y -p claude-taskflow@0.2.8 claude-taskflow-mcp)
 ```
 
 The bundled skill tells Claude Code *when* to reach for the tools (multi-phase

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -31,7 +31,7 @@ globally, and the plugin version binds the exact code that runs. Verify:
 
 ```sh
 codex plugin list   # → taskflow@taskflow  installed, enabled
-codex mcp list      # → taskflow … enabled  (npx -y -p codex-taskflow@0.2.7 codex-taskflow-mcp)
+codex mcp list      # → taskflow … enabled  (npx -y -p codex-taskflow@0.2.8 codex-taskflow-mcp)
 ```
 
 The bundled skill tells Codex *when* to reach for the tools (multi-phase or
@@ -70,7 +70,7 @@ To stop large flows from being cut off, the plugin's `.mcp.json` ships a
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.2.7", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.2.8", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/docs/grok-mcp.md
+++ b/docs/grok-mcp.md
@@ -27,7 +27,7 @@ Official Grok docs used for this integration:
 ## Install (recommended): register the published MCP server
 
 ```sh
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 A public Grok plugin marketplace/source is not published yet. Do not substitute
@@ -179,7 +179,7 @@ grok mcp add taskflow -- grok-taskflow-mcp
 Or with npx (no global install):
 
 ```sh
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 Verify:

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **هذه الترجمة قديمة.** يُرجى مراجعة [README بالإنجليزية](../../README.md) للحصول على أحدث المعلومات.
 
-taskflow رسم بياني تصريحي وقابل للتحقق للمهام على Pi وCodex وClaude Code وOpenCode وGrok Build. خط 0.2.7 يتطلب Node.js ≥ 22.19.0 ويضم 12 نوعًا من المراحل وأكثر من 1500 اختبار. طبقة MCP لا تعتمد على MCP SDK؛ يستخدم core ‏`typebox` كـ peer ويعتمد DSL على TypeScript.
+taskflow رسم بياني تصريحي وقابل للتحقق للمهام على Pi وCodex وClaude Code وOpenCode وGrok Build. خط 0.2.8 يتطلب Node.js ≥ 22.19.0 ويضم 12 نوعًا من المراحل وأكثر من 1500 اختبار. طبقة MCP لا تعتمد على MCP SDK؛ يستخدم core ‏`typebox` كـ peer ويعتمد DSL على TypeScript.
 
 > **لماذا "taskflow" وليس "workflow"؟** الـ *workflow* (بنمط code-mode) هو برنامج أمري *يتدفق*، ورسمه البياني مخبأ داخل تدفق التحكم. أما الـ *taskflow* فينقل الخطة إلى رسم بياني تصريحي من عقد مهام منفصلة — يمكن التحقق منه ساكنًا وعرضه واستئنافه وحفظه كأمر. نحن نستبدل القدرة التعبيرية بالقابلية للتحقق، عن قصد.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.bn.md
+++ b/docs/i18n/README.bn.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **এই অনুবাদটি পুরোনো।** অনুগ্রহ করে সর্বশেষ তথ্যের জন্য [ইংরেজি README](../../README.md) দেখুন।
 
-taskflow Pi, Codex, Claude Code, OpenCode ও Grok Build-এর জন্য একটি ডিক্লারেটিভ, যাচাইযোগ্য টাস্ক গ্রাফ। 0.2.7 লাইনে Node.js ≥ 22.19.0, 12টি phase kind এবং 1500+ পরীক্ষা রয়েছে। MCP layer-এর MCP SDK dependency নেই; core-এর peer `typebox`, আর DSL TypeScript-এর উপর নির্ভরশীল।
+taskflow Pi, Codex, Claude Code, OpenCode ও Grok Build-এর জন্য একটি ডিক্লারেটিভ, যাচাইযোগ্য টাস্ক গ্রাফ। 0.2.8 লাইনে Node.js ≥ 22.19.0, 12টি phase kind এবং 1500+ পরীক্ষা রয়েছে। MCP layer-এর MCP SDK dependency নেই; core-এর peer `typebox`, আর DSL TypeScript-এর উপর নির্ভরশীল।
 
 > **কেন "taskflow", "workflow" নয় কেন?** একটি *workflow* (code-mode) হল একটি ইম্পারেটিভ স্ক্রিপ্ট যা *প্রবাহিত হয়*, যার গ্রাফ কন্ট্রোল ফ্লোর মধ্যে লুকানো। একটি *taskflow* পরিকল্পনাকে পৃথক টাস্ক নোডের একটি ডিক্লারেটিভ গ্রাফে সরিয়ে নেয় — যা স্থিরভাবে যাচাই, দৃশ্যমান, পুনরারম্ভ এবং একটি কমান্ড হিসেবে সংরক্ষণ করা যায়। আমরা ইচ্ছাকৃতভাবে এক্সপ্রেসিভনেসকে যাচাইযোগ্যতার বিনিময়ে দিই।
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Esta traducción está desactualizada.** Consulta el [README en inglés](../../README.md) para obtener la información más reciente.
 
-taskflow es un *grafo de tareas* declarativo y verificable para agentes de codificación — funciona en Pi, Codex, Claude Code, OpenCode y Grok Build. Línea 0.2.7: Node.js ≥ 22.19.0, 12 tipos de fase y más de 1500 pruebas. La capa MCP no depende de un SDK MCP; core usa `typebox` como peer y el DSL depende de TypeScript.
+taskflow es un *grafo de tareas* declarativo y verificable para agentes de codificación — funciona en Pi, Codex, Claude Code, OpenCode y Grok Build. Línea 0.2.8: Node.js ≥ 22.19.0, 12 tipos de fase y más de 1500 pruebas. La capa MCP no depende de un SDK MCP; core usa `typebox` como peer y el DSL depende de TypeScript.
 
 > **¿Por qué "taskflow" y no "workflow"?** Un *workflow* (estilo code-mode) es un script imperativo que *fluye*, con el grafo oculto en el control de flujo. Un *taskflow* mueve el plan a un grafo declarativo de nodos de tarea discretos — que se puede verificar estáticamente, visualizar, reanudar y guardar como un comando. Cambiamos expresividad por verificabilidad, a propósito.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **यह अनुवाद पुराना है।** कृपया नवीनतम जानकारी के लिए [अंग्रेज़ी README](../../README.md) देखें।
 
-taskflow Pi, Codex, Claude Code, OpenCode और Grok Build के लिए एक घोषणात्मक, सत्यापन-योग्य टास्क ग्राफ है। 0.2.7 लाइन में Node.js ≥ 22.19.0, 12 phase kinds और 1500+ परीक्षण हैं। MCP layer किसी MCP SDK पर निर्भर नहीं है; core का peer `typebox` है और DSL TypeScript पर निर्भर है।
+taskflow Pi, Codex, Claude Code, OpenCode और Grok Build के लिए एक घोषणात्मक, सत्यापन-योग्य टास्क ग्राफ है। 0.2.8 लाइन में Node.js ≥ 22.19.0, 12 phase kinds और 1500+ परीक्षण हैं। MCP layer किसी MCP SDK पर निर्भर नहीं है; core का peer `typebox` है और DSL TypeScript पर निर्भर है।
 
 > **"taskflow" क्यों, "workflow" क्यों नहीं?** एक *workflow* (code-mode) एक आज्ञात्मक स्क्रिप्ट है जो *बहता* है, जिसका ग्राफ कंट्रोल फ़्लो में छिपा होता है। एक *taskflow* योजना को अलग-अलग टास्क नोड्स के एक घोषणात्मक ग्राफ में ले जाता है — जिसे स्थिर रूप से सत्यापित, दृश्य, पुनः शुरू और एक कमांड के रूप में सहेजा जा सकता है। हम जान-बूझकर अभिव्यक्ति को सत्यापन-योग्यता से बदलते हैं।
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.pt.md
+++ b/docs/i18n/README.pt.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Esta tradução está desatualizada.** Consulte o [README em inglês](../../README.md) para obter as informações mais recentes.
 
-taskflow é um *grafo de tarefas* declarativo e verificável para Pi, Codex, Claude Code, OpenCode e Grok Build. Linha 0.2.7: Node.js ≥ 22.19.0, 12 tipos de fase e mais de 1500 testes. A camada MCP não depende de um SDK MCP; core usa `typebox` como peer e o DSL depende de TypeScript.
+taskflow é um *grafo de tarefas* declarativo e verificável para Pi, Codex, Claude Code, OpenCode e Grok Build. Linha 0.2.8: Node.js ≥ 22.19.0, 12 tipos de fase e mais de 1500 testes. A camada MCP não depende de um SDK MCP; core usa `typebox` como peer e o DSL depende de TypeScript.
 
 > **Por que "taskflow" e não "workflow"?** Um *workflow* (estilo code-mode) é um script imperativo que *flui*, com o grafo escondido no controle de fluxo. Um *taskflow* move o plano para um grafo declarativo de nós de tarefa discretos — que pode ser verificado estaticamente, visualizado, retomado e salvo como um comando. Trocamos expressividade por verificabilidade, de propósito.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Этот перевод устарел.** Пожалуйста, обратитесь к [английскому README](../../README.md) за актуальной информацией.
 
-taskflow — декларативный и проверяемый граф задач для Pi, Codex, Claude Code, OpenCode и Grok Build. Линия 0.2.7: Node.js ≥ 22.19.0, 12 типов фаз и более 1500 тестов. Слой MCP не зависит от MCP SDK; core использует peer `typebox`, а DSL зависит от TypeScript.
+taskflow — декларативный и проверяемый граф задач для Pi, Codex, Claude Code, OpenCode и Grok Build. Линия 0.2.8: Node.js ≥ 22.19.0, 12 типов фаз и более 1500 тестов. Слой MCP не зависит от MCP SDK; core использует peer `typebox`, а DSL зависит от TypeScript.
 
 > **Почему "taskflow", а не "workflow"?** *Workflow* (в стиле code-mode) — это императивный скрипт, который *течёт*, а его граф спрятан в потоке управления. *Taskflow* переносит план в декларативный граф из дискретных узлов-задач — его можно статически проверить, визуализировать, возобновить и сохранить как команду. Мы осознанно меняем выразительность на проверяемость.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow-monorepo",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"private": true,
 	"description": "Monorepo for the Taskflow engine and DSL, host adapters, delivery packages, documentation, and the private CharterArc experiment.",
 	"type": "module",

--- a/packages/claude-taskflow/package.json
+++ b/packages/claude-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claude-taskflow",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Run taskflow on Claude Code: a Claude subagent runner plus an MCP server (and a plug-and-play Claude Code plugin) that exposes the taskflow_* tools to Claude Code users.",
 	"keywords": [
 		"claude",

--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/claude-taskflow/plugin/.mcp.json
+++ b/packages/claude-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "claude-taskflow@0.2.7", "claude-taskflow-mcp"]
+      "args": ["-y", "-p", "claude-taskflow@0.2.8", "claude-taskflow-mcp"]
     }
   }
 }

--- a/packages/claude-taskflow/test/mcp-server.test.ts
+++ b/packages/claude-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("claude mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-claude");
-	assert.equal(res.result.serverInfo.version, "0.2.7");
+	assert.equal(res.result.serverInfo.version, "0.2.8");
 });
 
 test("claude mcp: tools/list exposes the same taskflow tools as codex", async () => {

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-taskflow",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Run taskflow on OpenAI Codex: a Codex subagent runner plus an MCP server (and a plug-and-play Codex plugin) that exposes the taskflow_* tools to Codex users.",
 	"keywords": [
 		"codex",

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.2.7", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.2.8", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
+++ b/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
@@ -79,7 +79,7 @@ send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "
 const init = await waitFor(1, "initialize");
 assert.equal(init.result.protocolVersion, "2025-06-18");
 assert.equal(init.result.serverInfo.name, "taskflow-codex");
-assert.equal(init.result.serverInfo.version, "0.2.7");
+assert.equal(init.result.serverInfo.version, "0.2.8");
 ok(`initialize → ${JSON.stringify(init.result.serverInfo)}`);
 
 // notification must NOT produce a response

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -51,7 +51,7 @@ test("mcp: initialize returns the protocol version + serverInfo codex expects", 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-codex");
-	assert.equal(res.result.serverInfo.version, "0.2.7");
+	assert.equal(res.result.serverInfo.version, "0.2.8");
 });
 
 test("mcp: tools/list exposes the taskflow tools with schemas", async () => {

--- a/packages/grok-taskflow/package.json
+++ b/packages/grok-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grok-taskflow",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Run taskflow on Grok Build: a Grok subagent runner plus an MCP server (and a plug-and-play Grok plugin) that exposes the taskflow_* tools to Grok Build users.",
 	"keywords": [
 		"grok",

--- a/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
+++ b/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/grok-taskflow/plugin/.mcp.json
+++ b/packages/grok-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "grok-taskflow@0.2.7", "grok-taskflow-mcp"],
+      "args": ["-y", "-p", "grok-taskflow@0.2.8", "grok-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/grok-taskflow/test/mcp-server.test.ts
+++ b/packages/grok-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("grok mcp: initialize returns the protocol version + serverInfo", async () 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-grok");
-	assert.equal(res.result.serverInfo.version, "0.2.7");
+	assert.equal(res.result.serverInfo.version, "0.2.8");
 });
 
 test("grok mcp: tools/list exposes the same taskflow tools as other hosts", async () => {

--- a/packages/opencode-taskflow/package.json
+++ b/packages/opencode-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opencode-taskflow",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Run taskflow on OpenCode: an OpenCode subagent runner plus an MCP server (and an opencode.json config scaffold) that exposes the taskflow_* tools to OpenCode users.",
 	"keywords": [
 		"opencode",

--- a/packages/opencode-taskflow/plugin/opencode.json
+++ b/packages/opencode-taskflow/plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "taskflow": {
       "type": "local",
-      "command": ["npx", "-y", "-p", "opencode-taskflow@0.2.7", "opencode-taskflow-mcp"],
+      "command": ["npx", "-y", "-p", "opencode-taskflow@0.2.8", "opencode-taskflow-mcp"],
       "enabled": true
     }
   },

--- a/packages/opencode-taskflow/test/mcp-server.test.ts
+++ b/packages/opencode-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("opencode mcp: initialize returns the protocol version + serverInfo", async
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-opencode");
-	assert.equal(res.result.serverInfo.version, "0.2.7");
+	assert.equal(res.result.serverInfo.version, "0.2.8");
 });
 
 test("opencode mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
 	"keywords": [
 		"pi-package",

--- a/packages/pi-taskflow/src/approval-view.ts
+++ b/packages/pi-taskflow/src/approval-view.ts
@@ -1,10 +1,11 @@
 /**
  * Modal approval dialog for `approval` phases (ctx.ui.custom with overlay).
  *
- * Rendered as a centered bordered popup: the full upstream output (e.g. a
- * plan) is shown in a scrollable viewport so long content can be reviewed
- * before deciding. Every line is padded to the full dialog width so the
- * overlay composites cleanly (no see-through, no ghosting in scrollback).
+ * Rendered as a centered bordered popup with a sticky decision footer. Short
+ * upstream output is shown immediately; content larger than the viewport is
+ * collapsed by default and can be toggled independently. Every line is padded
+ * to the full dialog width so the overlay composites cleanly (no see-through,
+ * no ghosting in scrollback).
  *
  * Mouse tracking is intentionally NOT used here. Enabling terminal-level
  * SGR mouse reporting (DECSET 1000h/1006h) to capture wheel events would
@@ -14,12 +15,21 @@
  * Keyboard scrolling (↑↓/PgUp/PgDn/Home/End/j/k/g/G) covers the same
  * ground without risking a stuck mouse-tracking mode.
  *
- * Keys: ↑↓ scroll · PgUp/PgDn page · Home/End jump ·
- *       a/Enter approve · e edit (guidance) · r/Esc reject.
+ * Keys: A/E/R select a decision · Enter confirms · V toggles preview ·
+ *       ↑↓ scroll · PgUp/PgDn page · Home/End jump · Esc rejects.
  */
 
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	decodeKittyPrintable,
+	isKeyRelease,
+	isKeyRepeat,
+	matchesKey,
+	parseKey,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 
 export type ApprovalChoice = "approve" | "reject" | "edit";
 
@@ -33,6 +43,12 @@ export interface ApprovalViewOptions {
 }
 
 const FALLBACK_ROWS = 24;
+const DECISIONS: ApprovalChoice[] = ["reject", "edit", "approve"];
+const DECISION_LABELS: Record<ApprovalChoice, string> = {
+	reject: "Reject",
+	edit: "Edit guidance",
+	approve: "Approve",
+};
 
 export class ApprovalViewComponent {
 	private theme: Theme;
@@ -42,6 +58,8 @@ export class ApprovalViewComponent {
 	private scrollOffset = 0;
 	private cachedWidth?: number;
 	private cachedBody?: string[];
+	private previewExpanded?: boolean;
+	private selectedChoice: ApprovalChoice = "reject";
 	private decided = false;
 
 	constructor(
@@ -76,9 +94,14 @@ export class ApprovalViewComponent {
 	/** Visible body height given the message height — dialog targets ~80% of the terminal. */
 	private maxVisible(msgRows: number): number {
 		const avail = Math.max(10, Math.floor(this.rows() * 0.8));
-		// Chrome: top border, message rows, separator, scroll info, separator, hints, bottom border.
-		const chrome = 1 + msgRows + 1 + 1 + 1 + 1 + 1;
+		// Chrome: border, message, preview summary, scroll info, decision, hints, separators.
+		const chrome = msgRows + 8;
 		return Math.max(3, Math.min(avail - chrome, 60));
+	}
+
+	private upstreamLineCount(): number {
+		const upstream = (this.opts.upstream ?? "").replace(/\r\n/g, "\n").trimEnd();
+		return upstream ? upstream.split("\n").length : 0;
 	}
 
 	/** Wrap the upstream text to the viewport width (cached per width). */
@@ -113,6 +136,7 @@ export class ApprovalViewComponent {
 	}
 
 	private clampScroll(delta: number): void {
+		if (!this.previewExpanded) return;
 		const total = this.cachedBody?.length ?? 0;
 		const visible = this.maxVisible(1);
 		const cap = this.maxOffset(total, visible);
@@ -120,20 +144,34 @@ export class ApprovalViewComponent {
 	}
 
 	handleInput(data: string): void {
-		// Decisions
-		if (matchesKey(data, "return") || data === "a" || data === "y") {
-			this.decide("approve");
-			return;
-		}
-		if (data === "e") {
-			this.decide("edit");
-			return;
-		}
-		if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c") || data === "r" || data === "n") {
+		if (this.decided) return;
+		if (isKeyRelease(data)) return;
+		const printable = (decodeKittyPrintable(data) ?? parseKey(data))?.toLowerCase();
+		if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
 			this.decide("reject");
 			return;
 		}
-		// Scrolling (only meaningful when a body exists)
+		if (printable === "v" && !isKeyRepeat(data) && this.upstreamLineCount() > 0) {
+			this.previewExpanded = !(this.previewExpanded ?? false);
+			return;
+		}
+		if (matchesKey(data, "return")) {
+			this.decide(this.selectedChoice);
+			return;
+		}
+
+		if (printable === "r") this.selectedChoice = "reject";
+		else if (printable === "e") this.selectedChoice = "edit";
+		else if (printable === "a") this.selectedChoice = "approve";
+		else if (matchesKey(data, "left") || matchesKey(data, "shift+tab")) {
+			const current = DECISIONS.indexOf(this.selectedChoice);
+			this.selectedChoice = DECISIONS[(current - 1 + DECISIONS.length) % DECISIONS.length]!;
+		} else if (matchesKey(data, "right") || matchesKey(data, "tab")) {
+			const current = DECISIONS.indexOf(this.selectedChoice);
+			this.selectedChoice = DECISIONS[(current + 1) % DECISIONS.length]!;
+		}
+
+		// Scrolling is independent of the selected decision and only acts while expanded.
 		const page = this.maxVisible(1);
 		if (matchesKey(data, "up") || data === "k") {
 			this.clampScroll(-1);
@@ -168,6 +206,17 @@ export class ApprovalViewComponent {
 		return th.fg("border", left + "─".repeat(Math.max(0, width - 2)) + right);
 	}
 
+	private decisionLine(): string {
+		const th = this.theme;
+		const choices = DECISIONS.map((choice) => {
+			const label = DECISION_LABELS[choice];
+			return choice === this.selectedChoice
+				? th.fg("accent", `[${label}]`)
+				: th.fg("dim", ` ${label} `);
+		});
+		return `Decision: ${choices.join("   ")}`;
+	}
+
 	render(width: number): string[] {
 		const th = this.theme;
 		const innerW = Math.max(20, width - 4);
@@ -184,29 +233,43 @@ export class ApprovalViewComponent {
 		const msg = this.msgLines(innerW);
 		for (const l of msg) lines.push(this.row(th.fg("text", l), width));
 
-		// Scrollable upstream body
+		// Independently collapsible upstream body. Only overflowing previews start collapsed.
 		const body = this.bodyLines(innerW);
 		const visible = this.maxVisible(msg.length);
 		const cap = this.maxOffset(body.length, visible);
+		if (this.previewExpanded === undefined) this.previewExpanded = body.length > 0 && cap === 0;
 		this.scrollOffset = Math.min(this.scrollOffset, cap);
 		if (body.length > 0) {
 			lines.push(this.hrule(width, "├", "┤"));
-			const slice = body.slice(this.scrollOffset, this.scrollOffset + visible);
-			while (slice.length < Math.min(visible, body.length)) slice.push("");
-			for (const l of slice) lines.push(this.row(l, width));
-			if (cap > 0) {
-				const above = this.scrollOffset;
-				const below = Math.max(0, body.length - visible - this.scrollOffset);
-				lines.push(
-					this.row(th.fg("dim", `↑${above} more · ↓${below} more (${body.length} lines)`), width),
-				);
+			const state = this.previewExpanded ? "expanded" : "collapsed";
+			const action = this.previewExpanded ? "Hide" : "View";
+			lines.push(
+				this.row(
+					th.fg("dim", `Proposal: ${this.upstreamLineCount()} lines · ${state} · [V] ${action} proposal`),
+					width,
+				),
+			);
+			if (this.previewExpanded) {
+				const slice = body.slice(this.scrollOffset, this.scrollOffset + visible);
+				while (slice.length < Math.min(visible, body.length)) slice.push("");
+				for (const l of slice) lines.push(this.row(l, width));
+				if (cap > 0) {
+					const above = this.scrollOffset;
+					const below = Math.max(0, body.length - visible - this.scrollOffset);
+					lines.push(
+						this.row(th.fg("dim", `↑${above} more · ↓${below} more (${body.length} wrapped lines)`), width),
+					);
+				}
 			}
 		}
 
-		// Key hints
+		// Sticky decision footer: selecting never decides; Enter is always required.
 		lines.push(this.hrule(width, "├", "┤"));
-		const scrollHint = cap > 0 ? "↑↓/PgUp/PgDn scroll · " : "";
-		lines.push(this.row(th.fg("dim", `${scrollHint}a/Enter approve · e edit · r/Esc reject`), width));
+		lines.push(this.row(this.decisionLine(), width));
+		const scrollHint = this.previewExpanded && cap > 0 ? "↑↓/PgUp/PgDn scroll · " : "";
+		lines.push(
+			this.row(th.fg("dim", `${scrollHint}←/→ or R/E/A select · Enter confirm · V preview · Esc reject`), width),
+		);
 		lines.push(this.hrule(width, "╰", "╯"));
 		return lines;
 	}

--- a/packages/pi-taskflow/test/approval-view.test.ts
+++ b/packages/pi-taskflow/test/approval-view.test.ts
@@ -25,7 +25,8 @@ test("approval-view: renders title, message and hints inside a bordered dialog",
 	const text = out.join("\n");
 	assert.match(text, /Taskflow approval — flow\/checkpoint/);
 	assert.match(text, /Approve the plan\?/);
-	assert.match(text, /a\/Enter approve · e edit · r\/Esc reject/);
+	assert.match(text, /Decision: \[Reject\]\s+Edit guidance\s+Approve/);
+	assert.match(text, /←\/→ or R\/E\/A select · Enter confirm · V preview · Esc reject/);
 	assert.match(out[0], /^╭/, "top border");
 	assert.match(out[out.length - 1], /^╰/, "bottom border");
 });
@@ -39,25 +40,31 @@ test("approval-view: every rendered line is exactly the dialog width (no see-thr
 	}
 });
 
-test("approval-view: long upstream is windowed with scroll indicator", () => {
+test("approval-view: long upstream starts collapsed with a visible sticky decision", () => {
 	const upstream = Array.from({ length: 100 }, (_, i) => `line-${i}`).join("\n");
 	const { view } = mk(upstream, 24);
 	const out = view.render(80);
 	const text = out.join("\n");
-	assert.match(text, /line-0/, "top of content visible initially");
-	assert.doesNotMatch(text, /line-99\b/, "bottom not visible before scrolling");
-	assert.match(text, /↓\d+ more/, "scroll indicator shows hidden lines below");
-	assert.match(text, /scroll/, "hint mentions scrolling when content overflows");
+	assert.match(text, /Proposal: 100 lines · collapsed · \[V\] View proposal/);
+	assert.doesNotMatch(text, /line-0\b/, "overflowing content is hidden initially");
+	assert.match(text, /Decision: \[Reject\]/, "default decision remains visible");
 });
 
-test("approval-view: down/pageDown/end scroll the viewport", () => {
+test("approval-view: preview toggle is independent and expanded content remains scrollable", () => {
 	const upstream = Array.from({ length: 100 }, (_, i) => `line-${i}`).join("\n");
-	const { view } = mk(upstream, 24);
-	view.render(80); // establish wrapped body cache
-	view.handleInput("\u001b[B"); // down arrow
+	const { view, result } = mk(upstream, 24);
+	view.render(80); // establish auto-collapsed state
+	view.handleInput("v");
 	let text = view.render(80).join("\n");
+	assert.match(text, /Proposal: 100 lines · expanded · \[V\] Hide proposal/);
+	assert.match(text, /line-0/, "toggle reveals the preview");
+	assert.equal(result(), undefined, "toggling preview does not decide");
+
+	view.handleInput("\u001b[B"); // down arrow
+	text = view.render(80).join("\n");
 	assert.doesNotMatch(text, /line-0 /, "first line scrolled out");
 	assert.match(text, /↑1 more/, "indicator counts lines above");
+	assert.match(text, /Decision: \[Reject\]/, "decision remains visible while scrolled");
 
 	view.handleInput("\u001b[F"); // end
 	text = view.render(80).join("\n");
@@ -66,17 +73,24 @@ test("approval-view: down/pageDown/end scroll the viewport", () => {
 	view.handleInput("\u001b[H"); // home
 	text = view.render(80).join("\n");
 	assert.match(text, /line-0 /, "Home jumps back to the top");
+
+	view.handleInput("v");
+	text = view.render(80).join("\n");
+	assert.doesNotMatch(text, /line-0\b/, "second toggle collapses without deciding");
+	assert.equal(result(), undefined);
 });
 
-test("approval-view: decisions — enter approves, e edits, esc rejects", () => {
+test("approval-view: decisions require selection followed by Enter", () => {
 	{
 		const { view, result } = mk("x");
 		view.handleInput("\r");
-		assert.equal(result(), "approve");
+		assert.equal(result(), "reject", "default Enter fails closed");
 	}
 	{
 		const { view, result } = mk("x");
 		view.handleInput("e");
+		assert.equal(result(), undefined, "single-key edit only selects");
+		view.handleInput("\r");
 		assert.equal(result(), "edit");
 	}
 	{
@@ -87,13 +101,54 @@ test("approval-view: decisions — enter approves, e edits, esc rejects", () => 
 	{
 		const { view, result } = mk("x");
 		view.handleInput("a");
+		assert.equal(result(), undefined, "single-key approval is impossible");
+		view.handleInput("\r");
 		assert.equal(result(), "approve");
 	}
 	{
 		const { view, result } = mk("x");
 		view.handleInput("r");
+		assert.equal(result(), undefined, "single-key rejection only selects");
+		view.handleInput("\r");
 		assert.equal(result(), "reject");
 	}
+	{
+		const { view, result } = mk("x");
+		view.handleInput("\u0003"); // Ctrl-C
+		assert.equal(result(), "reject");
+	}
+});
+
+test("approval-view: arrows and Tab cycle through visible decisions", () => {
+	{
+		const { view, result } = mk("x");
+		view.handleInput("\u001b[C"); // right: reject -> edit
+		view.handleInput("\u001b[C"); // right: edit -> approve
+		assert.match(view.render(80).join("\n"), /Decision:\s+Reject\s+Edit guidance\s+\[Approve\]/);
+		view.handleInput("\r");
+		assert.equal(result(), "approve");
+	}
+	{
+		const { view, result } = mk("x");
+		view.handleInput("\u001b[Z"); // shift-tab: reject -> approve
+		view.handleInput("\r");
+		assert.equal(result(), "approve");
+	}
+});
+
+test("approval-view: Kitty printable keys select and toggle without deciding", () => {
+	const upstream = Array.from({ length: 100 }, (_, i) => `line-${i}`).join("\n");
+	const { view, result } = mk(upstream, 24);
+	view.render(80);
+	view.handleInput("\u001b[118;1:1u"); // Kitty CSI-u press: v
+	view.handleInput("\u001b[118;1:2u"); // repeat must not toggle again
+	view.handleInput("\u001b[118;1:3u"); // release must not toggle again
+	assert.match(view.render(80).join("\n"), /Proposal: 100 lines · expanded/);
+	view.handleInput("\u001b[97;1:1u"); // Kitty CSI-u press: a
+	view.handleInput("\u001b[97;1:3u"); // release is ignored
+	assert.equal(result(), undefined);
+	view.handleInput("\r");
+	assert.equal(result(), "approve");
 });
 
 test("approval-view: decision fires only once", () => {
@@ -101,6 +156,7 @@ test("approval-view: decision fires only once", () => {
 	const view = new ApprovalViewComponent(theme, { title: "t", message: "m" }, () => {
 		calls++;
 	});
+	view.handleInput("a");
 	view.handleInput("\r");
 	view.handleInput("\u001b");
 	view.handleInput("e");
@@ -120,6 +176,7 @@ test("approval-view: no upstream → no scroll hint, no scroll indicator", () =>
 	const text = view.render(80).join("\n");
 	assert.doesNotMatch(text, /more/, "no scroll indicator without body");
 	assert.doesNotMatch(text, /scroll/, "no scroll hint without overflow");
+	assert.doesNotMatch(text, /\[V\]/, "no preview toggle without a body");
 });
 
 test("approval-view: short upstream fits without scroll indicator", () => {
@@ -127,6 +184,7 @@ test("approval-view: short upstream fits without scroll indicator", () => {
 	const text = view.render(80).join("\n");
 	assert.match(text, /only/);
 	assert.match(text, /two lines here/);
+	assert.match(text, /Proposal: 2 lines · expanded/, "short content remains visible by default");
 	assert.doesNotMatch(text, /more/, "no scroll indicator when content fits");
 });
 
@@ -144,6 +202,7 @@ test("approval-view: getRows failure falls back to default height", () => {
 	);
 	const text = view.render(80).join("\n");
 	assert.match(text, /body/, "renders despite getRows throwing");
+	view.handleInput("a");
 	view.handleInput("\r");
 	assert.equal(result, "approve");
 });

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-core",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, and grok-taskflow.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-dsl/package.json
+++ b/packages/taskflow-dsl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-dsl",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Compile-time TypeScript DSL frontend for taskflow: erase .tf.ts runes to Taskflow JSON, then FlowIR via taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-hosts/package.json
+++ b/packages/taskflow-hosts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-hosts",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Shared host-runner collection for taskflow — the codex, claude, opencode, and grok SubagentRunner implementations + their argv builders and event-stream parsers. The per-host MCP servers, plugin scaffolds, and bins live in codex-taskflow / claude-taskflow / opencode-taskflow / grok-taskflow; this package holds just the runners so a new host can be added in one place.",
 	"homepage": "https://github.com/heggria/taskflow#readme",
 	"author": "heggria <bshengtao@gmail.com>",

--- a/packages/taskflow-mcp-core/package.json
+++ b/packages/taskflow-mcp-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-mcp-core",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Host-neutral MCP server for taskflow: a dependency-free stdio JSON-RPC server exposing the taskflow_* tools, plus the DAG SVG/outline renderer. Shared by the codex/claude/opencode/grok adapters — depends only on taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
+  nanoid: 3.3.17
   postcss: 8.5.23
   sharp: 0.35.3
   undici: 8.9.0
@@ -1771,8 +1772,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
@@ -2486,8 +2487,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4400,7 +4401,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5408,7 +5409,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
@@ -5428,7 +5429,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -5518,7 +5519,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,8 @@ packages:
   - "packages/taskflow-dsl"
   - "website"
 overrides:
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
+  nanoid: 3.3.17
   postcss: 8.5.23
   sharp: 0.35.3
   # Dependabot high/medium open alerts: undici < 8.9.0 (CRLF, cache, cookie, desync)

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -25,7 +25,7 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.2.7",
+			eyebrow: "taskflow 0.2.8",
 			title: [
 				"Plan before spend.",
 				"Close the loop after.",
@@ -187,7 +187,7 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.2.7",
+			eyebrow: "taskflow 0.2.8",
 			title: ["花 token 前先计划。", "跑完闭环通知。", "只重算变化部分。"],
 			sub: "taskflow 把多代理编程工作变成可编译的运行时：声明式图、零 token preflight、隔离执行、跑完 hooks、确定性 replay，以及跨 Pi、Codex、Claude Code、OpenCode、Grok 的增量重算。",
 			noteKicker: "面向 coding agents 的 compiled runtime",
@@ -341,7 +341,7 @@ export default async function HomePage({
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
 		name: "taskflow",
-		softwareVersion: "0.2.7",
+		softwareVersion: "0.2.8",
 		description: t.hero.sub,
 		applicationCategory: "DeveloperApplication",
 		operatingSystem: "Any",

--- a/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: Compile-time .tf.ts authoring — erase runes to Taskflow JSON, the
 S4 adds a **compile-time** TypeScript frontend. You author `*.tf.ts` with **runes** (`agent`, `map`, `race`, …). A CLI erases them to ordinary Taskflow JSON. Hosts still run **JSON** via `taskflow_run` / `/tf run` — there is **no** interpret path and **no** host auto-build of `.tf.ts`.
 
 <Callout type="info">
-  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests are `0.2.7` on this release line; install from npm after the `v0.2.7` publish job, or use a workspace / local path from this monorepo.
+  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests are `0.2.8` on this release line; install from npm after the `v0.2.8` publish job, or use a workspace / local path from this monorepo.
 </Callout>
 
 ## Workflow

--- a/website/content/docs/en/guides/grok-build.mdx
+++ b/website/content/docs/en/guides/grok-build.mdx
@@ -12,7 +12,7 @@ This page walks through install, verify, first run, permissions, and long-runnin
 ### Published MCP package (recommended)
 
 ```bash title="Register taskflow MCP"
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 Requires **Node.js ≥ 22.19.0**. The MCP protocol code has no MCP SDK dependency. A public Grok plugin marketplace/source is not published yet; do not substitute an imaginary source string.
@@ -170,7 +170,7 @@ MCP-driven runs are non-interactive, so an `approval` phase **auto-rejects** (fa
 ```bash title="Manual MCP registration"
 pnpm add -g grok-taskflow
 grok mcp add taskflow -- grok-taskflow-mcp
-# or: grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+# or: grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 ## Remove

--- a/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: 编译期 .tf.ts 写法 —— rune erase 成 Taskflow JSON，再�
 S4 增加**编译期** TypeScript 前端：用 rune（`agent`、`map`、`race`…）写 `*.tf.ts`，CLI erase 成普通 Taskflow JSON。宿主仍通过 `taskflow_run` / `/tf run` 跑 **JSON**——**没有**解释执行路径，也**没有**宿主对 `.tf.ts` 的自动 build。
 
 <Callout type="info">
-  **包状态。** `taskflow-dsl` 在 monorepo 的 `packages/taskflow-dsl`。纯 JSON 作者不需要它。本发布线 manifest 为 `0.2.7`；`v0.2.7` 发布任务完成后可从 npm 安装，或使用本 monorepo 的 workspace / 本地 path。
+  **包状态。** `taskflow-dsl` 在 monorepo 的 `packages/taskflow-dsl`。纯 JSON 作者不需要它。本发布线 manifest 为 `0.2.8`；`v0.2.8` 发布任务完成后可从 npm 安装，或使用本 monorepo 的 workspace / 本地 path。
 </Callout>
 
 ## 工作流

--- a/website/content/docs/zh-cn/guides/grok-build.mdx
+++ b/website/content/docs/zh-cn/guides/grok-build.mdx
@@ -12,7 +12,7 @@ description: 将 taskflow 作为 Grok Build 插件安装，通过 MCP 编排多�
 ### 已发布 MCP 包（推荐）
 
 ```bash title="注册 taskflow MCP"
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.7 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.8 grok-taskflow-mcp
 ```
 
 要求 **Node.js ≥ 22.19.0**。MCP 协议代码不依赖 MCP SDK。公共 Grok plugin marketplace/source 尚未发布；不要代入一个不存在的 source。


### PR DESCRIPTION
## Summary

- replace single-key approval with a fail-closed three-choice selector: Reject / Edit guidance / Approve
- require Enter after keyboard selection; Escape and Ctrl-C still reject immediately
- collapse large proposals by default, add independent V preview toggle and scrolling, and keep the decision footer visible
- decode Kitty press/repeat/release frames so releases and repeats cannot commit or double-toggle
- prepare v0.2.8 across all nine packages, plugin pins, docs, and server contracts
- override brace-expansion 5.0.9 and nanoid 3.3.17 after the release audit found newly disclosed high-severity advisories

## Interaction decision

This intentionally uses a three-state selection followed by Enter instead of a text y/N field. Pi approvals already have a first-class Edit guidance outcome; a visible selector preserves that outcome while still making approval a deliberate two-step action. The initial selection is Reject, so bare Enter fails closed.

## Verification

- focused approval view tests: 13/13
- full unit suite: 2102/2102
- TypeScript typecheck
- real Pi 0.83.0 terminal: 1,247-line proposal collapsed, V preview + scrolling, A selection stayed open, Enter approved
- Pi terminal-reap E2E
- Codex comprehensive MCP E2E plus Claude/OpenCode/Grok MCP E2E
- deterministic packed consumer smoke: 9 packages, 24 explicit imports, 73 wildcard exports, 5 bins
- private CharterArc packed consumer smoke
- website production export: 125 pages
- production dependency audit: no known vulnerabilities

Fixes #118