### PR TITLE
fix(pi): wire /tf verify slash command (#121)

### DIFF
--- a/packages/pi-taskflow/src/index.ts
+++ b/packages/pi-taskflow/src/index.ts
@@ -641,7 +641,10 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	// ---- Register per-saved-flow shortcut commands on session start ----
+	// Cached for /tf argument completions (getArgumentCompletions has no ctx).
+	let completionCwd: string | undefined;
 	const registerSavedFlowCommands = (ctx: ExtensionContext) => {
+		completionCwd = ctx.cwd;
 		const flows = listFlows(ctx.cwd);
 		for (const flow of flows) {
 			const cmdName = `tf:${flow.name}`;
@@ -1642,14 +1645,30 @@ export default function (pi: ExtensionAPI) {
 
 	// ---- The /tf user command ----
 	pi.registerCommand("tf", {
-		description: "Taskflow: list | run <name> | show <name> | compile <name> | runs | peek <runId> [phaseId] | reconcile-workspace --ack | init",
+		description: "Taskflow: list | run <name> | show <name> | verify <name> | compile <name> | plan <name> | runs | peek <runId> [phaseId] | reconcile-workspace --ack | init",
 		getArgumentCompletions: (prefix) => {
 			const subs = ["list", "run", "show", "runs", "peek", "resume", "init", "save", "verify", "compile", "plan", "analytics", "ir", "provenance", "trace", "replay", "why-stale", "recompute", "reconcile-workspace", "version"];
+			// Name-taking subcommands: complete saved flow names after the sub (cwd from session_start).
+			const nameSubs = new Set(["run", "show", "verify", "compile", "plan", "analytics", "ir"]);
+			const trimmed = prefix.trimStart();
+			const space = trimmed.indexOf(" ");
+			if (space >= 0) {
+				const sub = trimmed.slice(0, space);
+				const namePrefix = trimmed.slice(space + 1).trimStart();
+				if (nameSubs.has(sub) && completionCwd !== undefined) {
+					const flows = listFlows(completionCwd);
+					const items = flows
+						.filter((f) => f.name.startsWith(namePrefix))
+						.map((f) => ({ value: `${sub} ${f.name}`, label: f.name }));
+					return items.length > 0 ? items : null;
+				}
+			}
 			const items = subs.map((s) => ({ value: s, label: s }));
-			const filtered = items.filter((i) => i.value.startsWith(prefix));
+			const filtered = items.filter((i) => i.value.startsWith(trimmed));
 			return filtered.length > 0 ? filtered : null;
 		},
 		handler: async (argStr, ctx) => {
+			completionCwd = ctx.cwd;
 			const [sub, ...rest] = argStr.trim().split(/\s+/);
 			const arg = rest.join(" ");
 
@@ -1709,6 +1728,64 @@ export default function (pi: ExtensionAPI) {
 				} else {
 					ctx.ui.notify(JSON.stringify(flow.def, null, 2), "info");
 				}
+				return;
+			}
+
+					if (sub === "verify") {
+				if (!arg) {
+					ctx.ui.notify("Usage: /tf verify <name>", "warning");
+					return;
+				}
+				const flowName = arg.trim().split(/\s+/)[0];
+				const flowR = getFlowDiagnosed(ctx.cwd, flowName);
+				if (!flowR.ok) {
+					ctx.ui.notify(describeLoadFailure(flowR, `Flow "${flowName}"`), "error");
+					return;
+				}
+				const flow = flowR.value;
+				// Schema-validate first so a malformed saved flow yields a clean error
+				// (mirrors action=verify on the taskflow tool).
+				const vr = validateTaskflow(flow.def, { cwd: ctx.cwd ? String(ctx.cwd) : undefined });
+				if (!vr.ok) {
+					ctx.ui.notify(`Schema validation failed:\n${vr.errors.join("\n")}`, "error");
+					return;
+				}
+				const { verifyTaskflow } = await import("taskflow-core");
+				const result = verifyTaskflow({
+					name: flow.def.name!,
+					phases: flow.def.phases!,
+					budget: flow.def.budget,
+					concurrency: flow.def.concurrency,
+				});
+				const lines: string[] = [];
+				lines.push(`# Verification of "${flow.def.name}"`);
+				lines.push("");
+				if (result.issues.length === 0) {
+					lines.push("✅ No issues found.");
+				} else {
+					const errors = result.issues.filter((i) => i.severity === "error");
+					const warnings = result.issues.filter((i) => i.severity === "warning");
+					if (errors.length) {
+						lines.push(`## Errors (${errors.length})`);
+						for (const e of errors) lines.push(`- **${e.category}**${e.phaseId ? ` [${e.phaseId}]` : ""}: ${e.message}`);
+					}
+					if (warnings.length) {
+						lines.push(`## Warnings (${warnings.length})`);
+						for (const w of warnings) lines.push(`- ${w.category}${w.phaseId ? ` [${w.phaseId}]` : ""}: ${w.message}`);
+					}
+					lines.push("");
+					lines.push(result.ok ? "Status: PASS (no errors)" : "Status: FAIL (errors found)");
+				}
+				ctx.ui.notify(lines.join("\n"), result.ok ? "info" : "warning");
+				return;
+			}
+
+	if (sub === "save") {
+				// Saving needs an inline DSL body; that path stays on the taskflow tool.
+				ctx.ui.notify(
+					"Usage: save via the taskflow tool with action=\"save\" and define={...} (optionally purpose/tags/scope).\nThere is no standalone /tf save <name> path — the slash command only runs control-plane actions on already-saved flows.",
+					"warning",
+				);
 				return;
 			}
 

--- a/packages/pi-taskflow/test/tf-verify-command.test.ts
+++ b/packages/pi-taskflow/test/tf-verify-command.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression for https://github.com/heggria/taskflow/issues/121
+ *
+ * `/tf` autocomplete listed `verify`, but the slash handler fell through to
+ * "Unknown subcommand: verify". The taskflow tool path (action=verify) worked.
+ *
+ * Also guards the sibling hole: every entry in the /tf autocomplete list must
+ * resolve to a real handler (not "Unknown subcommand").
+ */
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, test, before, after } from "node:test";
+
+const extModule = await import("../src/index.ts");
+const extension = extModule.default;
+
+function loadExtension() {
+	const capturedCommands = new Map<string, any>();
+	const mockPi = {
+		registerTool: (_tool: any) => {},
+		registerCommand: (name: string, def: any) => {
+			capturedCommands.set(name, def);
+		},
+		on: (_event: string, _handler: any) => {},
+		sendUserMessage: (_text: string) => {},
+	};
+	extension(mockPi as any);
+	return capturedCommands;
+}
+
+function makeCtx(cwd: string, notify: (text: string, kind?: string) => void) {
+	return {
+		cwd,
+		hasUI: false,
+		isIdle: () => true,
+		ui: {
+			notify,
+			input: async () => "",
+			custom: async () => ({} as any),
+		},
+		modelRegistry: {
+			find: () => undefined,
+			getAvailable: () => [],
+		},
+	} as any;
+}
+
+describe("/tf verify slash command (#121)", () => {
+	let cwd: string;
+	let tf: any;
+
+	before(() => {
+		cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tf-verify-cmd-"));
+		fs.mkdirSync(path.join(cwd, ".pi", "taskflows"), { recursive: true });
+		// Minimal clean flow — verify should report no issues.
+		const def = {
+			name: "minimal-repro",
+			strictInterpolation: true,
+			agentScope: "project",
+			phases: [
+				{
+					id: "hello",
+					type: "script",
+					run: "printf 'hello world\\n'",
+					final: true,
+				},
+			],
+		};
+		fs.writeFileSync(
+			path.join(cwd, ".pi", "taskflows", "minimal-repro.json"),
+			JSON.stringify(def, null, 2),
+		);
+		// Flow that validates but emits a dead-end warning under verifyTaskflow.
+		const warnFlow = {
+			name: "warn-flow",
+			phases: [
+				{ id: "a", type: "script", run: "true" },
+				{ id: "b", type: "script", run: "true", final: true },
+			],
+		};
+		fs.writeFileSync(
+			path.join(cwd, ".pi", "taskflows", "warn-flow.json"),
+			JSON.stringify(warnFlow, null, 2),
+		);
+
+		const cmds = loadExtension();
+		tf = cmds.get("tf");
+		assert.ok(tf, "tf command should be registered");
+	});
+
+	after(() => {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	});
+
+	test("autocomplete lists verify", () => {
+		const items = tf.getArgumentCompletions("ver");
+		assert.ok(Array.isArray(items), "expected completion items");
+		assert.ok(
+			items.some((i: { value: string }) => i.value === "verify"),
+			`verify should appear in completions, got ${JSON.stringify(items)}`,
+		);
+	});
+
+	test("/tf verify <name> no longer reports unknown subcommand", async () => {
+		let notified = "";
+		let kind = "";
+		await tf.handler("verify minimal-repro", makeCtx(cwd, (text, k) => {
+			notified = text;
+			kind = k ?? "";
+		}));
+		assert.doesNotMatch(notified, /unknown subcommand/i);
+		assert.match(notified, /Verification of "minimal-repro"/);
+		assert.match(notified, /✅ No issues found/);
+		assert.equal(kind, "info");
+	});
+
+	test("/tf verify without name shows usage", async () => {
+		let notified = "";
+		let kind = "";
+		await tf.handler("verify", makeCtx(cwd, (text, k) => {
+			notified = text;
+			kind = k ?? "";
+		}));
+		assert.match(notified, /Usage: \/tf verify <name>/);
+		assert.equal(kind, "warning");
+	});
+
+	test("/tf verify missing flow errors cleanly", async () => {
+		let notified = "";
+		let kind = "";
+		await tf.handler("verify does-not-exist", makeCtx(cwd, (text, k) => {
+			notified = text;
+			kind = k ?? "";
+		}));
+		assert.doesNotMatch(notified, /unknown subcommand/i);
+		assert.match(notified, /does-not-exist/);
+		assert.equal(kind, "error");
+	});
+
+	test("/tf verify reports warnings for a flow with dead-end issues", async () => {
+		let notified = "";
+		let kind = "";
+		await tf.handler("verify warn-flow", makeCtx(cwd, (text, k) => {
+			notified = text;
+			kind = k ?? "";
+		}));
+		assert.doesNotMatch(notified, /unknown subcommand/i);
+		assert.match(notified, /Verification of "warn-flow"/);
+		assert.match(notified, /Warnings|dead-end|Status: PASS/);
+		// warnings-only still ok=true → info severity (mirrors tool path semantics)
+		assert.equal(kind, "info");
+	});
+
+	test("autocomplete name completion after verify works once cwd is known", async () => {
+		// Warm completionCwd via a real handler call.
+		await tf.handler("list", makeCtx(cwd, () => {}));
+		const items = tf.getArgumentCompletions("verify min");
+		assert.ok(Array.isArray(items), `expected items, got ${items}`);
+		assert.ok(
+			items.some((i: { value: string }) => i.value === "verify minimal-repro"),
+			`expected verify minimal-repro in ${JSON.stringify(items)}`,
+		);
+	});
+
+	test("every autocomplete subcommand has a handler (no unknown fallthrough)", async () => {
+		const items = tf.getArgumentCompletions("");
+		assert.ok(Array.isArray(items) && items.length > 0);
+		const subs: string[] = items.map((i: { value: string }) => i.value);
+		assert.ok(subs.includes("verify"));
+		assert.ok(subs.includes("save"));
+
+		for (const sub of subs) {
+			let notified = "";
+			// Pass a dummy arg so name-required subs don't only show usage —
+			// either is fine; the regression is specifically "Unknown subcommand".
+			const arg = ["list", "runs", "init", "version", "save", "reconcile-workspace"].includes(sub)
+				? sub
+				: `${sub} __no_such_flow__`;
+			await tf.handler(arg, makeCtx(cwd, (text) => {
+				notified = text;
+			}));
+			assert.doesNotMatch(
+				notified,
+				/unknown subcommand/i,
+				`subcommand "${sub}" fell through to unknown: ${notified}`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #121: `/tf verify <name>` no longer reports `unknown subcommand: verify`.
- Root cause: autocomplete listed `verify`, but the slash handler never implemented the branch (tool `action=verify` already worked).
- Class check: only two autocomplete entries lacked handlers — `verify` (implemented) and `save` (tool-only path; now returns clear usage instead of unknown).
- Bonus: name completion after name-taking subs (`run`/`show`/`verify`/`compile`/…) once session cwd is known.

## Test plan
- [x] `pnpm run test:pi` — 195 pass
- [x] New `tf-verify-command.test.ts` (7 cases): happy path, usage, missing flow, warnings, autocomplete, full subcommand fallthrough guard
- [x] Sabotage: removing the verify handler makes 5 of 7 new tests fail; restore → all green

## Risk
Low. Pi adapter slash-handler only; no DSL/runtime/API change. Token path still zero-token static verify.