### PR TITLE
feat: add organized saved-flow directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+### Added
+
+- **Organized saved-flow discovery.** Project and user flows may be nested recursively below the bounded `flows/` convention directory (for example `.pi/taskflows/flows/release/publish.json`) while legacy top-level saved flows remain compatible and take same-scope precedence on duplicate names.
+- **Flow-relative script execution.** A file-backed flow can declare `scriptCwd: "flow"` so script phases without an explicit `cwd` execute from the definition file's directory. Canonical loader provenance is persisted across foreground, background, resume, saved subflow, Pi, MCP, imperative, and event-kernel paths; inline definitions fail closed because they have no trusted file source.
+
+### Changed
+
+- Nested discovery is deterministic and bounded by one shared user/project budget: 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per definition, and 16 levels. Symlinks below trusted storage boundaries through definition leaves, dot directories, sidecars, and FlowIR artifacts are excluded; duplicate flow names emit diagnostics. A configured user agent-directory boundary may itself be a symlink for home relocation, while project `.pi` boundaries remain no-follow. Re-saving a discovered nested flow updates its existing definition and adjacent library sidecar in place; listing/search avoids repeated namespace scans.
+
+### Security
+
+- Saved-flow and `defineFile` definitions are read through bounded no-follow descriptors with pre/post file identity checks. Canonical source path plus parent directory identity travel together through run persistence and are revalidated immediately before flow-relative script spawn. New project storage is validated and created one plain directory component at a time before any descendant side effect; flow and sidecar writes recheck the physical target directory before locking and each write. Flow-relative script cwd cannot expand an inherited cwd-bridge boundary.
+
 ## [0.2.9] — 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 
 - Nested discovery is deterministic and bounded by one shared user/project budget: 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per definition, and 16 levels. Symlinks below trusted storage boundaries through definition leaves, dot directories, sidecars, and FlowIR artifacts are excluded; duplicate flow names emit diagnostics. A configured user agent-directory boundary may itself be a symlink for home relocation, while project `.pi` boundaries remain no-follow. Re-saving a discovered nested flow updates its existing definition and adjacent library sidecar in place; listing/search avoids repeated namespace scans.
 
+### Fixed
+
+- Legacy top-level hidden JSON flows and flow names ending in `.flowir` remain discoverable, directory-entry I/O failures remain fail-soft instead of escaping `listFlows`, and nested flow/sidecar saves revalidate the physical parent at each atomic-write stage so a concurrently replaced directory cannot receive definition/sidecar bytes or a promoted final file.
+
 ### Security
 
 - Saved-flow and `defineFile` definitions are read through bounded no-follow descriptors with pre/post file identity checks. Canonical source path plus parent directory identity travel together through run persistence and are revalidated immediately before flow-relative script spawn. New project storage is validated and created one plain directory component at a time before any descendant side effect; flow and sidecar writes recheck the physical target directory before locking and each write. Flow-relative script cwd cannot expand an inherited cwd-bridge boundary.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ Save it as `.pi/taskflows/audit-api.json`, then run:
 
 On Codex, Claude Code, OpenCode, Grok Build, and Hermes Agent, run the same saved definition by name through `taskflow_run`. For long DAGs, use `mode: "background"`, then manage the durable run with `taskflow_runs` (`list` / `status` / `wait` / `cancel`); list output reports active concurrency and can filter `running` or `terminal` runs.
 
+Large projects may organize saved definitions recursively below `.pi/taskflows/flows/`, for example `.pi/taskflows/flows/release/audit-api.json`. Legacy `.pi/taskflows/*.json` files remain discoverable and win same-scope name collisions; nested duplicates use locale-independent Unicode-scalar path order. Saving an already-discovered nested flow updates that file and its adjacent metadata in place; new flows still use the legacy top-level location. Discovery uses one shared user/project budget and fails closed if it exceeds 1,000 flows, 10,000 visited entries, 512 directories, 8 MiB of definition data, 1 MiB per definition, or 16 levels. It rejects symlinks below the trusted storage boundary through definition leaves and skips dot paths, metadata (`*.meta.json`), and compiled IR (`*.flowir.json`). The configured agent-directory boundary itself may be a symlink for compatible home-directory relocation. New-flow saves enforce the same storage-boundary policy and revalidate the physical target directory inside the write lock.
+
+A file-backed flow can opt script phases into definition-relative execution:
+
+```json
+{
+  "name": "release",
+  "scriptCwd": "flow",
+  "phases": [
+    { "id": "prepare", "type": "script", "run": ["./scripts/prepare.sh"], "final": true }
+  ]
+}
+```
+
+Here `./scripts/prepare.sh` resolves from the directory containing the saved flow or `defineFile`. The default remains `"invocation"`, and an explicit phase `cwd` still takes precedence. Inline definitions have no trusted file source and therefore fail closed if they request `scriptCwd: "flow"`. If execution inherits a cwd-bridge boundary, the resolved flow source directory must remain inside that boundary.
+
 [Follow the full quickstart →](https://heggria.github.io/taskflow/en/docs/getting-started)
 
 ## See the graph run

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,6 +133,22 @@ pi install npm:pi-taskflow
 
 在 Codex、Claude Code、OpenCode、Grok Build 和 Hermes Agent 上，通过 `taskflow_run` 按名称运行同一份保存定义。长任务可使用 `mode: "background"`，再用 `taskflow_runs` 执行 `list` / `status` / `wait` / `cancel`，无需担心单次 MCP 调用超时；列表会显示当前并发数，并可筛选 `running` 或 `terminal` 运行。
 
+大型项目可以把保存的定义递归组织在 `.pi/taskflows/flows/` 下，例如 `.pi/taskflows/flows/release/audit-api.json`。旧的 `.pi/taskflows/*.json` 仍可发现，并在同一作用域的重名冲突中优先；嵌套定义按与区域设置无关的 Unicode 标量路径顺序确定优先级。重新保存一个已发现的嵌套 flow 会原地更新该定义及相邻元数据；新 flow 仍写入旧版顶层位置。发现过程由用户与项目共享一套预算，超过 1,000 个 flow、10,000 个已访问目录项、512 个目录、8 MiB 定义总量、单文件 1 MiB 或 16 层深度时会安全失败。它拒绝可信存储边界以下直到定义叶子的符号链接，并跳过点路径、元数据（`*.meta.json`）和已编译 IR（`*.flowir.json`）；为兼容 home 目录迁移，配置的 agent 目录边界本身可以是符号链接。保存新 flow 时会执行相同的存储边界校验，并在写锁内重新验证目标目录的物理身份。
+
+文件支持的 flow 可以显式选择从定义文件目录运行脚本阶段：
+
+```json
+{
+  "name": "release",
+  "scriptCwd": "flow",
+  "phases": [
+    { "id": "prepare", "type": "script", "run": ["./scripts/prepare.sh"], "final": true }
+  ]
+}
+```
+
+此时 `./scripts/prepare.sh` 从保存 flow 或 `defineFile` 所在目录解析。默认值仍是 `"invocation"`，显式 phase `cwd` 仍然优先；inline 定义没有可信文件来源，因此请求 `scriptCwd: "flow"` 时会安全失败。如果执行继承了 cwd bridge 边界，解析出的 flow 来源目录也必须位于该边界内。
+
 [查看完整快速开始 →](https://heggria.github.io/taskflow/zh-cn/docs/getting-started)
 
 ## 看见整张图运行

--- a/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
@@ -487,6 +487,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/packages/claude-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/configuration.md
@@ -32,6 +32,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -46,10 +47,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
@@ -482,6 +482,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
@@ -32,6 +32,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -46,10 +47,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -212,6 +212,34 @@ test("mcp: defineFile cannot escape cwd or the OS temp directory", async (t) => 
 	assert.match(res.error.message, /contained in the server cwd or OS temp directory/i);
 });
 
+test("mcp: defineFile rejects a lexical symlink leaf even when its target is contained", async (t) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-mcp-define-symlink-"));
+	try {
+		const target = path.join(dir, "target.json");
+		const link = path.join(dir, "link.json");
+		fs.writeFileSync(target, JSON.stringify({
+			name: "define-symlink-target",
+			phases: [{ id: "a", type: "agent", agent: "default", task: "x", final: true }],
+		}));
+		try {
+			fs.symlinkSync(target, link, "file");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") return t.skip("file symlinks unavailable");
+			throw error;
+		}
+		const [res] = await rpcRoundtrip([{
+			jsonrpc: "2.0",
+			id: 102,
+			method: "tools/call",
+			params: { name: "taskflow_verify", arguments: { defineFile: link } },
+		}]);
+		assert.equal(res.error.code, -32602);
+		assert.match(res.error.message, /defineFile must not be a symlink/i);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test("mcp: tools/call unknown tool returns invalid-params", async () => {
 	const [res] = await rpcRoundtrip([
 		{ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "nope", arguments: {} } },
@@ -550,6 +578,7 @@ test("mcp: taskflow_resume forks failed history, applies override, and preserves
 	const os = await import("node:os");
 	const path = await import("node:path");
 	const {
+		discoverAgents,
 		executeTaskflow,
 		newRunId,
 		runsDir,
@@ -577,7 +606,7 @@ test("mcp: taskflow_resume forks failed history, applies override, and preserves
 			...(task === "fail-me" ? { errorMessage: "boom" } : {}),
 		});
 		const parentResult = await executeTaskflow(parent, {
-			cwd, agents: [],
+			cwd, agents: discoverAgents(cwd, "both").agents,
 			runTask: parentRunner,
 		});
 		assert.equal(parentResult.ok, false);

--- a/packages/grok-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/grok-taskflow/plugin/skills/taskflow/SKILL.md
@@ -492,6 +492,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/packages/grok-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/grok-taskflow/plugin/skills/taskflow/configuration.md
@@ -32,6 +32,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -46,10 +47,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/packages/hermes-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/hermes-taskflow/plugin/skills/taskflow/SKILL.md
@@ -487,6 +487,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/packages/hermes-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/hermes-taskflow/plugin/skills/taskflow/configuration.md
@@ -32,6 +32,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -46,10 +47,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
@@ -483,6 +483,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/packages/opencode-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/configuration.md
@@ -32,6 +32,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -46,10 +47,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/packages/pi-taskflow/skills/taskflow/SKILL.md
+++ b/packages/pi-taskflow/skills/taskflow/SKILL.md
@@ -459,6 +459,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/packages/pi-taskflow/skills/taskflow/configuration.md
+++ b/packages/pi-taskflow/skills/taskflow/configuration.md
@@ -32,6 +32,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -46,10 +47,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/packages/pi-taskflow/src/index.ts
+++ b/packages/pi-taskflow/src/index.ts
@@ -11,6 +11,7 @@
  */
 
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { resolve as resolvePath } from "node:path";
 import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
@@ -51,6 +52,7 @@ import {
 	type ReplayOverrides,
 	type RuntimeDeps,
 	type RuntimeResult,
+	type DirectoryIdentity,
 } from "taskflow-core";
 import { type UsageStats } from "taskflow-core";
 import { resolveArgs, type Taskflow, validateTaskflow, desugar, isShorthand } from "taskflow-core";
@@ -68,8 +70,10 @@ import {
 	DEFAULT_KEPT_RUNS,
 	DEFAULT_RUN_AGE_DAYS,
 	readDefineFile,
+	readDefineFileWithSource,
 	describeLoadFailure,
 	readMeta,
+	readMetaNextTo,
 	saveFlowWithMeta,
 	bumpReuseInSidecar,
 	deriveMeta,
@@ -422,7 +426,13 @@ function parseToolReplayOverrides(params: {
 	return o;
 }
 
-function makeRunState(def: Taskflow, args: Record<string, unknown>, cwd: string): RunState {
+function makeRunState(
+	def: Taskflow,
+	args: Record<string, unknown>,
+	cwd: string,
+	flowSourceFile?: string,
+	flowSourceDirIdentity?: DirectoryIdentity,
+): RunState {
 	const info = getBuildInfo();
 	return {
 		runId: newRunId(def.name),
@@ -434,6 +444,8 @@ function makeRunState(def: Taskflow, args: Record<string, unknown>, cwd: string)
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		cwd,
+		flowSourceFile,
+		flowSourceDirIdentity,
 		invocationRootSnapshot: directoryIdentity(cwd),
 		// Dogfood build identity: stamp every new run for diagnostics/audit.
 		host: "pi",
@@ -465,8 +477,10 @@ async function runFlow(
 	// Invocation-level incremental override: when set, wins over def.incremental.
 	// undefined → fall back to the flow's own `incremental` field (default off).
 	incrementalOverride?: boolean,
+	flowSourceFile?: string,
+	flowSourceDirIdentity?: DirectoryIdentity,
 ): Promise<RuntimeResult> {
-	const state = existing ?? makeRunState(def, args, ctx.cwd);
+	const state = existing ?? makeRunState(def, args, ctx.cwd, flowSourceFile, flowSourceDirIdentity);
 
 	const emit = (s: RunState, finalOutput?: string) => {
 		onUpdate?.({
@@ -599,7 +613,10 @@ async function runFlow(
 			// in the same package) now silently breaks all phase execution.
 			runTask: createPiSubagentRunner(settings.taskflow.piChild).runTask,
 			requestApproval,
-			loadFlow: (name: string) => getFlow(ctx.cwd, name)?.def,
+			loadSavedFlow: (name: string) => {
+				const saved = getFlow(ctx.cwd, name);
+				return saved ? { def: saved.def, filePath: saved.filePath, sourceDirIdentity: saved.sourceDirIdentity } : undefined;
+			},
 			// Cross-run cache is opt-in. By default a real run is `run-only` (fresh
 			// each run): defaulting every phase to cross-run silently persists
 			// outputs and can serve stale results for phases whose agents read files
@@ -873,7 +890,7 @@ export default function (pi: ExtensionAPI) {
 				const text = flows.length
 					? flows
 							.map((f) => {
-								const metaR = readMeta(ctx.cwd, f.name);
+								const metaR = readMetaNextTo(f.filePath);
 							const meta = metaR.ok ? metaR.value : undefined;
 								const base = `- ${f.name} (${f.scope}): ${f.def.description ?? ""} — ${f.def.phases?.length ?? 0} phase(s)`;
 								if (meta?.purpose) {
@@ -1276,7 +1293,10 @@ export default function (pi: ExtensionAPI) {
 					globalThinking: settings.globalThinking,
 					signal,
 					runTask: createPiSubagentRunner(settings.taskflow.piChild).runTask,
-					loadFlow: (name: string) => getFlow(ctx.cwd, name)?.def,
+					loadSavedFlow: (name: string) => {
+						const saved = getFlow(ctx.cwd, name);
+						return saved ? { def: saved.def, filePath: saved.filePath, sourceDirIdentity: saved.sourceDirIdentity } : undefined;
+					},
 					trace: new FileTraceSink(traceFilePath(runsDir(ctx.cwd), prev.flowName, prev.runId)),
 				};
 				const { report, state } = await recomputeTaskflow(prev, deps, [String(params.phaseId)], { dryRun });
@@ -1291,15 +1311,20 @@ export default function (pi: ExtensionAPI) {
 
 			// resolve the definition: inline `define` / shorthand (single|parallel|chain), else saved `name`.
 			let def: Taskflow | undefined;
+			let flowSourceFile: string | undefined;
+			let flowSourceDirIdentity: DirectoryIdentity | undefined;
 
 			// Auto-parse string `define` — LLMs sometimes pass a JSON string
 			// instead of a parsed object. safeParse handles markdown fences too.
 			// `defineFile` lets verify/run share ONE on-disk draft (e.g. in /tmp).
 			let resolvedDefine: unknown = params.define;
 			if (resolvedDefine === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
-				const fromFile = readDefineFile(params.defineFile);
+				const defineFilePath = resolvePath(ctx.cwd, params.defineFile);
+				const fromFile = readDefineFileWithSource(defineFilePath);
 				if (!fromFile.ok) return errorResult(action, describeLoadFailure(fromFile, "defineFile"));
-				resolvedDefine = fromFile.value;
+				resolvedDefine = fromFile.value.value;
+				flowSourceFile = fromFile.value.filePath;
+				flowSourceDirIdentity = fromFile.value.sourceDirIdentity;
 			}
 			if (typeof resolvedDefine === "string") {
 				const parsed = safeParse(resolvedDefine);
@@ -1346,6 +1371,8 @@ export default function (pi: ExtensionAPI) {
 					return errorResult(action, `${describeLoadFailure(savedR, `Saved flow '${params.name}'`)}.${hint}`);
 				}
 				def = savedR.value.def;
+				flowSourceFile = savedR.value.filePath;
+				flowSourceDirIdentity = savedR.value.sourceDirIdentity;
 			}
 			if (!def)
 				return errorResult(
@@ -1414,7 +1441,7 @@ export default function (pi: ExtensionAPI) {
 			}
 			// Detached (background) execution: spawn a child process and return immediately.
 			if (params.detach) {
-				const state = makeRunState(def, args, ctx.cwd);
+				const state = makeRunState(def, args, ctx.cwd, flowSourceFile, flowSourceDirIdentity);
 				state.detached = true;
 				state.detachedStartedAt = Date.now();
 				state.detachedControlVersion = DETACHED_CONTROL_VERSION;
@@ -1584,7 +1611,17 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 
-			const result = await runFlow(def, args, ctx, signal, onUpdate as any, undefined, params.incremental as boolean | undefined);
+			const result = await runFlow(
+				def,
+				args,
+				ctx,
+				signal,
+				onUpdate as any,
+				undefined,
+				params.incremental as boolean | undefined,
+				flowSourceFile,
+				flowSourceDirIdentity,
+			);
 			// RFC library reuse flywheel: if this run was chosen because of a prior
 			// action=search (reusedFromSearch=true), bump the flow's reuseCount. We
 			// only bump for run-by-name of a SAVED flow (not inline define). Failures
@@ -1725,7 +1762,7 @@ export default function (pi: ExtensionAPI) {
 					return;
 				}
 				const flow = flowR.value;
-				const metaR = readMeta(ctx.cwd, arg);
+				const metaR = readMetaNextTo(flow.filePath);
 				const meta = metaR.ok ? metaR.value : undefined;
 				if (meta) {
 					const out = { definition: flow.def, library: { purpose: meta.purpose, tags: meta.tags, notes: meta.notes, generality: meta.generality, reuseCount: meta.reuseCount, version: meta.version, phaseSignature: meta.phaseSignature } };
@@ -2018,7 +2055,10 @@ export default function (pi: ExtensionAPI) {
 					agents,
 					globalThinking: settings.globalThinking,
 					runTask: createPiSubagentRunner(settings.taskflow.piChild).runTask,
-					loadFlow: (name: string) => getFlow(ctx.cwd, name)?.def,
+					loadSavedFlow: (name: string) => {
+						const saved = getFlow(ctx.cwd, name);
+						return saved ? { def: saved.def, filePath: saved.filePath, sourceDirIdentity: saved.sourceDirIdentity } : undefined;
+					},
 					trace: new FileTraceSink(traceFilePath(runsDir(ctx.cwd), prev.flowName, prev.runId)),
 				};
 				if (apply) {

--- a/packages/taskflow-core/src/detached-runner.ts
+++ b/packages/taskflow-core/src/detached-runner.ts
@@ -275,7 +275,10 @@ try {
 		trace: new FileTraceSink(traceFilePath(runsDir(ctx.cwd), state.flowName, state.runId)),
 		// No requestApproval — approval phases auto-reject in detached/CI mode
 		// (safety: approval gates are never bypassed; the run records the rejection).
-		loadFlow: (name: string) => getFlow(ctx.cwd, name)?.def,
+		loadSavedFlow: (name: string) => {
+			const saved = getFlow(ctx.cwd, name);
+			return saved ? { def: saved.def, filePath: saved.filePath, sourceDirIdentity: saved.sourceDirIdentity } : undefined;
+		},
 	};
 	if (ctx.incremental === true) deps.cacheScopeDefault = "cross-run";
 	try {

--- a/packages/taskflow-core/src/exec/driver.ts
+++ b/packages/taskflow-core/src/exec/driver.ts
@@ -29,6 +29,7 @@ import type { AgentConfig } from "../agents.ts";
 import type { UsageStats } from "../usage.ts";
 import { pluginVerifierErrors } from "../verify.ts";
 import type { TaskflowVerifier } from "../verify.ts";
+import type { DirectoryIdentity } from "../cwd-bridge.ts";
 import {
 	clampSubFlowBudget,
 	containsInterpolationPlaceholder,
@@ -51,6 +52,7 @@ export interface EventKernelDeps {
 	eventKernel?: boolean;
 	requestApproval?: (req: KernelApprovalRequest) => Promise<KernelApprovalDecision>;
 	loadFlow?: (name: string) => Taskflow | undefined;
+	loadSavedFlow?: (name: string) => { def: Taskflow; filePath?: string; sourceDirIdentity?: DirectoryIdentity } | undefined;
 	/** Caller-supplied zero-token verifiers (see verify.ts). Run in runNested's
 	 *  plugin-error preflight before every child-flow dispatch on this engine, and
 	 *  recursed via the ...deps spread. */
@@ -211,6 +213,8 @@ export async function runEventKernel(state: RunState, deps: EventKernelDeps): Pr
 		args: Record<string, unknown>;
 		stack: string[];
 		dynamic?: boolean;
+		flowSourceFile?: string;
+		flowSourceDirIdentity?: DirectoryIdentity;
 	}): Promise<NestedFlowResult> => {
 		const nestedArgs = resolveArgs(opts.def, opts.args);
 		const dynamic = deps._dynamic === true || opts.dynamic === true;
@@ -298,6 +302,8 @@ export async function runEventKernel(state: RunState, deps: EventKernelDeps): Pr
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 			cwd: deps.cwd,
+			flowSourceFile: opts.flowSourceFile,
+			flowSourceDirIdentity: opts.flowSourceDirIdentity,
 		};
 		const child = await runEventKernel(childState, {
 			...deps,
@@ -328,6 +334,7 @@ export async function runEventKernel(state: RunState, deps: EventKernelDeps): Pr
 		globalThinking: deps.globalThinking,
 		requestApproval: deps.requestApproval,
 		loadFlow: deps.loadFlow,
+		loadSavedFlow: deps.loadSavedFlow,
 		stack: deps._stack ?? [],
 		runNested,
 	};

--- a/packages/taskflow-core/src/exec/step-kinds.ts
+++ b/packages/taskflow-core/src/exec/step-kinds.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Phase, Taskflow } from "../schema.ts";
+import type { DirectoryIdentity } from "../cwd-bridge.ts";
 import { readFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import {
@@ -694,6 +695,8 @@ export async function executeFlowBody(phase: Phase, ctx: StepContext): Promise<B
 	const hasDef = (phase as { def?: unknown }).def !== undefined;
 	const stack = ctx.deps.stack ?? [];
 	let subDef: Taskflow | undefined;
+	let subFlowSourceFile: string | undefined;
+	let subFlowSourceDirIdentity: DirectoryIdentity | undefined;
 	let recursionKey: string;
 
 	const defFailOpen = (diag: string): BodyResult => ({
@@ -760,7 +763,7 @@ export async function executeFlowBody(phase: Phase, ctx: StepContext): Promise<B
 				usage: emptyUsage(),
 			};
 		}
-		if (!ctx.deps.loadFlow) {
+		if (!ctx.deps.loadSavedFlow) {
 			return {
 				midEvents: [],
 				status: "failed",
@@ -768,8 +771,8 @@ export async function executeFlowBody(phase: Phase, ctx: StepContext): Promise<B
 				usage: emptyUsage(),
 			};
 		}
-		subDef = ctx.deps.loadFlow(useName);
-		if (!subDef) {
+		const loaded = ctx.deps.loadSavedFlow(useName);
+		if (!loaded) {
 			return {
 				midEvents: [],
 				status: "failed",
@@ -777,6 +780,9 @@ export async function executeFlowBody(phase: Phase, ctx: StepContext): Promise<B
 				usage: emptyUsage(),
 			};
 		}
+		subDef = loaded.def;
+		subFlowSourceFile = loaded.filePath;
+		subFlowSourceDirIdentity = loaded.sourceDirIdentity;
 		recursionKey = useName;
 	}
 
@@ -815,6 +821,8 @@ export async function executeFlowBody(phase: Phase, ctx: StepContext): Promise<B
 		args: provided,
 		stack: nextStack,
 		dynamic: hasDef,
+		flowSourceFile: subFlowSourceFile,
+		flowSourceDirIdentity: subFlowSourceDirIdentity,
 	});
 
 	return {

--- a/packages/taskflow-core/src/exec/step.ts
+++ b/packages/taskflow-core/src/exec/step.ts
@@ -11,6 +11,7 @@ import { dependenciesOf, MAX_DYNAMIC_MAP_ITEMS, PHASE_TYPES } from "../schema.ts
 import { readFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import type { RunState } from "../store.ts";
+import type { DirectoryIdentity } from "../cwd-bridge.ts";
 import type { AgentConfig } from "../agents.ts";
 import type { RunOptions, RunResult } from "../host/runner-types.ts";
 import type { Event } from "./events.ts";
@@ -25,6 +26,7 @@ import {
 } from "../interpolate.ts";
 import { abortableDelay, failedResultDisplayOutput, hasMeaningfulFailedOutput, isFailed as isFailedResult, isTransientError, mapWithConcurrencyLimit, PHASE_TIMEOUT_ABORT_GRACE_MS } from "../runner-core.ts";
 import {
+	resolveScriptCwd,
 	runScriptCommand,
 	scriptResultToPhaseState,
 	scriptSpawnErrorToPhaseState,
@@ -85,6 +87,7 @@ export interface StepDeps {
 	globalThinking?: string;
 	requestApproval?: (req: KernelApprovalRequest) => Promise<KernelApprovalDecision>;
 	loadFlow?: (name: string) => Taskflow | undefined;
+	loadSavedFlow?: (name: string) => { def: Taskflow; filePath?: string; sourceDirIdentity?: DirectoryIdentity } | undefined;
 	/** Sub-flow call stack (recursion guard). */
 	stack?: string[];
 	/** Nested flow runner (driver injects runEventKernel). */
@@ -93,6 +96,8 @@ export interface StepDeps {
 		args: Record<string, unknown>;
 		stack: string[];
 		dynamic?: boolean;
+		flowSourceFile?: string;
+		flowSourceDirIdentity?: DirectoryIdentity;
 	}) => Promise<NestedFlowResult>;
 }
 
@@ -208,10 +213,25 @@ async function executeScriptBody(phase: Phase, ctx: StepContext): Promise<BodyRe
 	const timeoutMs = phase.timeout ?? 60_000;
 	let phaseState;
 	try {
+		const executionCwd = typeof phase.cwd === "string" && !/^(temp|dedicated|worktree)$/.test(phase.cwd)
+			&& !phase.cwd.includes("{")
+			? resolvePath(ctx.deps.cwd, phase.cwd)
+			: ctx.deps.cwd;
+		const hasExplicitScriptCwd = phase.cwd !== undefined;
+		const scriptCwd = resolveScriptCwd({
+			executionCwd,
+			hasExplicitCwd: hasExplicitScriptCwd,
+			scriptCwd: ctx.state.def.scriptCwd,
+			flowSourceFile: ctx.state.flowSourceFile,
+			flowSourceDirIdentity: ctx.state.flowSourceDirIdentity,
+		});
 		const result = await runScriptCommand({
 			interpRunText: argv,
 			arrayForm: Array.isArray(run),
-			cwd: ctx.deps.cwd,
+			cwd: scriptCwd,
+			cwdIdentity: !hasExplicitScriptCwd && ctx.state.def.scriptCwd === "flow"
+				? ctx.state.flowSourceDirIdentity
+				: undefined,
 			signal: ctx.deps.signal,
 			timeoutMs,
 		});

--- a/packages/taskflow-core/src/flowir/compile.ts
+++ b/packages/taskflow-core/src/flowir/compile.ts
@@ -248,6 +248,7 @@ export function compileTaskflowToFlowIR(def: Taskflow): CompileTaskflowToFlowIRR
 			annotations: {
 				agentScope: def.agentScope ?? "user",
 				contextSharing: def.contextSharing ?? false,
+				scriptCwd: def.scriptCwd ?? "invocation",
 			},
 		},
 	};

--- a/packages/taskflow-core/src/flowir/phasefp.ts
+++ b/packages/taskflow-core/src/flowir/phasefp.ts
@@ -124,6 +124,7 @@ export async function phaseFingerprint(def: Taskflow, phaseId: string): Promise<
 		flow: {
 			agentScope: def.agentScope ?? "user",
 			contextSharing: def.contextSharing ?? false,
+			scriptCwd: def.scriptCwd ?? "invocation",
 		},
 		self: stripPolicy(phase),
 		deps: depsPayload,

--- a/packages/taskflow-core/src/library/search.ts
+++ b/packages/taskflow-core/src/library/search.ts
@@ -9,7 +9,7 @@
  * §5.2.2 (staleness), §5.3 (why/reuseHint templates).
  */
 
-import { getFlow, listFlows, readMeta } from "../store.ts";
+import { getFlow, listFlows, readMetaNextTo } from "../store.ts";
 import type { Taskflow } from "../schema.ts";
 import type { FlowMeta } from "./types.ts";
 import {
@@ -246,7 +246,7 @@ export async function searchLibrary(deps: LibraryDeps, input: SearchInput): Prom
 
 	const scored: Array<{ cand: ResolvedCandidate; score: number; semScore?: number; structScore: number; textScore: number }> = [];
 	for (const f of flows) {
-		const sidecarR = readMeta(deps.cwd, f.name);
+		const sidecarR = readMetaNextTo(f.filePath);
 		const sidecar = sidecarR.ok ? sidecarR.value : undefined;
 		const cand = resolveCandidate(f.def, f.scope, f.name, sidecar);
 		const qShape = {

--- a/packages/taskflow-core/src/resume.ts
+++ b/packages/taskflow-core/src/resume.ts
@@ -186,6 +186,8 @@ export function forkRunForResume(
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		cwd: opts.cwd ?? prev.cwd,
+		...(prev.flowSourceFile !== undefined ? { flowSourceFile: prev.flowSourceFile } : {}),
+		...(prev.flowSourceDirIdentity !== undefined ? { flowSourceDirIdentity: structuredClone(prev.flowSourceDirIdentity) } : {}),
 		parentRunId: prev.runId,
 		// Preserve workspace provenance/authority so a resume cannot silently
 		// escape or downgrade the parent's cwd boundary.

--- a/packages/taskflow-core/src/runtime.ts
+++ b/packages/taskflow-core/src/runtime.ts
@@ -83,6 +83,14 @@ export interface ApprovalDecision {
 	note?: string;
 }
 
+export interface LoadedSavedFlow {
+	def: Taskflow;
+	/** Canonical loader-owned definition path. Omitted for legacy loaders. */
+	filePath?: string;
+	/** Identity of the canonical definition directory, captured with the file. */
+	sourceDirIdentity?: DirectoryIdentity;
+}
+
 export interface RuntimeDeps {
 	cwd: string;
 	agents: AgentConfig[];
@@ -100,8 +108,12 @@ export interface RuntimeDeps {
 	runTask?: RunTaskFn;
 	/** Resolve an `approval` phase. Omit for non-interactive runs (auto-reject). */
 	requestApproval?: (req: ApprovalRequest) => Promise<ApprovalDecision>;
-	/** Resolve a saved taskflow by name for `flow` (sub-workflow) phases. */
+	/** Legacy definition-only loader. Prefer `loadSavedFlow` when file-backed
+	 * semantics such as `scriptCwd:"flow"` are available. */
 	loadFlow?: (name: string) => Taskflow | undefined;
+	/** Atomically resolve a saved definition together with its trusted canonical
+	 * source path. Runtime snapshots the pair as one immutable capability. */
+	loadSavedFlow?: (name: string) => LoadedSavedFlow | undefined;
 	/** Cross-run memoization store. Omit to construct a default one for `deps.cwd`. */
 	cacheStore?: CacheStore;
 	/** Default cache scope for phases that don't specify one. */
@@ -165,7 +177,7 @@ export interface RuntimeDeps {
 }
 
 type FlowLoaderSnapshotEntry =
-	| { ok: true; value: Taskflow | undefined }
+	| { ok: true; value: LoadedSavedFlow | undefined }
 	| { ok: false; error: unknown };
 
 export interface RuntimeResult {
@@ -827,17 +839,20 @@ function flowTreeUsesCwdBridge(
  * after the root binding and cache policy were decided.
  */
 function snapshotFlowLoader(deps: RuntimeDeps): RuntimeDeps {
-	if (!deps.loadFlow || deps._flowLoaderSnapshot) return deps;
-	const source = deps.loadFlow;
+	if ((!deps.loadSavedFlow && !deps.loadFlow) || deps._flowLoaderSnapshot) return deps;
+	const source: (name: string) => LoadedSavedFlow | undefined = deps.loadSavedFlow
+		?? ((name) => {
+			const def = deps.loadFlow?.(name);
+			return def === undefined ? undefined : { def };
+		});
 	const snapshot = new Map<string, FlowLoaderSnapshotEntry>();
-	const loadFlow = (name: string): Taskflow | undefined => {
+	const loadSavedFlow = (name: string): LoadedSavedFlow | undefined => {
 		let entry = snapshot.get(name);
 		if (!entry) {
 			try {
 				const loaded = source(name);
-				// Loader-owned objects may be mutated asynchronously. Capability scan
-				// and execution operate on a detached structured snapshot, never the
-				// loader's live reference.
+				// Definition and provenance are detached and cached as one value, so
+				// mutable discovery cannot pair data from one flow with another path.
 				entry = { ok: true, value: loaded === undefined ? undefined : structuredClone(loaded) };
 			} catch (error) {
 				entry = { ok: false, error };
@@ -847,7 +862,8 @@ function snapshotFlowLoader(deps: RuntimeDeps): RuntimeDeps {
 		if (!entry.ok) throw entry.error;
 		return entry.value;
 	};
-	return { ...deps, loadFlow, _flowLoaderSnapshot: snapshot };
+	const loadFlow = (name: string): Taskflow | undefined => loadSavedFlow(name)?.def;
+	return { ...deps, loadFlow, loadSavedFlow, _flowLoaderSnapshot: snapshot };
 }
 
 function sameDirectoryIdentity(a: DirectoryIdentity | undefined, b: DirectoryIdentity | undefined): boolean {
@@ -2490,7 +2506,7 @@ async function executePhaseInner(
 
 	// script — zero-token shell (spawn/timeout/size caps in runtime/phases/script.ts)
 	if (type === "script") {
-		const { runScriptCommand, scriptResultToPhaseState, scriptSpawnErrorToPhaseState } =
+		const { resolveScriptCwd, runScriptCommand, scriptResultToPhaseState, scriptSpawnErrorToPhaseState } =
 			await import("./runtime/phases/script.ts");
 		const cmd = phase.run;
 		if (!cmd) {
@@ -2514,19 +2530,48 @@ async function executePhaseInner(
 		const stdinInterp = phase.input !== undefined ? interpolate(phase.input, ctx) : undefined;
 		if (stdinInterp?.missing.length) warnUnresolvedRefs(phase.id, stdinInterp.missing);
 		const stdinInput = stdinInterp?.text;
+		const reads = readRefs.length ? readRefsToReads(readRefs, state) : undefined;
+		let scriptCwd: string;
+		const hasExplicitScriptCwd = deps._cwdOverride !== undefined || phase.cwd !== undefined;
+		try {
+			scriptCwd = resolveScriptCwd({
+				executionCwd: effCwd,
+				hasExplicitCwd: hasExplicitScriptCwd,
+				scriptCwd: state.def.scriptCwd,
+				flowSourceFile: state.flowSourceFile,
+				flowSourceDirIdentity: state.flowSourceDirIdentity,
+			});
+		} catch (err: unknown) {
+			return scriptSpawnErrorToPhaseState(phase.id, err, {
+				inputHash: hashInput(phase.id, JSON.stringify(interpRunText), stdinInput ?? "", "script-cwd-unresolved"),
+				reads,
+			});
+		}
+		if (deps._cwdBoundary && !isPathWithin(deps._cwdBoundary, scriptCwd)) {
+			return scriptSpawnErrorToPhaseState(
+				phase.id,
+				new Error("TF_CWD_BOUNDARY_ESCAPE: script cwd must remain inside the inherited cwd boundary"),
+				{
+					inputHash: hashInput(phase.id, JSON.stringify(interpRunText), stdinInput ?? "", "script-cwd-boundary-escape"),
+					reads,
+				},
+			);
+		}
 
-		const ck = cacheKeys(cc, [phase.id, JSON.stringify(interpRunText), stdinInput ?? ""]);
+		const ck = cacheKeys(cc, [phase.id, JSON.stringify(interpRunText), stdinInput ?? "", `cwd:${scriptCwd}`]);
 		const inputHash = ck.key;
 		const cached = cachedPhase(cc, ck);
 		if (cached) return cached;
 
 		const SCRIPT_TIMEOUT_MS = phase.timeout ?? 60_000;
-		const reads = readRefs.length ? readRefsToReads(readRefs, state) : undefined;
 		try {
 			const invoke = () => runScriptCommand({
 				interpRunText,
 				arrayForm: Array.isArray(cmd),
-				cwd: effCwd,
+				cwd: scriptCwd,
+				cwdIdentity: !hasExplicitScriptCwd && state.def.scriptCwd === "flow"
+					? state.flowSourceDirIdentity
+					: undefined,
 				signal: deps.signal,
 				stdinInput,
 				timeoutMs: SCRIPT_TIMEOUT_MS,
@@ -2762,6 +2807,8 @@ async function executePhaseInner(
 		}
 
 		let subDef: Taskflow | undefined;
+		let subFlowSourceFile: string | undefined;
+		let subFlowSourceDirIdentity: DirectoryIdentity | undefined;
 		let name: string;
 		let recursionKey: string; // identity used for cache key + recursion guard
 
@@ -2869,9 +2916,12 @@ async function executePhaseInner(
 			// --- Saved flow via `use` (unchanged behavior). ---
 			const useName = phase.use;
 			if (!useName) return failPhase(phase.id, `flow phase '${phase.id}' requires 'use' or 'def'`);
-			if (!deps.loadFlow) return failPhase(phase.id, `flow phase '${phase.id}': no sub-flow loader available`);
-			subDef = deps.loadFlow(useName);
-			if (!subDef) return failPhase(phase.id, `flow phase '${phase.id}': saved flow not found: '${useName}'`);
+			if (!deps.loadSavedFlow) return failPhase(phase.id, `flow phase '${phase.id}': no sub-flow loader available`);
+			const loaded = deps.loadSavedFlow(useName);
+			if (!loaded) return failPhase(phase.id, `flow phase '${phase.id}': saved flow not found: '${useName}'`);
+			subDef = loaded.def;
+			subFlowSourceFile = loaded.filePath;
+			subFlowSourceDirIdentity = loaded.sourceDirIdentity;
 			name = useName;
 			recursionKey = useName;
 		}
@@ -2919,7 +2969,7 @@ async function executePhaseInner(
 		// Every sub-flow cache identity includes the resolved definition. A saved
 		// flow's name alone is insufficient: its contents can change without the
 		// parent definition moving.
-		const flowIdentity = `${hasDef ? "def" : "flow"}:${name}:${JSON.stringify(subDef)}`;
+		const flowIdentity = `${hasDef ? "def" : "flow"}:${name}:${JSON.stringify(subDef)}:source:${subFlowSourceFile ?? ""}:source-dir:${JSON.stringify(subFlowSourceDirIdentity ?? null)}`;
 		const ck = cacheKeys(flowCc, [phase.id, flowIdentity, preRead, JSON.stringify(subArgs)]);
 		const inputHash = ck.key;
 		const cached = cachedPhase(flowCc, ck);
@@ -2952,6 +3002,8 @@ async function executePhaseInner(
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 			cwd: effCwd,
+			flowSourceFile: subFlowSourceFile,
+			flowSourceDirIdentity: subFlowSourceDirIdentity,
 		};
 		// B8: pass this flow phase's preRead content to every sub-flow phase by
 		// wrapping runTask — sub-phase preRead still gets prepended on top of it.
@@ -4338,6 +4390,7 @@ export async function executeTaskflow(state: RunState, deps: RuntimeDeps): Promi
 				verifiers: deps.verifiers,
 				requestApproval: deps.requestApproval,
 				loadFlow: deps.loadFlow,
+				loadSavedFlow: deps.loadSavedFlow,
 				_stack: deps._stack,
 				_dynamic: deps._dynamic,
 			});

--- a/packages/taskflow-core/src/runtime/phases/script.ts
+++ b/packages/taskflow-core/src/runtime/phases/script.ts
@@ -7,12 +7,39 @@ import type { Phase } from "../../schema.ts";
 import type { PhaseState } from "../../store.ts";
 import { emptyUsage } from "../../usage.ts";
 import { StringDecoder } from "node:string_decoder";
+import * as path from "node:path";
 import { killProcessTree, registerProcessTree, unregisterProcessTree } from "../../runner-core.ts";
-import { CWD_BRIDGE_MODE_ENV } from "../../cwd-bridge.ts";
+import { CWD_BRIDGE_MODE_ENV, directoryIdentity, type DirectoryIdentity } from "../../cwd-bridge.ts";
 import { WORKSPACE_RECONCILE_MODE_ENV } from "../../resources/execution.ts";
 
 const MAX_STDOUT = 1_048_576; // 1 MB cap
 const SIGKILL_GRACE_MS = 5_000;
+
+function assertDirectoryIdentity(dir: string, expected: DirectoryIdentity): DirectoryIdentity {
+	const current = directoryIdentity(dir);
+	if (!current || current.canonicalPath !== expected.canonicalPath || current.device !== expected.device || current.inode !== expected.inode) {
+		throw new Error("flow-relative script cwd source directory identity changed after definition load");
+	}
+	return current;
+}
+
+/** Resolve a script phase cwd without changing any existing explicit cwd or
+ * workspace-isolation semantics. Flow-relative mode is opt-in and requires
+ * trusted loader provenance; it never guesses a directory from flow data. */
+export function resolveScriptCwd(opts: {
+	executionCwd: string;
+	hasExplicitCwd: boolean;
+	scriptCwd?: "invocation" | "flow";
+	flowSourceFile?: string;
+	flowSourceDirIdentity?: DirectoryIdentity;
+}): string {
+	if (opts.hasExplicitCwd || opts.scriptCwd !== "flow") return opts.executionCwd;
+	if (!opts.flowSourceFile || !opts.flowSourceDirIdentity) {
+		throw new Error("flow-relative script cwd requires stable saved-flow or defineFile provenance");
+	}
+	const sourceDir = path.dirname(opts.flowSourceFile);
+	return assertDirectoryIdentity(sourceDir, opts.flowSourceDirIdentity).canonicalPath;
+}
 
 export interface ScriptRunResult {
 	stdout: string;
@@ -31,6 +58,8 @@ export async function runScriptCommand(opts: {
 	/** Original `run` shape: array → no shell; string → shell true. */
 	arrayForm: boolean;
 	cwd: string;
+	/** When present, revalidated synchronously inside the spawn closure. */
+	cwdIdentity?: DirectoryIdentity;
 	signal?: AbortSignal;
 	stdinInput?: string;
 	timeoutMs: number;
@@ -39,6 +68,9 @@ export async function runScriptCommand(opts: {
 	const { interpRunText, arrayForm, cwd, signal, stdinInput, timeoutMs } = opts;
 
 	return new Promise((resolve, reject) => {
+		// This is deliberately inside the post-import Promise executor: no await or
+		// host wrapper runs between this identity check and child_process.spawn.
+		if (opts.cwdIdentity) assertDirectoryIdentity(cwd, opts.cwdIdentity);
 		const childEnv = { ...process.env };
 		// Script phases execute flow-authored commands, so they are not a trusted
 		// host principal. Host-only workspace controls must never be delegated even

--- a/packages/taskflow-core/src/schema.ts
+++ b/packages/taskflow-core/src/schema.ts
@@ -535,6 +535,13 @@ export const TaskflowSchema = Type.Object(
 					"Default every phase to cross-run caching (scope:'cross-run') so re-running this flow reuses unchanged phases across runs/sessions. Equivalent to setting cache:{scope:'cross-run'} on every phase; per-phase cache settings and the cross-run-blocked types (gate/approval/loop/tournament) still take precedence. Default false (run-only — each run starts fresh unless a phase opts in). A run-time `incremental` argument overrides this.",
 			}),
 		),
+		scriptCwd: Type.Optional(
+			StringEnum(["invocation", "flow"] as const, {
+				description:
+					"Default cwd for script phases without an explicit phase.cwd. 'flow' uses the saved flow or defineFile directory; default 'invocation' preserves legacy behavior.",
+				default: "invocation",
+			}),
+		),
 		/**
 		 * Flow-level idle watchdog (ms) for all agent-running phases that don't set
 		 * their own `idleTimeout`. Positive (>= 1000) overrides the host default

--- a/packages/taskflow-core/src/store.ts
+++ b/packages/taskflow-core/src/store.ts
@@ -1258,6 +1258,14 @@ function isFlowDefinitionFile(name: string): boolean {
 	return name.endsWith(".json") && !name.endsWith(".meta.json") && !name.endsWith(".flowir.json");
 }
 
+/** The 0.2.9 top-level scanner excluded only metadata sidecars. In particular,
+ * a valid flow named `release.flowir` is stored as `release.flowir.json` and
+ * must remain discoverable. The new nested convention can still reserve that
+ * suffix for generated FlowIR artifacts. */
+function isLegacyFlowDefinitionFile(name: string): boolean {
+	return name.endsWith(".json") && !name.endsWith(".meta.json");
+}
+
 function isPhysicallyContained(rootReal: string, candidateReal: string): boolean {
 	const relative = path.relative(rootReal, candidateReal);
 	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
@@ -1323,8 +1331,14 @@ function readDirectoryBounded(dir: string, budget: DiscoveryBudget): fs.Dirent[]
 			}
 			entries.push(entry);
 		}
+	} catch {
+		// Preserve the legacy listFlows contract: an unreadable or concurrently
+		// replaced directory is skipped rather than escaping as a process-level
+		// exception. Discard a partial read so precedence never depends on where
+		// the failure happened.
+		return [];
 	} finally {
-		handle.closeSync();
+		try { handle.closeSync(); } catch { /* unreadable/replaced directory: skip */ }
 	}
 	return entries.sort((a, b) => codePointCompare(a.name, b.name));
 }
@@ -1353,7 +1367,10 @@ function listLegacyFlowFiles(rootReal: string, budget: DiscoveryBudget): string[
 	const files: string[] = [];
 	for (const entry of readDirectoryBounded(rootReal, budget)) {
 		if (budget.exceeded) break;
-		if (entry.name.startsWith(".") || entry.isSymbolicLink() || !entry.isFile() || !isFlowDefinitionFile(entry.name)) continue;
+		// Legacy 0.2.9 discovery accepted hidden top-level JSON definitions. Keep
+		// that compatibility at the storage root; only the new recursive `flows/`
+		// convention skips hidden entries/directories.
+		if (entry.isSymbolicLink() || !entry.isFile() || !isLegacyFlowDefinitionFile(entry.name)) continue;
 		const real = canonicalRegularFile(path.join(rootReal, entry.name), rootReal);
 		if (!real || !reserveFlowCandidate(budget)) continue;
 		files.push(real);
@@ -1639,8 +1656,7 @@ export function saveFlow(
 	const fileLockPath = filePath + ".lock";
 	withLock(fileLockPath, () => {
 		assertFlowSaveTarget(target);
-		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`);
-		assertFlowSaveTarget(target);
+		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`, () => assertFlowSaveTarget(target));
 	});
 
 	// One-shot: let the user know about .pi/ directory on first save (Finding 8).
@@ -1732,10 +1748,9 @@ export function saveFlowWithMeta(
 	const fileLockPath = filePath + ".lock"; // shared lock key for flow+sidecar (R2R5)
 	withLock(fileLockPath, () => {
 		assertFlowSaveTarget(target);
-		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`);
+		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`, () => assertFlowSaveTarget(target));
 		assertFlowSaveTarget(target);
-		writeFileAtomic(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
-		assertFlowSaveTarget(target);
+		writeFileAtomic(metaPath, `${JSON.stringify(meta, null, 2)}\n`, () => assertFlowSaveTarget(target));
 	});
 	return { filePath, metaPath };
 }
@@ -1776,8 +1791,7 @@ export function bumpReuseInSidecar(cwd: string, flowName: string): number | null
 					embedding: null,
 			  };
 		assertFlowSaveTarget(target);
-		writeFileAtomic(metaPath, `${JSON.stringify(updated, null, 2)}\n`);
-		assertFlowSaveTarget(target);
+		writeFileAtomic(metaPath, `${JSON.stringify(updated, null, 2)}\n`, () => assertFlowSaveTarget(target));
 		return updated.reuseCount;
 	});
 }
@@ -2069,18 +2083,48 @@ export function isProcessAlive(pid: number): boolean {
  * then rename over the target (rename is atomic on the same filesystem). Prevents
  * a crash or concurrent write from leaving a half-written, corrupt JSON file.
  */
-export function writeFileAtomic(filePath: string, data: string): void {
+export function writeFileAtomic(filePath: string, data: string, guard?: () => void): void {
 	// Ensure parent directory exists.
+	guard?.();
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	guard?.();
 	const tmp = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
+	let fd: number | undefined;
 	try {
-		fs.writeFileSync(tmp, data, "utf-8");
+		guard?.();
+		// Open the unique temp path without following a pre-existing leaf and write
+		// through the descriptor. If the parent is renamed/replaced after open,
+		// the descriptor remains bound to the original directory's file instead of
+		// redirecting content through a new symlinked lexical path.
+		const noFollow = process.platform === "win32" ? 0 : fs.constants.O_NOFOLLOW;
+		fd = fs.openSync(tmp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollow, 0o666);
+		// Close the final pre-open race: if the lexical parent changed between the
+		// prior guard and openSync, fail before any definition bytes reach the fd.
+		guard?.();
+		fs.writeFileSync(fd, data, "utf-8");
+		fs.closeSync(fd);
+		fd = undefined;
+		// The directory can be renamed/replaced while the temp file is written.
+		// Revalidate immediately before the externally visible rename; on failure
+		// the guarded path is left untouched and no file is promoted.
+		guard?.();
 		fs.renameSync(tmp, filePath);
 	} catch (e) {
-		try {
-			if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
-		} catch {
-			/* ignore cleanup failure */
+		if (fd !== undefined) {
+			try { fs.closeSync(fd); } catch { /* ignore close failure */ }
+		}
+		// A guarded caller is protecting a directory-identity boundary. Once a
+		// guard or write fails, the lexical temp path may already resolve through
+		// a replacement directory/symlink; unlinking it could delete an unrelated
+		// external same-name file. Fail closed and leave any temp artifact in the
+		// original (possibly displaced) directory. Unguarded legacy callers keep
+		// the original best-effort cleanup behavior.
+		if (!guard) {
+			try {
+				if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+			} catch {
+				/* ignore cleanup failure */
+			}
 		}
 		throw e;
 	}

--- a/packages/taskflow-core/src/store.ts
+++ b/packages/taskflow-core/src/store.ts
@@ -31,7 +31,10 @@ import type { FlowMeta } from "./library/types.ts";
 export interface SavedFlow {
 	name: string;
 	scope: "user" | "project";
+	/** Canonical physical definition path captured by the stable loader. */
 	filePath: string;
+	/** Identity of the canonical definition directory at load time. */
+	sourceDirIdentity: DirectoryIdentity;
 	def: Taskflow;
 }
 
@@ -186,6 +189,12 @@ export interface RunState {
 	createdAt: number;
 	updatedAt: number;
 	cwd: string;
+	/** Canonical source file for a saved flow or defineFile invocation. Runtime
+	 * provenance only: inline definitions omit it, and flow data cannot set it. */
+	flowSourceFile?: string;
+	/** Physical identity of `dirname(flowSourceFile)` captured atomically with the
+	 * definition. Revalidated immediately before a flow-relative script spawn. */
+	flowSourceDirIdentity?: DirectoryIdentity;
 	/** Root identity captured by a host when it creates the run. This closes the
 	 * detached launch window, but does not itself grant/taint cwd-bridge use. */
 	invocationRootSnapshot?: DirectoryIdentity;
@@ -1054,67 +1063,445 @@ function findProjectFlowsDirInternal(cwd: string, create = false): string | null
 	return create ? path.join(canonicalCwd, ".pi", "taskflows") : null;
 }
 
-/**
- * Read a flow definition from a file on disk. Supports raw JSON or a Markdown
- * document with a fenced ```json block. Used by the `defineFile` parameter so
- * verify/compile/run can share one persisted draft (e.g. in the OS temp dir)
- * without saving it into the project's .pi/taskflows.
- *
- * Returns a `LoadResult`: `{ ok: true, value }` on success, or
- * `{ ok: false, reason: "missing" | "unparseable", ... }` on failure. Callers
- * surface an explicit error via `describeLoadFailure`.
- */
-export function readDefineFile(filePath: string): LoadResult<unknown> {
-	return loadFile(filePath, (raw) => parseStrict(raw, { allowFence: true }));
+const MAX_FLOW_DEFINITION_BYTES = 1_048_576; // 1 MiB per JSON/JSONC/defineFile
+const MAX_DISCOVERY_TOTAL_BYTES = 8_388_608; // 8 MiB across user + project discovery
+
+interface DiscoveryBudget {
+	entries: number;
+	directories: number;
+	files: number;
+	bytes: number;
+	exceeded: boolean;
 }
 
-function readFlowFile(filePath: string, scope: "user" | "project"): LoadResult<SavedFlow> {
-	const r = loadFile(filePath, (raw) => parseJsonc(raw) as Taskflow);
+interface StableSource<T> {
+	value: T;
+	filePath: string;
+	sourceDirIdentity: DirectoryIdentity;
+	byteLength: number;
+}
+
+function sameFileStat(a: fs.BigIntStats, b: fs.BigIntStats): boolean {
+	return a.dev === b.dev && a.ino === b.ino && a.size === b.size && a.mtimeNs === b.mtimeNs && a.ctimeNs === b.ctimeNs;
+}
+
+function sameDirectoryIdentityValue(a: DirectoryIdentity | undefined, b: DirectoryIdentity | undefined): boolean {
+	return !!a && !!b && a.canonicalPath === b.canonicalPath && a.device === b.device && a.inode === b.inode;
+}
+
+/** Read a bounded regular file through one descriptor and bind parsed content to
+ * a canonical path + parent identity. Symlink leaves and files changed during
+ * the read fail closed. */
+function loadStableSource<T>(
+	filePath: string,
+	parse: (raw: string) => T,
+	budget?: DiscoveryBudget,
+	allowedRootReal?: string | readonly string[],
+): LoadResult<StableSource<T>> {
+	const allowedRoots = allowedRootReal === undefined
+		? []
+		: (typeof allowedRootReal === "string" ? [allowedRootReal] : [...allowedRootReal]);
+	const isAllowedSource = (candidate: string): boolean =>
+		allowedRoots.length === 0 || allowedRoots.some((root) => isPhysicallyContained(root, candidate));
+	let fd: number | undefined;
+	try {
+		const lexicalStat = fs.lstatSync(filePath, { bigint: true });
+		if (lexicalStat.isSymbolicLink() || !lexicalStat.isFile()) {
+			throw new Error("definition must be a regular non-symlink file");
+		}
+		const canonicalBefore = fs.realpathSync.native(filePath);
+		if (allowedRoots.length > 0 && (
+			!sameDiscoveryPath(canonicalBefore, path.resolve(filePath)) ||
+			!isAllowedSource(canonicalBefore)
+		)) {
+			throw new Error("definition escaped or changed its canonical saved-flow root");
+		}
+		const sourceDirBefore = directoryIdentity(path.dirname(canonicalBefore));
+		if (!sourceDirBefore) throw new Error("definition parent directory identity is unavailable");
+
+		const noFollow = process.platform === "win32" ? 0 : fs.constants.O_NOFOLLOW;
+		fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
+		const before = fs.fstatSync(fd, { bigint: true });
+		if (!before.isFile()) throw new Error("definition must remain a regular file");
+		if (before.size > BigInt(MAX_FLOW_DEFINITION_BYTES)) {
+			if (budget) budget.exceeded = true;
+			throw new Error(`definition exceeds ${MAX_FLOW_DEFINITION_BYTES} byte limit`);
+		}
+		const byteLength = Number(before.size);
+		if (budget && budget.bytes + byteLength > MAX_DISCOVERY_TOTAL_BYTES) {
+			budget.exceeded = true;
+			throw new Error(`flow discovery exceeds ${MAX_DISCOVERY_TOTAL_BYTES} cumulative byte limit`);
+		}
+		if (budget) budget.bytes += byteLength;
+
+		const buffer = Buffer.allocUnsafe(byteLength + 1);
+		let bytesRead = 0;
+		while (bytesRead < buffer.length) {
+			const count = fs.readSync(fd, buffer, bytesRead, buffer.length - bytesRead, null);
+			if (count === 0) break;
+			bytesRead += count;
+		}
+		const after = fs.fstatSync(fd, { bigint: true });
+		if (bytesRead !== byteLength || !sameFileStat(before, after)) {
+			throw new Error("definition changed while it was being read");
+		}
+
+		const lexicalAfter = fs.lstatSync(filePath, { bigint: true });
+		if (lexicalAfter.isSymbolicLink() || !sameFileStat(after, lexicalAfter)) {
+			throw new Error("definition path identity changed while it was being read");
+		}
+		const canonicalAfter = fs.realpathSync.native(filePath);
+		const sourceDirAfter = directoryIdentity(path.dirname(canonicalAfter));
+		if (
+			canonicalAfter !== canonicalBefore ||
+			(allowedRoots.length > 0 && !isAllowedSource(canonicalAfter)) ||
+			!sameDirectoryIdentityValue(sourceDirBefore, sourceDirAfter)
+		) {
+			throw new Error("definition parent directory changed while it was being read");
+		}
+
+		const raw = buffer.subarray(0, bytesRead).toString("utf8");
+		return {
+			ok: true,
+			value: {
+				value: parse(raw),
+				filePath: canonicalAfter,
+				sourceDirIdentity: sourceDirAfter!,
+				byteLength,
+			},
+		};
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		return {
+			ok: false,
+			reason: code === "ENOENT" || code === "EACCES" ? "missing" : "unparseable",
+			path: filePath,
+			detail: errMessage(error),
+		};
+	} finally {
+		if (fd !== undefined) {
+			try { fs.closeSync(fd); } catch { /* best effort */ }
+		}
+	}
+}
+
+export interface LoadedDefineFile {
+	value: unknown;
+	filePath: string;
+	sourceDirIdentity: DirectoryIdentity;
+}
+
+/** Stable defineFile loader used by execution hosts that need source provenance. */
+export function readDefineFileWithSource(
+	filePath: string,
+	allowedRootReal?: string | readonly string[],
+): LoadResult<LoadedDefineFile> {
+	const loaded = loadStableSource(filePath, (raw) => parseStrict(raw, { allowFence: true }), undefined, allowedRootReal);
+	if (!loaded.ok) return loaded;
+	return {
+		ok: true,
+		value: {
+			value: loaded.value.value,
+			filePath: loaded.value.filePath,
+			sourceDirIdentity: loaded.value.sourceDirIdentity,
+		},
+	};
+}
+
+export function readDefineFile(filePath: string): LoadResult<unknown> {
+	const loaded = readDefineFileWithSource(filePath);
+	return loaded.ok ? { ok: true, value: loaded.value.value } : loaded;
+}
+
+function readFlowFile(
+	filePath: string,
+	scope: "user" | "project",
+	budget?: DiscoveryBudget,
+	allowedRootReal?: string,
+): LoadResult<SavedFlow> {
+	const r = loadStableSource(filePath, (raw) => parseJsonc(raw) as Taskflow, budget, allowedRootReal);
 	if (!r.ok) return r;
-	if (!r.value?.name) {
+	if (!r.value.value?.name) {
 		return { ok: false, reason: "unparseable", path: filePath, detail: "parsed OK but missing required field: name" };
 	}
-	return { ok: true, value: { name: r.value.name, scope, filePath, def: r.value } };
+	return {
+		ok: true,
+		value: {
+			name: r.value.value.name,
+			scope,
+			filePath: r.value.filePath,
+			sourceDirIdentity: r.value.sourceDirIdentity,
+			def: r.value.value,
+		},
+	};
 }
 
-/** List all saved flows (project overrides user on name collision). */
+const NESTED_FLOWS_DIR = "flows";
+const MAX_NESTED_FLOW_DEPTH = 16;
+const MAX_DISCOVERY_FILES = 1_000;
+const MAX_DISCOVERY_ENTRIES = 10_000;
+const MAX_DISCOVERY_DIRS = 512;
+
+function codePointCompare(a: string, b: string): number {
+	const left = Array.from(a);
+	const right = Array.from(b);
+	const length = Math.min(left.length, right.length);
+	for (let i = 0; i < length; i++) {
+		const l = left[i]!.codePointAt(0)!;
+		const r = right[i]!.codePointAt(0)!;
+		if (l !== r) return l - r;
+	}
+	return left.length - right.length;
+}
+
+function isFlowDefinitionFile(name: string): boolean {
+	return name.endsWith(".json") && !name.endsWith(".meta.json") && !name.endsWith(".flowir.json");
+}
+
+function isPhysicallyContained(rootReal: string, candidateReal: string): boolean {
+	const relative = path.relative(rootReal, candidateReal);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/** Validate every directory component from a trusted boundary (`.pi` for a
+ * project, agent root for user flows) through the taskflows storage root.
+ * Only an explicitly configured user agent boundary may itself be a symlink. */
+function validateStorageRoot(root: string, boundary: string, allowBoundarySymlink = false): string | undefined {
+	const rootAbs = path.resolve(root);
+	const boundaryAbs = path.resolve(boundary);
+	const lexicalRelative = path.relative(boundaryAbs, rootAbs);
+	if (lexicalRelative.startsWith("..") || path.isAbsolute(lexicalRelative)) return undefined;
+	// The configured trust boundary itself may be a symlink (for example a
+	// user moving ~/.pi/agent to another disk). Preserve that historical setup,
+	// while still rejecting every symlink component *below* the boundary.
+	let current = rootAbs;
+	for (;;) {
+		const atBoundary = sameDiscoveryPath(current, boundaryAbs);
+		if (atBoundary && allowBoundarySymlink) break;
+		try {
+			const stat = fs.lstatSync(current);
+			if (stat.isSymbolicLink() || !stat.isDirectory()) return undefined;
+		} catch {
+			return undefined;
+		}
+		if (atBoundary) break;
+		const parent = path.dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+	try {
+		const boundaryReal = fs.realpathSync.native(boundaryAbs);
+		const rootReal = fs.realpathSync.native(rootAbs);
+		if (!fs.statSync(boundaryReal).isDirectory() || !fs.statSync(rootReal).isDirectory()) return undefined;
+		return isPhysicallyContained(boundaryReal, rootReal) ? rootReal : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function readDirectoryBounded(dir: string, budget: DiscoveryBudget): fs.Dirent[] {
+	if (budget.exceeded || budget.directories >= MAX_DISCOVERY_DIRS) {
+		budget.exceeded = true;
+		return [];
+	}
+	budget.directories++;
+	let handle: fs.Dir;
+	try {
+		handle = fs.opendirSync(dir);
+	} catch {
+		return [];
+	}
+	const entries: fs.Dirent[] = [];
+	try {
+		for (;;) {
+			const entry = handle.readSync();
+			if (!entry) break;
+			budget.entries++;
+			if (budget.entries > MAX_DISCOVERY_ENTRIES) {
+				budget.exceeded = true;
+				break;
+			}
+			entries.push(entry);
+		}
+	} finally {
+		handle.closeSync();
+	}
+	return entries.sort((a, b) => codePointCompare(a.name, b.name));
+}
+
+function reserveFlowCandidate(budget: DiscoveryBudget): boolean {
+	budget.files++;
+	if (budget.files > MAX_DISCOVERY_FILES) {
+		budget.exceeded = true;
+		return false;
+	}
+	return true;
+}
+
+function canonicalRegularFile(candidate: string, rootReal: string): string | undefined {
+	try {
+		const stat = fs.lstatSync(candidate);
+		if (stat.isSymbolicLink() || !stat.isFile()) return undefined;
+		const real = fs.realpathSync.native(candidate);
+		return isPhysicallyContained(rootReal, real) ? real : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function listLegacyFlowFiles(rootReal: string, budget: DiscoveryBudget): string[] {
+	const files: string[] = [];
+	for (const entry of readDirectoryBounded(rootReal, budget)) {
+		if (budget.exceeded) break;
+		if (entry.name.startsWith(".") || entry.isSymbolicLink() || !entry.isFile() || !isFlowDefinitionFile(entry.name)) continue;
+		const real = canonicalRegularFile(path.join(rootReal, entry.name), rootReal);
+		if (!real || !reserveFlowCandidate(budget)) continue;
+		files.push(real);
+	}
+	return files;
+}
+
+/** Deterministically discover ordinary JSON files below `<root>/flows/` under
+ * one shared user+project budget. Every path component below the validated
+ * storage root must remain a regular non-symlink directory/file. */
+function listNestedFlowFiles(rootReal: string, budget: DiscoveryBudget): string[] {
+	const conventionRoot = path.join(rootReal, NESTED_FLOWS_DIR);
+	let conventionReal: string;
+	try {
+		const stat = fs.lstatSync(conventionRoot);
+		if (stat.isSymbolicLink() || !stat.isDirectory()) return [];
+		conventionReal = fs.realpathSync.native(conventionRoot);
+		if (!isPhysicallyContained(rootReal, conventionReal)) return [];
+	} catch {
+		return [];
+	}
+
+	const found: string[] = [];
+	const visit = (dir: string, depth: number): void => {
+		if (budget.exceeded || depth > MAX_NESTED_FLOW_DEPTH) {
+			budget.exceeded = true;
+			return;
+		}
+		for (const entry of readDirectoryBounded(dir, budget)) {
+			if (budget.exceeded) break;
+			if (entry.name.startsWith(".") || entry.isSymbolicLink()) continue;
+			const candidate = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				try {
+					const stat = fs.lstatSync(candidate);
+					if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+					const real = fs.realpathSync.native(candidate);
+					if (!isPhysicallyContained(conventionReal, real)) continue;
+					visit(real, depth + 1);
+				} catch {
+					// Entry disappeared or changed; skip safely.
+				}
+			} else if (entry.isFile() && isFlowDefinitionFile(entry.name)) {
+				const real = canonicalRegularFile(candidate, conventionReal);
+				if (!real || !reserveFlowCandidate(budget)) continue;
+				found.push(real);
+			}
+		}
+	};
+	visit(conventionReal, 0);
+	return found.sort(codePointCompare);
+}
+
+function discoveryLimitDetail(): string {
+	return `${MAX_DISCOVERY_FILES} flows, ${MAX_DISCOVERY_ENTRIES} entries, ` +
+		`${MAX_DISCOVERY_DIRS} directories, ${MAX_DISCOVERY_TOTAL_BYTES} bytes, ` +
+		`${MAX_FLOW_DEFINITION_BYTES} bytes/file, depth ${MAX_NESTED_FLOW_DEPTH}`;
+}
+
+function warnDiscoveryLimit(): void {
+	console.warn(`[taskflow] Saved flow discovery failed closed after exceeding a safety limit (${discoveryLimitDetail()}).`);
+}
+
 /** Internal-but-exported for tests: walk-up `.pi` finder with home-dir stop. */
 export function findProjectFlowsDir(cwd: string, create = false): string | null {
 	return findProjectFlowsDirInternal(cwd, create);
 }
 
-export function listFlows(cwd: string): SavedFlow[] {
-	const map = new Map<string, SavedFlow>();
-	const dirs: Array<{ dir: string; scope: "user" | "project" }> = [{ dir: userFlowsDir(), scope: "user" }];
-	const projDir = findProjectFlowsDir(cwd);
-	if (projDir) dirs.push({ dir: projDir, scope: "project" });
+interface FlowDiscoveryResult {
+	flows: SavedFlow[];
+	/** Same-scope winners before project-over-user precedence is applied. */
+	scopedFlows: SavedFlow[];
+	failures: Array<{
+		scope: "user" | "project";
+		filePath: string;
+		result: Extract<LoadResult<SavedFlow>, { ok: false }>;
+	}>;
+	diagnostics: string[];
+	exceeded: boolean;
+}
 
-	for (const { dir, scope } of dirs) {
-		if (!fs.existsSync(dir)) continue;
-		let entries: string[];
-		try {
-			entries = fs.readdirSync(dir);
-		} catch {
-			continue;
-		}
-		for (const name of entries) {
-			if (!name.endsWith(".json")) continue;
-			// A1: sidecar .meta.json must never be scanned as a candidate flow.
-			if (name.endsWith(".meta.json")) continue;
-			const r = readFlowFile(path.join(dir, name), scope);
+/** One bounded discovery pass shared by list/get/diagnosed lookup. */
+function discoverFlows(cwd: string): FlowDiscoveryResult {
+	const map = new Map<string, SavedFlow>();
+	const scopedFlows: SavedFlow[] = [];
+	const failures: FlowDiscoveryResult["failures"] = [];
+	const diagnostics: string[] = [];
+	const budget: DiscoveryBudget = { entries: 0, directories: 0, files: 0, bytes: 0, exceeded: false };
+	const agentRoot = getAgentDir();
+	const dirs: Array<{ dir: string; boundary: string; scope: "user" | "project" }> = [
+		{ dir: userFlowsDir(), boundary: agentRoot, scope: "user" },
+	];
+	const projDir = findProjectFlowsDir(cwd);
+	if (projDir) dirs.push({ dir: projDir, boundary: path.dirname(projDir), scope: "project" });
+
+	for (const { dir, boundary, scope } of dirs) {
+		const rootReal = validateStorageRoot(dir, boundary, scope === "user");
+		if (!rootReal) continue;
+		const legacyFiles = listLegacyFlowFiles(rootReal, budget);
+		const nestedFiles = listNestedFlowFiles(rootReal, budget);
+		if (budget.exceeded) break;
+		const scopeFlows = new Map<string, SavedFlow>();
+		for (const filePath of [...legacyFiles, ...nestedFiles]) {
+			const r = readFlowFile(filePath, scope, budget, rootReal);
+			if (budget.exceeded) break;
 			if (r.ok) {
-				map.set(r.value.name, r.value); // project after user → overrides
+				// Candidates are precedence-ordered: legacy top-level first, then
+				// Unicode-scalar sorted nested paths. The first same-scope definition wins.
+				const existing = scopeFlows.get(r.value.name);
+				if (!existing) {
+					scopeFlows.set(r.value.name, r.value);
+				} else {
+					diagnostics.push(
+						`[taskflow] duplicate saved flow name '${r.value.name}' in ${scope} scope; ` +
+							`using ${path.relative(rootReal, existing.filePath)} and ignoring ${path.relative(rootReal, filePath)}`,
+					);
+				}
 			} else if (r.reason === "unparseable") {
-				// A corrupt saved flow used to be silently dropped here, so `getFlow`
-				// would later report "not found" for a file that clearly exists.
-				// Surface it loudly instead — the detail carries line/column.
-				console.warn(
-					`[taskflow] saved flow is corrupt and was excluded from the list: ${name} — ${r.detail}`,
+				failures.push({ scope, filePath, result: r });
+				diagnostics.push(
+					`[taskflow] saved flow is corrupt and was excluded from the list: ${path.relative(rootReal, filePath)} — ${r.detail}`,
 				);
 			}
 		}
+		if (budget.exceeded) break;
+		for (const flow of scopeFlows.values()) {
+			scopedFlows.push(flow);
+			map.set(flow.name, flow);
+		}
 	}
-	return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+	return {
+		flows: Array.from(map.values()).sort((a, b) => codePointCompare(a.name, b.name)),
+		scopedFlows,
+		failures,
+		diagnostics,
+		exceeded: budget.exceeded,
+	};
+}
+
+/** List all saved flows (project overrides user on name collision). */
+export function listFlows(cwd: string): SavedFlow[] {
+	const discovery = discoverFlows(cwd);
+	for (const diagnostic of discovery.diagnostics) console.warn(diagnostic);
+	if (discovery.exceeded) {
+		warnDiscoveryLimit();
+		return [];
+	}
+	return discovery.flows;
 }
 
 export function getFlow(cwd: string, name: string): SavedFlow | null {
@@ -1124,42 +1511,137 @@ export function getFlow(cwd: string, name: string): SavedFlow | null {
 /**
  * Resolve a saved flow by name with diagnosable failure. Unlike `getFlow`
  * (which returns `null` for both "no such flow" and "file exists but corrupt",
- * because corrupt files are excluded from `listFlows`), this re-reads the
- * candidate file directly so callers can report *why* a name didn't resolve.
+ * because corrupt files are excluded from `listFlows`), this consumes the same
+ * bounded discovery snapshot and reports a matching corrupt candidate without
+ * rescanning the namespace.
  */
 export function getFlowDiagnosed(cwd: string, name: string): LoadResult<SavedFlow> {
-	const found = getFlow(cwd, name);
-	if (found) return { ok: true, value: found };
-	// Not in the list — check whether a file exists for this name but is corrupt.
-	const candidates: Array<{ dir: string; scope: "user" | "project" }> = [
-		{ dir: userFlowsDir(), scope: "user" },
-	];
-	const projDir = findProjectFlowsDir(cwd);
-	if (projDir) candidates.push({ dir: projDir, scope: "project" });
-	for (const { dir, scope } of candidates) {
-		const filePath = path.join(dir, `${safeFlowDirName(name)}.json`);
-		if (fs.existsSync(filePath)) {
-			const r = readFlowFile(filePath, scope);
-			if (!r.ok) return r; // unparseable (or a missing-in-race) — surface detail
-		}
+	const discovery = discoverFlows(cwd);
+	if (discovery.exceeded) {
+		return {
+			ok: false,
+			reason: "unparseable",
+			path: name,
+			detail: `saved flow discovery exceeded a safety limit (${discoveryLimitDetail()})`,
+		};
 	}
+	const found = discovery.flows.find((flow) => flow.name === name);
+	if (found) return { ok: true, value: found };
+
+	// Preserve the old filename-based diagnosis, but consume the failures already
+	// captured by the same bounded pass. Project scope wins over user scope.
+	const expectedFilename = `${safeFlowDirName(name)}.json`;
+	const matching = discovery.failures
+		.filter((failure) => path.basename(failure.filePath) === expectedFilename)
+		.sort((a, b) => (a.scope === b.scope ? 0 : a.scope === "project" ? -1 : 1))[0];
+	if (matching) return matching.result;
 	return { ok: false, reason: "missing", path: name, detail: `no saved flow named '${name}'` };
 }
 
 let _piCreationHinted = false;
+
+function ensureProjectStorageRoot(root: string, boundary: string): void {
+	const rootAbs = path.resolve(root);
+	const boundaryAbs = path.resolve(boundary);
+	if (!sameDiscoveryPath(path.dirname(rootAbs), boundaryAbs)) {
+		throw new Error("unsafe saved-flow storage: project root is not directly below .pi");
+	}
+
+	const ensurePlainDirectory = (dir: string, parentIdentity: DirectoryIdentity): DirectoryIdentity => {
+		try {
+			const stat = fs.lstatSync(dir);
+			if (stat.isSymbolicLink() || !stat.isDirectory()) {
+				throw new Error("unsafe saved-flow storage: project storage boundary must be a non-symlink directory");
+			}
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			if (!sameDirectoryIdentityValue(parentIdentity, directoryIdentity(path.dirname(dir)))) {
+				throw new Error("unsafe saved-flow storage: project storage parent changed before creation");
+			}
+			try {
+				fs.mkdirSync(dir);
+			} catch (mkdirError) {
+				if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
+			}
+			const created = fs.lstatSync(dir);
+			if (created.isSymbolicLink() || !created.isDirectory()) {
+				throw new Error("unsafe saved-flow storage: created project storage component is not a plain directory");
+			}
+		}
+		const identity = directoryIdentity(dir);
+		if (!identity || !sameDirectoryIdentityValue(parentIdentity, directoryIdentity(path.dirname(dir)))) {
+			throw new Error("unsafe saved-flow storage: project storage changed during creation");
+		}
+		return identity;
+	};
+
+	const boundaryParent = path.dirname(boundaryAbs);
+	const boundaryParentIdentity = directoryIdentity(boundaryParent);
+	if (!boundaryParentIdentity) {
+		throw new Error("unsafe saved-flow storage: project directory identity is unavailable");
+	}
+	const boundaryIdentity = ensurePlainDirectory(boundaryAbs, boundaryParentIdentity);
+	ensurePlainDirectory(rootAbs, boundaryIdentity);
+}
+
+interface FlowSaveTarget {
+	dir: string;
+	filePath: string;
+	expectedDirIdentity: DirectoryIdentity;
+}
+
+/** Preserve the path of an already-discovered flow in the requested scope.
+ * New definitions retain the legacy top-level save location. */
+function resolveFlowSaveTarget(cwd: string, flowName: string, scope: "user" | "project"): FlowSaveTarget {
+	const discovery = discoverFlows(cwd);
+	if (discovery.exceeded) {
+		throw new Error(`cannot safely resolve saved flow path: discovery exceeded a safety limit (${discoveryLimitDetail()})`);
+	}
+	const existing = discovery.scopedFlows.find((flow) => flow.scope === scope && flow.name === flowName);
+	if (existing) {
+		return {
+			dir: path.dirname(existing.filePath),
+			filePath: existing.filePath,
+			expectedDirIdentity: existing.sourceDirIdentity,
+		};
+	}
+	const requestedDir =
+		scope === "user" ? userFlowsDir() : (findProjectFlowsDir(cwd, true) ?? path.join(cwd, ".pi", "taskflows"));
+	const boundary = scope === "user" ? getAgentDir() : path.dirname(requestedDir);
+	if (scope === "project") ensureProjectStorageRoot(requestedDir, boundary);
+	else fs.mkdirSync(requestedDir, { recursive: true });
+	const dir = validateStorageRoot(requestedDir, boundary, scope === "user");
+	if (!dir) throw new Error("unsafe saved-flow storage: target is outside a trusted storage root");
+	const expectedDirIdentity = directoryIdentity(dir);
+	if (!expectedDirIdentity) throw new Error("unsafe saved-flow storage: target directory identity is unavailable");
+	return {
+		dir,
+		filePath: path.join(dir, `${safeFlowDirName(flowName)}.json`),
+		expectedDirIdentity,
+	};
+}
+
+function assertFlowSaveTarget(target: FlowSaveTarget): void {
+	if (!sameDirectoryIdentityValue(target.expectedDirIdentity, directoryIdentity(target.dir))) {
+		throw new Error("saved flow parent directory changed before write");
+	}
+}
 
 export function saveFlow(
 	cwd: string,
 	def: Taskflow,
 	scope: "user" | "project" = "project",
 ): { filePath: string } {
-	const dir = scope === "user" ? userFlowsDir() : (findProjectFlowsDir(cwd, true) ?? path.join(cwd, ".pi", "taskflows"));
 	if (!def.name || def.name.trim().length === 0) throw new Error("Flow name must not be empty");
-	fs.mkdirSync(dir, { recursive: true });
-	const safe = safeFlowDirName(def.name);
-	const filePath = path.join(dir, `${safe}.json`);
+	const target = resolveFlowSaveTarget(cwd, def.name, scope);
+	const { dir, filePath } = target;
+	assertFlowSaveTarget(target);
 	const fileLockPath = filePath + ".lock";
-	withLock(fileLockPath, () => { writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`); });
+	withLock(fileLockPath, () => {
+		assertFlowSaveTarget(target);
+		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`);
+		assertFlowSaveTarget(target);
+	});
 
 	// One-shot: let the user know about .pi/ directory on first save (Finding 8).
 	if (!_piCreationHinted) {
@@ -1194,7 +1676,14 @@ function sidecarPathIn(flowFilePath: string): string {
 /** Read a flow's library sidecar. Returns a `LoadResult`; missing/unparseable
  *  are discriminated by `reason`. */
 export function readMeta(cwd: string, flowName: string): LoadResult<FlowMeta> {
-	// Try project scope first, then user — mirrors getFlow's resolution.
+	// A discovered flow owns the sidecar adjacent to its actual definition file.
+	// This preserves metadata for nested convention-directory flows and avoids
+	// accidentally pairing one with a stale top-level sidecar of the same name.
+	const saved = getFlow(cwd, flowName);
+	if (saved) return readMetaNextTo(saved.filePath);
+
+	// No flow resolved (for example, a caller is about to save a new definition):
+	// preserve the legacy ability to recover an orphaned top-level sidecar.
 	for (const scope of ["project", "user"] as const) {
 		const p = sidecarPathFor(cwd, flowName, scope);
 		if (!fs.existsSync(p)) continue;
@@ -1235,16 +1724,18 @@ export function saveFlowWithMeta(
 	meta: FlowMeta,
 	scope: "user" | "project" = "project",
 ): { filePath: string; metaPath: string } {
-	const dir = scope === "user" ? userFlowsDir() : (findProjectFlowsDir(cwd, true) ?? path.join(cwd, ".pi", "taskflows"));
 	if (!def.name || def.name.trim().length === 0) throw new Error("Flow name must not be empty");
-	fs.mkdirSync(dir, { recursive: true });
-	const safe = safeFlowDirName(def.name);
-	const filePath = path.join(dir, `${safe}.json`);
-	const metaPath = path.join(dir, `${safe}.meta.json`);
+	const target = resolveFlowSaveTarget(cwd, def.name, scope);
+	const { filePath } = target;
+	const metaPath = sidecarPathIn(filePath);
+	assertFlowSaveTarget(target);
 	const fileLockPath = filePath + ".lock"; // shared lock key for flow+sidecar (R2R5)
 	withLock(fileLockPath, () => {
+		assertFlowSaveTarget(target);
 		writeFileAtomic(filePath, `${JSON.stringify(def, null, 2)}\n`);
+		assertFlowSaveTarget(target);
 		writeFileAtomic(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
+		assertFlowSaveTarget(target);
 	});
 	return { filePath, metaPath };
 }
@@ -1257,9 +1748,16 @@ export function saveFlowWithMeta(
 export function bumpReuseInSidecar(cwd: string, flowName: string): number | null {
 	const saved = getFlow(cwd, flowName);
 	if (!saved) return null;
+	const target: FlowSaveTarget = {
+		dir: path.dirname(saved.filePath),
+		filePath: saved.filePath,
+		expectedDirIdentity: saved.sourceDirIdentity,
+	};
 	const metaPath = sidecarPathIn(saved.filePath);
+	assertFlowSaveTarget(target);
 	const lockPath = saved.filePath + ".lock";
 	return withLock(lockPath, () => {
+		assertFlowSaveTarget(target);
 		const existingR = readMetaNextTo(saved.filePath);
 		const existing = existingR.ok ? existingR.value : undefined;
 		const now = Date.now();
@@ -1277,7 +1775,9 @@ export function bumpReuseInSidecar(cwd: string, flowName: string): number | null
 					version: 1,
 					embedding: null,
 			  };
+		assertFlowSaveTarget(target);
 		writeFileAtomic(metaPath, `${JSON.stringify(updated, null, 2)}\n`);
+		assertFlowSaveTarget(target);
 		return updated.reuseCount;
 	});
 }

--- a/packages/taskflow-core/test/define-file.test.ts
+++ b/packages/taskflow-core/test/define-file.test.ts
@@ -15,7 +15,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
-import { describeLoadFailure, readDefineFile, type LoadResult } from "../src/store.ts";
+import { describeLoadFailure, readDefineFile, readDefineFileWithSource, type LoadResult } from "../src/store.ts";
+import { directoryIdentity } from "../src/cwd-bridge.ts";
 
 function tmpFile(prefix: string, content: string): string {
 	const p = path.join(os.tmpdir(), `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
@@ -87,6 +88,74 @@ test("readDefineFile: handles a JSON string define value (shorthand forms parse 
 	const f = tmpFile("sh", JSON.stringify(def));
 	assert.equal((valueOf(readDefineFile(f)) as { task: string }).task, "do something");
 	fs.unlinkSync(f);
+});
+
+test("readDefineFileWithSource: binds parsed content to canonical file and parent identity", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-define-source-"));
+	try {
+		const file = path.join(dir, "flow.json");
+		fs.writeFileSync(file, JSON.stringify({ name: "stable", phases: [] }), "utf8");
+		const loaded = valueOf(readDefineFileWithSource(file));
+		assert.equal((loaded.value as { name: string }).name, "stable");
+		assert.equal(loaded.filePath, fs.realpathSync(file));
+		assert.deepEqual(loaded.sourceDirIdentity, directoryIdentity(dir));
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("readDefineFileWithSource: enforces stable allowed-root containment", () => {
+	const allowed = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-define-allowed-"));
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-define-outside-"));
+	try {
+		const insideFile = path.join(allowed, "inside.json");
+		const outsideFile = path.join(outside, "outside.json");
+		const insideDef = { name: "inside", phases: [{ id: "p1", type: "agent", agent: "a", task: "inside" }] };
+		const outsideDef = { name: "outside", phases: [{ id: "p1", type: "agent", agent: "a", task: "outside" }] };
+		fs.writeFileSync(insideFile, JSON.stringify(insideDef));
+		fs.writeFileSync(outsideFile, JSON.stringify(outsideDef));
+		assert.equal(readDefineFileWithSource(insideFile, [fs.realpathSync(allowed)]).ok, true);
+		const escaped = readDefineFileWithSource(outsideFile, [fs.realpathSync(allowed)]);
+		assert.equal(escaped.ok, false);
+		if (!escaped.ok) assert.match(escaped.detail, /escaped or changed its canonical saved-flow root/);
+	} finally {
+		fs.rmSync(allowed, { recursive: true, force: true });
+		fs.rmSync(outside, { recursive: true, force: true });
+	}
+});
+
+test("readDefineFileWithSource: rejects a symlink definition leaf", (t) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-define-symlink-"));
+	try {
+		const target = path.join(dir, "target.json");
+		const link = path.join(dir, "link.json");
+		fs.writeFileSync(target, JSON.stringify({ name: "target", phases: [] }), "utf8");
+		try {
+			fs.symlinkSync(target, link, "file");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("file symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		const result = readDefineFileWithSource(link);
+		assert.equal(result.ok, false);
+		if (!result.ok) assert.match(result.detail, /non-symlink/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("readDefineFileWithSource: rejects definitions above the per-file byte cap", () => {
+	const file = tmpFile("oversized", JSON.stringify({ name: "large", description: "x".repeat(1_100_000), phases: [] }));
+	try {
+		const result = readDefineFileWithSource(file);
+		assert.equal(result.ok, false);
+		if (!result.ok) assert.match(result.detail, /1048576 byte limit/);
+	} finally {
+		fs.unlinkSync(file);
+	}
 });
 
 test("describeLoadFailure: formats a clear missing vs unparseable message", () => {

--- a/packages/taskflow-core/test/exec-driver.test.ts
+++ b/packages/taskflow-core/test/exec-driver.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import type { AgentConfig } from "../src/agents.ts";
 import type { RunOptions, RunResult } from "../src/runner-core.ts";
 import { executeTaskflow, type RuntimeDeps } from "../src/runtime.ts";
-import { canUseEventKernel, eventKernelEnabled } from "../src/exec/driver.ts";
+import { canUseEventKernel, eventKernelEnabled, kernelUnsupportedReason } from "../src/exec/driver.ts";
 import type { Taskflow } from "../src/schema.ts";
 import type { RunState } from "../src/store.ts";
 import { emptyUsage } from "../src/usage.ts";
@@ -82,6 +82,18 @@ test("canUseEventKernel: all kinds including gate", () => {
 		}),
 		true,
 	);
+});
+
+test("canUseEventKernel: workspace cwd keywords force the isolation-aware imperative runtime", () => {
+	for (const cwd of ["temp", "dedicated", "worktree"] as const) {
+		const def: Taskflow = {
+			name: `workspace-${cwd}`,
+			scriptCwd: "flow",
+			phases: [{ id: "s", type: "script", run: ["node", "-e", "1"], cwd, final: true }],
+		};
+		assert.equal(canUseEventKernel(def), false);
+		assert.match(kernelUnsupportedReason(def) ?? "", /workspace cwd.*imperative runtime/);
+	}
 });
 test("event kernel: script phase captures stdout (zero tokens)", async () => {
 	const def: Taskflow = {

--- a/packages/taskflow-core/test/library-store.test.ts
+++ b/packages/taskflow-core/test/library-store.test.ts
@@ -60,6 +60,28 @@ test("saveFlowWithMeta: writes flow + sidecar, readMeta recovers it", () => {
 	}
 });
 
+test("saveFlowWithMeta: updates a nested flow and its adjacent sidecar in place", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		const nestedDir = path.join(root, "flows", "teams", "api");
+		const flowPath = path.join(nestedDir, "audit.json");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(flowPath, JSON.stringify(sampleDef), "utf8");
+
+		const updated = { ...sampleDef, description: "nested update" };
+		const meta = deriveMeta(updated, { purpose: "updated nested metadata" });
+		const saved = saveFlowWithMeta(cwd, updated, meta);
+
+		assert.equal(saved.filePath, fs.realpathSync(flowPath));
+		assert.equal(saved.metaPath, path.join(nestedDir, "audit.meta.json"));
+		assert.equal(fs.existsSync(path.join(root, `${sampleDef.name}.json`)), false);
+		assert.equal(metaOf(cwd, sampleDef.name)?.purpose, "updated nested metadata");
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
 test("A1 fix: listFlows excludes .meta.json sidecar (no ghost flow)", () => {
 	const cwd = makeTmpCwd();
 	try {
@@ -98,6 +120,24 @@ test("readMeta: returns null for missing flow", () => {
 	const cwd = makeTmpCwd();
 	try {
 		assert.equal(metaOf(cwd, "does-not-exist"), null);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("readMeta: resolves a sidecar next to a nested discovered flow", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const nestedDir = path.join(cwd, ".pi", "taskflows", "flows", "teams", "api");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		const flowPath = path.join(nestedDir, "audit.json");
+		fs.writeFileSync(flowPath, JSON.stringify(sampleDef), "utf8");
+		const meta = deriveMeta(sampleDef, { purpose: "nested metadata", tags: ["nested"] });
+		fs.writeFileSync(path.join(nestedDir, "audit.meta.json"), JSON.stringify(meta), "utf8");
+
+		assert.equal(metaOf(cwd, sampleDef.name)?.purpose, "nested metadata");
+		assert.equal(bumpReuseInSidecar(cwd, sampleDef.name), 1);
+		assert.equal(metaOf(cwd, sampleDef.name)?.reuseCount, 1);
 	} finally {
 		fs.rmSync(cwd, { recursive: true, force: true });
 	}

--- a/packages/taskflow-core/test/resume.test.ts
+++ b/packages/taskflow-core/test/resume.test.ts
@@ -101,10 +101,15 @@ function parentDoneABFailedC(): RunState {
 
 test("forkRunForResume: child has a new runId + parentRunId, parent untouched", () => {
 	const prev = parentDoneABFailedC();
+	prev.flowSourceFile = "/repo/.pi/taskflows/flows/release/publish.json";
+	prev.flowSourceDirIdentity = { canonicalPath: "/repo/.pi/taskflows/flows/release", device: "1", inode: "2" };
 	const prevJson = JSON.stringify(prev);
 	const child = forkRunForResume(prev);
 	assert.notEqual(child.runId, prev.runId);
 	assert.equal(child.parentRunId, prev.runId);
+	assert.equal(child.flowSourceFile, prev.flowSourceFile);
+	assert.deepEqual(child.flowSourceDirIdentity, prev.flowSourceDirIdentity);
+	assert.notEqual(child.flowSourceDirIdentity, prev.flowSourceDirIdentity);
 	assert.equal(child.status, "running");
 	// Parent is NOT mutated.
 	assert.equal(JSON.stringify(prev), prevJson);

--- a/packages/taskflow-core/test/runtime-closure-0.2.0.test.ts
+++ b/packages/taskflow-core/test/runtime-closure-0.2.0.test.ts
@@ -301,14 +301,17 @@ test("kernel opt-in routes budgeted map to imperative per-item guard", async () 
 	assert.equal(result.state.phases.m.budgetTruncated, true);
 });
 
-test("FlowIR hash includes agentScope and contextSharing", async () => {
+test("FlowIR hash includes agentScope, contextSharing, and scriptCwd", async () => {
 	const base: Taskflow = { name: "semantic-hash", phases: [{ id: "p", task: "x", final: true }] };
 	const user = await compileTaskflowToIR({ ...base, agentScope: "user" });
 	const project = await compileTaskflowToIR({ ...base, agentScope: "project" });
 	const plain = await compileTaskflowToIR({ ...base, contextSharing: false });
 	const shared = await compileTaskflowToIR({ ...base, contextSharing: true });
+	const invocation = await compileTaskflowToIR({ ...base, scriptCwd: "invocation" });
+	const flow = await compileTaskflowToIR({ ...base, scriptCwd: "flow" });
 	assert.notEqual(user.hash, project.hash);
 	assert.notEqual(plain.hash, shared.hash);
+	assert.notEqual(invocation.hash, flow.hash);
 });
 
 test("cross-run cache cannot cross agentScope or contextSharing boundaries", async () => {

--- a/packages/taskflow-core/test/schema.test.ts
+++ b/packages/taskflow-core/test/schema.test.ts
@@ -16,6 +16,25 @@ test("validateTaskflow: accepts a valid flow", () => {
 	assert.equal(r.ok, true, r.errors.join("; "));
 });
 
+test("validateTaskflow: scriptCwd accepts only invocation or flow", () => {
+	for (const scriptCwd of ["invocation", "flow"]) {
+		const result = validateTaskflow({
+			name: "script-cwd",
+			scriptCwd,
+			phases: [{ id: "run", type: "script", run: "echo ok", final: true }],
+		});
+		assert.equal(result.ok, true, `${scriptCwd}: ${result.errors.join("; ")}`);
+	}
+	for (const scriptCwd of ["project", true, { base: "flow" }]) {
+		const result = validateTaskflow({
+			name: "script-cwd",
+			scriptCwd,
+			phases: [{ id: "run", type: "script", run: "echo ok", final: true }],
+		});
+		assert.equal(result.ok, false, `${JSON.stringify(scriptCwd)} must fail closed`);
+	}
+});
+
 test("validateTaskflow: rejects missing name / phases", () => {
 	assert.equal(validateTaskflow({}).ok, false);
 	assert.equal(validateTaskflow({ name: "x" }).ok, false);

--- a/packages/taskflow-core/test/script.test.ts
+++ b/packages/taskflow-core/test/script.test.ts
@@ -10,6 +10,7 @@ import { runScriptCommand } from "../src/runtime/phases/script.ts";
 import { type Taskflow, validateTaskflow } from "../src/schema.ts";
 import type { RunState } from "../src/store.ts";
 import { emptyUsage } from "../src/usage.ts";
+import { directoryIdentity } from "../src/cwd-bridge.ts";
 
 // The script phase shells out, so tests invoke `node -e` (guaranteed on PATH in
 // CI) rather than assuming any particular unix utility. String-form `run` uses
@@ -160,6 +161,171 @@ test("script run: array form spawns directly (no shell)", async () => {
 	assert.equal(res.finalOutput, "arr-ok");
 });
 
+test("script run: scriptCwd flow uses the flow file directory", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-flow-cwd-"));
+	try {
+		const invocationCwd = path.join(root, "repo");
+		const flowDir = path.join(invocationCwd, ".pi", "taskflows", "flows", "release bundle");
+		fs.mkdirSync(flowDir, { recursive: true });
+		const flowSourceFile = path.join(flowDir, "publish.json");
+		fs.writeFileSync(flowSourceFile, "{}", "utf8");
+		const def: Taskflow = {
+			name: "flow-relative",
+			scriptCwd: "flow",
+			phases: [{ id: "where", type: "script", run: [process.execPath, "-e", "process.stdout.write(process.cwd())"], final: true }],
+		};
+		const state = mkState(def);
+		state.cwd = invocationCwd;
+		state.flowSourceFile = fs.realpathSync(flowSourceFile);
+		state.flowSourceDirIdentity = directoryIdentity(flowDir);
+		const deps = { ...baseDeps(), cwd: invocationCwd };
+
+		const res = await executeTaskflow(state, deps);
+		assert.equal(res.ok, true);
+		assert.equal(res.finalOutput, fs.realpathSync(flowDir));
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("script run: event kernel honors scriptCwd flow", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-kernel-flow-cwd-"));
+	try {
+		const invocationCwd = path.join(root, "repo");
+		const flowDir = path.join(invocationCwd, ".pi", "taskflows", "flows", "kernel");
+		fs.mkdirSync(flowDir, { recursive: true });
+		const flowSourceFile = path.join(flowDir, "publish.json");
+		fs.writeFileSync(flowSourceFile, "{}", "utf8");
+		const def: Taskflow = {
+			name: "kernel-flow-relative",
+			scriptCwd: "flow",
+			phases: [{ id: "where", type: "script", run: [process.execPath, "-e", "process.stdout.write(process.cwd())"], final: true }],
+		};
+		const state = mkState(def);
+		state.cwd = invocationCwd;
+		state.flowSourceFile = fs.realpathSync(flowSourceFile);
+		state.flowSourceDirIdentity = directoryIdentity(flowDir);
+		const deps = { ...baseDeps(), cwd: invocationCwd, eventKernel: true };
+
+		const res = await executeTaskflow(state, deps);
+		assert.equal(res.ok, true);
+		assert.equal(res.finalOutput, fs.realpathSync(flowDir));
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("runScriptCommand: revalidates flow cwd after its async import immediately before spawn", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-pre-spawn-swap-"));
+	try {
+		const flowDir = path.join(root, "flow");
+		const movedDir = path.join(root, "flow-moved");
+		fs.mkdirSync(flowDir);
+		fs.writeFileSync(path.join(flowDir, "identity.txt"), "original");
+		const expected = directoryIdentity(flowDir);
+		assert.ok(expected);
+		const pending = runScriptCommand({
+			interpRunText: [process.execPath, "-e", "process.stdout.write(require('node:fs').readFileSync('identity.txt','utf8'))"],
+			arrayForm: true,
+			cwd: flowDir,
+			cwdIdentity: expected,
+			timeoutMs: 5_000,
+		});
+		fs.renameSync(flowDir, movedDir);
+		fs.mkdirSync(flowDir);
+		fs.writeFileSync(path.join(flowDir, "identity.txt"), "replacement");
+		await assert.rejects(pending, /source directory identity changed after definition load/);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("script run: source directory replacement is rejected before spawn", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-source-swap-"));
+	try {
+		const invocationCwd = path.join(root, "repo");
+		const flowDir = path.join(invocationCwd, ".pi", "taskflows", "flows", "swap");
+		fs.mkdirSync(flowDir, { recursive: true });
+		const source = path.join(flowDir, "flow.json");
+		fs.writeFileSync(source, "{}", "utf8");
+		const sourceFile = fs.realpathSync(source);
+		const sourceDirIdentity = directoryIdentity(flowDir);
+		assert.ok(sourceDirIdentity);
+		fs.renameSync(flowDir, `${flowDir}-original`);
+		fs.mkdirSync(flowDir, { recursive: true });
+		const marker = path.join(root, "spawned.txt");
+		const def: Taskflow = {
+			name: "source-swap",
+			scriptCwd: "flow",
+			phases: [{
+				id: "run",
+				type: "script",
+				run: [process.execPath, "-e", "require('node:fs').writeFileSync(process.argv[1], 'ran')", marker],
+				final: true,
+			}],
+		};
+		for (const eventKernel of [false, true]) {
+			const state = mkState(def);
+			state.cwd = invocationCwd;
+			state.flowSourceFile = sourceFile;
+			state.flowSourceDirIdentity = sourceDirIdentity;
+			const res = await executeTaskflow(state, { ...baseDeps(), cwd: invocationCwd, eventKernel });
+			assert.equal(res.ok, false, `eventKernel=${eventKernel}`);
+			assert.match(res.state.phases.run.error ?? "", /source directory identity changed/);
+			assert.equal(fs.existsSync(marker), false);
+		}
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("script run: scriptCwd flow fails closed for inline definitions without provenance", async () => {
+	const def: Taskflow = {
+		name: "inline-no-source",
+		scriptCwd: "flow",
+		phases: [{ id: "run", type: "script", run: [process.execPath, "-e", "process.stdout.write('must-not-run')"], final: true }],
+	};
+	for (const eventKernel of [false, true]) {
+		const res = await executeTaskflow(mkState(def), { ...baseDeps(), eventKernel });
+		assert.equal(res.ok, false, `eventKernel=${eventKernel}`);
+		assert.match(res.state.phases.run.error ?? "", /requires stable saved-flow or defineFile provenance/);
+	}
+});
+
+test("script run: explicit phase cwd overrides scriptCwd flow", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-explicit-cwd-"));
+	try {
+		const invocationCwd = path.join(root, "repo");
+		const flowDir = path.join(invocationCwd, ".pi", "taskflows", "flows", "team");
+		const explicitCwd = path.join(invocationCwd, "packages", "api");
+		fs.mkdirSync(flowDir, { recursive: true });
+		fs.mkdirSync(explicitCwd, { recursive: true });
+		const source = path.join(flowDir, "flow.json");
+		fs.writeFileSync(source, "{}", "utf8");
+		const def: Taskflow = {
+			name: "explicit-wins",
+			scriptCwd: "flow",
+			phases: [{
+				id: "where",
+				type: "script",
+				run: [process.execPath, "-e", "process.stdout.write(process.cwd())"],
+				cwd: explicitCwd,
+				final: true,
+			}],
+		};
+		for (const eventKernel of [false, true]) {
+			const state = mkState(def);
+			state.cwd = invocationCwd;
+			state.flowSourceFile = fs.realpathSync(source);
+			const res = await executeTaskflow(state, { ...baseDeps(), cwd: invocationCwd, eventKernel });
+			assert.equal(res.ok, true, `eventKernel=${eventKernel}`);
+			assert.equal(res.finalOutput, fs.realpathSync(explicitCwd), `eventKernel=${eventKernel}`);
+		}
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("script run: 'input' is piped to stdin with interpolation", async () => {
 	const echoStdin = "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write('in['+d+']'))";
 	const def: Taskflow = {
@@ -231,6 +397,93 @@ test("script integration: agent output flows into a script via stdin", async () 
 	const res = await executeTaskflow(mkState(def), baseDeps(cannedRunner("DRAFT_TEXT")));
 	assert.equal(res.ok, true);
 	assert.equal(res.finalOutput, "SAVED:DRAFT_TEXT");
+});
+
+test("script integration: saved subflow receives its own source file directory", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-subflow-cwd-"));
+	try {
+		const invocationCwd = path.join(root, "repo");
+		const childDir = path.join(invocationCwd, ".pi", "taskflows", "flows", "children");
+		fs.mkdirSync(childDir, { recursive: true });
+		const childSource = path.join(childDir, "child.json");
+		fs.writeFileSync(childSource, "{}", "utf8");
+		const child: Taskflow = {
+			name: "child",
+			scriptCwd: "flow",
+			phases: [{ id: "where", type: "script", run: [process.execPath, "-e", "process.stdout.write(process.cwd())"], final: true }],
+		};
+		const parent: Taskflow = {
+			name: "parent",
+			phases: [{ id: "child", type: "flow", use: "child", final: true }],
+		};
+		for (const eventKernel of [false, true]) {
+			const state = mkState(parent);
+			state.cwd = invocationCwd;
+			let loads = 0;
+			const deps: RuntimeDeps = {
+				...baseDeps(),
+				cwd: invocationCwd,
+				eventKernel,
+				loadSavedFlow: (name: string) => {
+					if (name !== "child") return undefined;
+					loads++;
+					return {
+						def: child,
+						filePath: loads === 1 ? fs.realpathSync(childSource) : invocationCwd,
+						sourceDirIdentity: directoryIdentity(childDir),
+					};
+				},
+			};
+
+			const res = await executeTaskflow(state, deps);
+			assert.equal(res.ok, true, `eventKernel=${eventKernel}`);
+			assert.equal(res.finalOutput, fs.realpathSync(childDir), `eventKernel=${eventKernel}`);
+			assert.equal(loads, 1, `definition and provenance must be loaded atomically; eventKernel=${eventKernel}`);
+		}
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("script integration: saved subflow cannot expand an inherited cwd boundary", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tf-script-subflow-boundary-"));
+	try {
+		const boundaryDir = path.join(root, "workspace");
+		const childDir = path.join(root, "outside-flow-source");
+		fs.mkdirSync(boundaryDir, { recursive: true });
+		fs.mkdirSync(childDir, { recursive: true });
+		const childSource = path.join(childDir, "child.json");
+		fs.writeFileSync(childSource, "{}", "utf8");
+		const child: Taskflow = {
+			name: "child",
+			scriptCwd: "flow",
+			phases: [{ id: "where", type: "script", run: [process.execPath, "-e", "process.stdout.write(process.cwd())"], final: true }],
+		};
+		const parent: Taskflow = {
+			name: "parent",
+			phases: [{ id: "child", type: "flow", use: "child", final: true }],
+		};
+		const state = mkState(parent);
+		state.cwd = boundaryDir;
+		const deps: RuntimeDeps = {
+			...baseDeps(),
+			cwd: boundaryDir,
+			_cwdBoundary: fs.realpathSync(boundaryDir),
+			loadSavedFlow: (name: string) => name === "child"
+				? {
+						def: child,
+						filePath: fs.realpathSync(childSource),
+						sourceDirIdentity: directoryIdentity(childDir),
+				  }
+				: undefined,
+		};
+
+		const res = await executeTaskflow(state, deps);
+		assert.equal(res.ok, false);
+		assert.match(JSON.stringify(res.state.phases), /TF_CWD_BOUNDARY_ESCAPE/);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("script integration: skipped by an unmet 'when' condition", async () => {

--- a/packages/taskflow-core/test/store.test.ts
+++ b/packages/taskflow-core/test/store.test.ts
@@ -309,6 +309,34 @@ test("listFlows: discovers project flows recursively below the flows convention 
 	}
 });
 
+test("listFlows: preserves legacy discovery of hidden top-level JSON definitions", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(root, { recursive: true });
+		const hiddenPath = path.join(root, ".release.json");
+		fs.writeFileSync(hiddenPath, JSON.stringify(minimalFlow("hidden-legacy")), "utf8");
+
+		const loaded = getFlow(cwd, "hidden-legacy");
+		assert.ok(loaded, "0.2.9 discovered every top-level *.json except sidecars");
+		assert.equal(loaded.filePath, fs.realpathSync(hiddenPath));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("saveFlow: preserves legacy discovery for flow names ending in .flowir", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const saved = saveFlow(cwd, minimalFlow("release.flowir"));
+		assert.equal(path.basename(saved.filePath), "release.flowir.json");
+		assert.equal(getFlow(cwd, "release.flowir")?.filePath, fs.realpathSync(saved.filePath));
+		assert.ok(listFlows(cwd).some((flow) => flow.name === "release.flowir"));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
 test("saveFlow: updates an existing nested flow in place without creating a legacy shadow", () => {
 	const cwd = makeTmpCwd();
 	try {
@@ -505,6 +533,186 @@ test("saveFlow: revalidates a newly created target directory inside the write lo
 		assert.equal(fs.existsSync(path.join(displacedDir, "new-target-swap.json")), false);
 	} finally {
 		mutableFs.openSync = originalOpenSync;
+		syncBuiltinESMExports();
+		cleanup(cwd);
+	}
+});
+
+test("saveFlow: rejects a nested target directory swapped after validation but before atomic write", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-nested-save-swap-outside-"));
+	const nestedDir = path.join(cwd, ".pi", "taskflows", "flows", "release");
+	const displacedDir = `${nestedDir}-displaced`;
+	const nestedPath = path.join(nestedDir, "publish.json");
+	const mutableFs = createRequire(import.meta.url)("node:fs") as { openSync: typeof fs.openSync; writeFileSync: typeof fs.writeFileSync };
+	const originalOpenSync = mutableFs.openSync;
+	const originalWriteFileSync = mutableFs.writeFileSync;
+	let swapped = false;
+	let outsideDecoy = "";
+	try {
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(nestedPath, JSON.stringify(minimalFlow("nested-swap")), "utf8");
+		mutableFs.openSync = ((...args: Parameters<typeof fs.openSync>) => {
+			const target = String(args[0]);
+			const fd = Reflect.apply(originalOpenSync, mutableFs, args) as number;
+			if (!swapped && target.startsWith(`${nestedPath}.`) && target.endsWith(".tmp")) {
+				swapped = true;
+				fs.renameSync(nestedDir, displacedDir);
+				try {
+					fs.symlinkSync(outside, nestedDir, "dir");
+					outsideDecoy = path.join(outside, path.basename(target));
+					Reflect.apply(originalWriteFileSync, mutableFs, [outsideDecoy, "outside-owned", "utf8"]);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "EPERM") {
+						t.skip("directory symlinks unavailable");
+						fs.mkdirSync(nestedDir, { recursive: true });
+						return fd;
+					}
+					throw error;
+				}
+			}
+			return fd;
+		}) as typeof fs.openSync;
+		syncBuiltinESMExports();
+
+		assert.throws(
+			() => saveFlow(cwd, { ...minimalFlow("nested-swap"), description: "must not escape" }),
+			/saved flow parent directory changed before write/,
+		);
+		assert.equal(swapped, true);
+		assert.equal(fs.existsSync(path.join(outside, "publish.json")), false, "no definition may be written outside the trusted directory");
+		if (!outsideDecoy) return; // t.skip() marks but does not abort the test body.
+		assert.equal(fs.readFileSync(outsideDecoy, "utf8"), "outside-owned", "failed cleanup must not unlink an external same-name file");
+		assert.equal(
+			JSON.parse(fs.readFileSync(path.join(displacedDir, "publish.json"), "utf8")).description,
+			undefined,
+			"the displaced original definition must remain unchanged",
+		);
+	} finally {
+		mutableFs.openSync = originalOpenSync;
+		syncBuiltinESMExports();
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("saveFlow: revalidates after temp open and before writing definition bytes", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-nested-preopen-swap-outside-"));
+	const nestedDir = path.join(cwd, ".pi", "taskflows", "flows", "release");
+	const displacedDir = `${nestedDir}-displaced`;
+	const nestedPath = path.join(nestedDir, "publish.json");
+	const mutableFs = createRequire(import.meta.url)("node:fs") as { openSync: typeof fs.openSync };
+	const originalOpenSync = mutableFs.openSync;
+	let swapped = false;
+	try {
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(nestedPath, JSON.stringify(minimalFlow("nested-preopen-swap")), "utf8");
+		mutableFs.openSync = ((...args: Parameters<typeof fs.openSync>) => {
+			const target = String(args[0]);
+			if (!swapped && target.startsWith(`${nestedPath}.`) && target.endsWith(".tmp")) {
+				swapped = true;
+				fs.renameSync(nestedDir, displacedDir);
+				try {
+					fs.symlinkSync(outside, nestedDir, "dir");
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "EPERM") {
+						t.skip("directory symlinks unavailable");
+						fs.mkdirSync(nestedDir, { recursive: true });
+					}
+					else throw error;
+				}
+			}
+			return Reflect.apply(originalOpenSync, mutableFs, args) as number;
+		}) as typeof fs.openSync;
+		syncBuiltinESMExports();
+
+		assert.throws(
+			() => saveFlow(cwd, { ...minimalFlow("nested-preopen-swap"), description: "must not escape" }),
+			/saved flow parent directory changed before write/,
+		);
+		assert.equal(swapped, true);
+		assert.equal(fs.existsSync(path.join(outside, "publish.json")), false);
+		for (const entry of fs.readdirSync(outside)) {
+			assert.equal(fs.readFileSync(path.join(outside, entry), "utf8"), "", "no definition bytes may be written after a pre-open directory swap");
+		}
+	} finally {
+		mutableFs.openSync = originalOpenSync;
+		syncBuiltinESMExports();
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("saveFlow: rejects a nested target directory swapped at the atomic rename sink", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-nested-rename-swap-outside-"));
+	const nestedDir = path.join(cwd, ".pi", "taskflows", "flows", "release");
+	const displacedDir = `${nestedDir}-displaced`;
+	const nestedPath = path.join(nestedDir, "publish.json");
+	const mutableFs = createRequire(import.meta.url)("node:fs") as { renameSync: typeof fs.renameSync };
+	const originalRenameSync = mutableFs.renameSync;
+	let swapped = false;
+	try {
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(nestedPath, JSON.stringify(minimalFlow("nested-rename-swap")), "utf8");
+		mutableFs.renameSync = ((...args: Parameters<typeof fs.renameSync>) => {
+			const source = String(args[0]);
+			const destination = String(args[1]);
+			if (!swapped && source.startsWith(`${nestedPath}.`) && source.endsWith(".tmp") && destination === nestedPath) {
+				swapped = true;
+				Reflect.apply(originalRenameSync, mutableFs, [nestedDir, displacedDir]);
+				try {
+					fs.symlinkSync(outside, nestedDir, "dir");
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "EPERM") {
+						t.skip("directory symlinks unavailable");
+						fs.mkdirSync(nestedDir, { recursive: true });
+						return Reflect.apply(originalRenameSync, mutableFs, args);
+					}
+					throw error;
+				}
+			}
+			return Reflect.apply(originalRenameSync, mutableFs, args);
+		}) as typeof fs.renameSync;
+		syncBuiltinESMExports();
+
+		assert.throws(() => saveFlow(cwd, { ...minimalFlow("nested-rename-swap"), description: "must not escape" }));
+		assert.equal(swapped, true);
+		assert.equal(fs.existsSync(path.join(outside, "publish.json")), false, "the final definition must not be promoted outside the trusted directory");
+	} finally {
+		mutableFs.renameSync = originalRenameSync;
+		syncBuiltinESMExports();
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("listFlows: treats an entry-read failure as a skipped unreadable directory", () => {
+	const cwd = makeTmpCwd();
+	const mutableFs = createRequire(import.meta.url)("node:fs") as { opendirSync: typeof fs.opendirSync };
+	const originalOpendirSync = mutableFs.opendirSync;
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(root, { recursive: true });
+		fs.writeFileSync(path.join(root, "stable.json"), JSON.stringify(minimalFlow("stable")), "utf8");
+		mutableFs.opendirSync = ((...args: Parameters<typeof fs.opendirSync>) => {
+			const handle = Reflect.apply(originalOpendirSync, mutableFs, args) as fs.Dir;
+			if (path.resolve(String(args[0])) === path.resolve(root)) {
+				handle.readSync = (() => {
+					const error = new Error("simulated directory read failure") as NodeJS.ErrnoException;
+					error.code = "EIO";
+					throw error;
+				}) as typeof handle.readSync;
+			}
+			return handle;
+		}) as typeof fs.opendirSync;
+		syncBuiltinESMExports();
+
+		assert.doesNotThrow(() => listFlows(cwd));
+		assert.deepEqual(listFlows(cwd).filter((flow) => flow.scope === "project"), []);
+	} finally {
+		mutableFs.opendirSync = originalOpendirSync;
 		syncBuiltinESMExports();
 		cleanup(cwd);
 	}

--- a/packages/taskflow-core/test/store.test.ts
+++ b/packages/taskflow-core/test/store.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { createRequire, syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
 import type { Taskflow } from "../src/schema.ts";
 import {
 	getFlow,
+	getFlowDiagnosed,
 	hashInput,
 	listFlows,
 	listRuns,
@@ -17,6 +19,7 @@ import {
 	type RunIndexEntry,
 	type RunState,
 } from "../src/store.ts";
+import { directoryIdentity } from "../src/cwd-bridge.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -288,6 +291,432 @@ test("listFlows: returns project-scope flows sorted by name", () => {
 	}
 });
 
+test("listFlows: discovers project flows recursively below the flows convention directory", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const nestedDir = path.join(cwd, ".pi", "taskflows", "flows", "release", "scripts-and-flow");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		const filePath = path.join(nestedDir, "publish.json");
+		fs.writeFileSync(filePath, JSON.stringify(minimalFlow("nested-publish")), "utf8");
+
+		const loaded = getFlow(cwd, "nested-publish");
+		assert.ok(loaded, "nested flow should be discoverable by its declared name");
+		assert.equal(loaded.scope, "project");
+		assert.equal(loaded.filePath, fs.realpathSync(filePath));
+		assert.deepEqual(loaded.sourceDirIdentity, directoryIdentity(nestedDir));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("saveFlow: updates an existing nested flow in place without creating a legacy shadow", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		const nestedDir = path.join(root, "flows", "release");
+		const nestedPath = path.join(nestedDir, "publish.json");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(nestedPath, JSON.stringify(minimalFlow("nested-publish")), "utf8");
+
+		const updated: Taskflow = {
+			...minimalFlow("nested-publish"),
+			description: "updated in place",
+		};
+		const saved = saveFlow(cwd, updated, "project");
+
+		assert.equal(saved.filePath, fs.realpathSync(nestedPath));
+		assert.equal(fs.existsSync(path.join(root, "nested-publish.json")), false);
+		assert.equal(getFlow(cwd, "nested-publish")?.def.description, "updated in place");
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("saveFlow: preserves a nested user path even when project scope has the same name", () => {
+	const cwd = makeTmpCwd();
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-user-save-scope-"));
+	const previous = process.env.TASKFLOW_AGENT_DIR;
+	try {
+		process.env.TASKFLOW_AGENT_DIR = agentDir;
+		const userRoot = path.join(agentDir, "taskflows");
+		const userNestedDir = path.join(userRoot, "flows", "team");
+		const userPath = path.join(userNestedDir, "shared.json");
+		fs.mkdirSync(userNestedDir, { recursive: true });
+		fs.writeFileSync(userPath, JSON.stringify({ ...minimalFlow("shared"), description: "user old" }), "utf8");
+
+		const projectPath = path.join(cwd, ".pi", "taskflows", "shared.json");
+		fs.mkdirSync(path.dirname(projectPath), { recursive: true });
+		fs.writeFileSync(projectPath, JSON.stringify({ ...minimalFlow("shared"), description: "project" }), "utf8");
+
+		const saved = saveFlow(cwd, { ...minimalFlow("shared"), description: "user new" }, "user");
+		assert.equal(saved.filePath, fs.realpathSync(userPath));
+		assert.equal(fs.existsSync(path.join(userRoot, "shared.json")), false);
+		assert.equal(JSON.parse(fs.readFileSync(userPath, "utf8")).description, "user new");
+		assert.equal(JSON.parse(fs.readFileSync(projectPath, "utf8")).description, "project");
+	} finally {
+		if (previous === undefined) delete process.env.TASKFLOW_AGENT_DIR;
+		else process.env.TASKFLOW_AGENT_DIR = previous;
+		cleanup(cwd);
+		cleanup(agentDir);
+	}
+});
+
+test("listFlows: supports a symlinked user agent boundary without following symlinks below it", (t) => {
+	const cwd = makeTmpCwd();
+	const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-agent-boundary-"));
+	const actualAgentDir = path.join(sandbox, "agent-real");
+	const linkedAgentDir = path.join(sandbox, "agent-link");
+	const previous = process.env.TASKFLOW_AGENT_DIR;
+	try {
+		const userFlows = path.join(actualAgentDir, "taskflows");
+		fs.mkdirSync(userFlows, { recursive: true });
+		fs.writeFileSync(path.join(userFlows, "portable.json"), JSON.stringify(minimalFlow("portable-user-flow")), "utf8");
+		try {
+			fs.symlinkSync(actualAgentDir, linkedAgentDir, "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("directory symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		process.env.TASKFLOW_AGENT_DIR = linkedAgentDir;
+
+		const found = listFlows(cwd).find((flow) => flow.scope === "user" && flow.name === "portable-user-flow");
+		assert.ok(found, "the trusted agent-dir boundary may itself be a symlink");
+		assert.equal(found.filePath, fs.realpathSync(path.join(userFlows, "portable.json")));
+	} finally {
+		if (previous === undefined) delete process.env.TASKFLOW_AGENT_DIR;
+		else process.env.TASKFLOW_AGENT_DIR = previous;
+		cleanup(cwd);
+		cleanup(sandbox);
+	}
+});
+
+test("listFlows: rejects a symlinked project .pi trust boundary", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-project-boundary-outside-"));
+	try {
+		fs.rmSync(path.join(cwd, ".pi"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(outside, "taskflows"), { recursive: true });
+		fs.writeFileSync(
+			path.join(outside, "taskflows", "escape.json"),
+			JSON.stringify(minimalFlow("project-boundary-escape")),
+			"utf8",
+		);
+		try {
+			fs.symlinkSync(outside, path.join(cwd, ".pi"), "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("directory symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		assert.equal(getFlow(cwd, "project-boundary-escape"), null);
+	} finally {
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("saveFlow: rejects a symlinked project .pi boundary without writing outside", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-project-save-outside-"));
+	try {
+		fs.rmSync(path.join(cwd, ".pi"), { recursive: true, force: true });
+		try {
+			fs.symlinkSync(outside, path.join(cwd, ".pi"), "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("directory symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+
+		assert.throws(
+			() => saveFlow(cwd, minimalFlow("project-save-escape")),
+			/trusted storage root|unsafe saved-flow storage/i,
+		);
+		assert.equal(fs.existsSync(path.join(outside, "taskflows")), false, "rejection must not create outside directories");
+		assert.equal(fs.existsSync(path.join(outside, "taskflows", "project-save-escape.json")), false);
+	} finally {
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("saveFlow: rejects a symlinked user taskflows root without writing outside", (t) => {
+	const cwd = makeTmpCwd();
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-user-save-agent-"));
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-user-save-outside-"));
+	const previous = process.env.TASKFLOW_AGENT_DIR;
+	try {
+		try {
+			fs.symlinkSync(outside, path.join(agentDir, "taskflows"), "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("directory symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		process.env.TASKFLOW_AGENT_DIR = agentDir;
+
+		assert.throws(
+			() => saveFlow(cwd, minimalFlow("user-save-escape"), "user"),
+			/trusted storage root|unsafe saved-flow storage/i,
+		);
+		assert.equal(fs.existsSync(path.join(outside, "user-save-escape.json")), false);
+	} finally {
+		if (previous === undefined) delete process.env.TASKFLOW_AGENT_DIR;
+		else process.env.TASKFLOW_AGENT_DIR = previous;
+		cleanup(cwd);
+		cleanup(agentDir);
+		cleanup(outside);
+	}
+});
+
+test("saveFlow: revalidates a newly created target directory inside the write lock", () => {
+	const cwd = makeTmpCwd();
+	const targetDir = path.join(cwd, ".pi", "taskflows");
+	const displacedDir = path.join(cwd, ".pi", "taskflows-displaced");
+	const lockPath = path.join(targetDir, "new-target-swap.json.lock");
+	const mutableFs = createRequire(import.meta.url)("node:fs") as { openSync: typeof fs.openSync };
+	const originalOpenSync = mutableFs.openSync;
+	let swapped = false;
+	mutableFs.openSync = ((...args: Parameters<typeof fs.openSync>) => {
+		if (!swapped && path.resolve(String(args[0])) === path.resolve(lockPath)) {
+			swapped = true;
+			fs.renameSync(targetDir, displacedDir);
+			fs.mkdirSync(targetDir, { recursive: true });
+		}
+		return Reflect.apply(originalOpenSync, mutableFs, args) as number;
+	}) as typeof fs.openSync;
+	syncBuiltinESMExports();
+	try {
+		assert.throws(
+			() => saveFlow(cwd, minimalFlow("new-target-swap")),
+			/saved flow parent directory changed before write/,
+		);
+		assert.equal(swapped, true);
+		assert.equal(fs.existsSync(path.join(targetDir, "new-target-swap.json")), false);
+		assert.equal(fs.existsSync(path.join(displacedDir, "new-target-swap.json")), false);
+	} finally {
+		mutableFs.openSync = originalOpenSync;
+		syncBuiltinESMExports();
+		cleanup(cwd);
+	}
+});
+
+test("listFlows: legacy top-level wins same-scope nested duplicates with a diagnostic", (t) => {
+	const cwd = makeTmpCwd();
+	const warnings: string[] = [];
+	t.mock.method(console, "warn", (message: unknown) => warnings.push(String(message)));
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		const nestedDir = path.join(root, "flows", "team");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(root, "duplicate.json"),
+			JSON.stringify({ ...minimalFlow("duplicate"), description: "legacy" }),
+			"utf8",
+		);
+		fs.writeFileSync(
+			path.join(nestedDir, "duplicate.json"),
+			JSON.stringify({ ...minimalFlow("duplicate"), description: "nested" }),
+			"utf8",
+		);
+
+		const loaded = getFlow(cwd, "duplicate");
+		assert.equal(loaded?.def.description, "legacy");
+		assert.ok(warnings.some((message) => message.includes("duplicate") && message.includes("flows/team/duplicate.json")));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("listFlows: rejects a symlinked flows convention root", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-store-outside-"));
+	try {
+		fs.writeFileSync(path.join(outside, "escape.json"), JSON.stringify(minimalFlow("escape")), "utf8");
+		const taskflowsRoot = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(taskflowsRoot, { recursive: true });
+		try {
+			fs.symlinkSync(outside, path.join(taskflowsRoot, "flows"), "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("directory symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		assert.equal(getFlow(cwd, "escape"), null);
+	} finally {
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("listFlows: rejects a symlinked taskflows parent root", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-store-parent-outside-"));
+	try {
+		fs.mkdirSync(path.join(outside, "flows"), { recursive: true });
+		fs.writeFileSync(path.join(outside, "flows", "escape.json"), JSON.stringify(minimalFlow("parent-escape")), "utf8");
+		try {
+			fs.symlinkSync(outside, path.join(cwd, ".pi", "taskflows"), "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("directory symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		assert.equal(getFlow(cwd, "parent-escape"), null);
+	} finally {
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("listFlows: rejects symlinked legacy definition files", (t) => {
+	const cwd = makeTmpCwd();
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "taskflow-store-file-outside-"));
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(root, { recursive: true });
+		const externalFlow = path.join(outside, "external.json");
+		fs.writeFileSync(externalFlow, JSON.stringify(minimalFlow("legacy-escape")), "utf8");
+		try {
+			fs.symlinkSync(externalFlow, path.join(root, "legacy-escape.json"), "file");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") {
+				t.skip("file symlinks unavailable");
+				return;
+			}
+			throw error;
+		}
+		assert.equal(getFlow(cwd, "legacy-escape"), null);
+	} finally {
+		cleanup(cwd);
+		cleanup(outside);
+	}
+});
+
+test("listFlows: oversized definition fails discovery closed", (t) => {
+	const cwd = makeTmpCwd();
+	const warnings: string[] = [];
+	t.mock.method(console, "warn", (message: unknown) => warnings.push(String(message)));
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(root, { recursive: true });
+		fs.writeFileSync(
+			path.join(root, "oversized.json"),
+			JSON.stringify({ ...minimalFlow("oversized"), description: "x".repeat(1_100_000) }),
+			"utf8",
+		);
+		assert.deepEqual(listFlows(cwd), []);
+		assert.ok(warnings.some((message) => message.includes("1048576 bytes/file")));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("listFlows: cumulative definition bytes are bounded across candidates", (t) => {
+	const cwd = makeTmpCwd();
+	const warnings: string[] = [];
+	t.mock.method(console, "warn", (message: unknown) => warnings.push(String(message)));
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(root, { recursive: true });
+		for (let i = 0; i < 9; i++) {
+			const name = `large-${i}`;
+			fs.writeFileSync(
+				path.join(root, `${name}.json`),
+				JSON.stringify({ ...minimalFlow(name), description: "x".repeat(940_000) }),
+				"utf8",
+			);
+		}
+		assert.deepEqual(listFlows(cwd), []);
+		assert.ok(warnings.some((message) => message.includes("8388608 bytes")));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("listFlows: legacy root entry breadth is bounded", (t) => {
+	const cwd = makeTmpCwd();
+	const warnings: string[] = [];
+	t.mock.method(console, "warn", (message: unknown) => warnings.push(String(message)));
+	try {
+		const root = path.join(cwd, ".pi", "taskflows");
+		fs.mkdirSync(root, { recursive: true });
+		for (let i = 0; i <= 10_000; i++) fs.writeFileSync(path.join(root, `entry-${i}.txt`), "");
+		assert.deepEqual(listFlows(cwd), []);
+		assert.ok(warnings.some((message) => message.includes("10000 entries")));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("getFlowDiagnosed: safety exhaustion uses one discovery budget without a listFlows pre-pass", () => {
+	const cwd = makeTmpCwd();
+	try {
+		const nestedRoot = path.join(cwd, ".pi", "taskflows", "flows");
+		fs.mkdirSync(nestedRoot, { recursive: true });
+		for (let i = 0; i < 513; i++) fs.mkdirSync(path.join(nestedRoot, `dir-${i.toString().padStart(4, "0")}`));
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+		try {
+			const result = getFlowDiagnosed(cwd, "missing");
+			assert.equal(result.ok, false);
+			if (!result.ok) assert.match(result.detail, /exceeded a safety limit/);
+			assert.deepEqual(warnings, []);
+		} finally {
+			console.warn = originalWarn;
+		}
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("listFlows: nested duplicate precedence uses locale-independent code-point order", (t) => {
+	const cwd = makeTmpCwd();
+	t.mock.method(console, "warn", () => undefined);
+	try {
+		const root = path.join(cwd, ".pi", "taskflows", "flows");
+		const zDir = path.join(root, "z");
+		const umlautDir = path.join(root, "ä");
+		fs.mkdirSync(zDir, { recursive: true });
+		fs.mkdirSync(umlautDir, { recursive: true });
+		fs.writeFileSync(path.join(zDir, "same.json"), JSON.stringify({ ...minimalFlow("same"), description: "z" }), "utf8");
+		fs.writeFileSync(path.join(umlautDir, "same.json"), JSON.stringify({ ...minimalFlow("same"), description: "umlaut" }), "utf8");
+
+		assert.equal(getFlow(cwd, "same")?.def.description, "z");
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("listFlows: directory breadth limit fails closed with a diagnostic", (t) => {
+	const cwd = makeTmpCwd();
+	const warnings: string[] = [];
+	t.mock.method(console, "warn", (message: unknown) => warnings.push(String(message)));
+	try {
+		const root = path.join(cwd, ".pi", "taskflows", "flows");
+		fs.mkdirSync(root, { recursive: true });
+		for (let i = 0; i < 512; i++) fs.mkdirSync(path.join(root, `dir-${String(i).padStart(3, "0")}`));
+		assert.deepEqual(listFlows(cwd).filter((flow) => flow.scope === "project"), []);
+		assert.ok(warnings.some((message) => message.includes("failed closed") && message.includes("512 directories")));
+	} finally {
+		cleanup(cwd);
+	}
+});
+
 test("listFlows: ignores non-JSON files in flows directory", () => {
 	const cwd = makeTmpCwd();
 	try {
@@ -318,6 +747,27 @@ test("listFlows: skips malformed JSON files gracefully", () => {
 		const flows = listFlows(cwd);
 		const projectNames = flows.filter((f) => f.scope === "project").map((f) => f.name);
 		assert.deepEqual(projectNames, ["valid"]);
+	} finally {
+		cleanup(cwd);
+	}
+});
+
+test("getFlowDiagnosed: reports a corrupt nested flow by filename", async (t) => {
+	const { getFlowDiagnosed } = await import("../src/store.ts");
+	const cwd = makeTmpCwd();
+	t.mock.method(console, "warn", () => undefined);
+	try {
+		const nestedDir = path.join(cwd, ".pi", "taskflows", "flows", "team");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		const filePath = path.join(nestedDir, "broken.json");
+		fs.writeFileSync(filePath, "{ nope", "utf8");
+
+		const result = getFlowDiagnosed(cwd, "broken");
+		assert.equal(result.ok, false);
+		if (!result.ok) {
+			assert.equal(result.reason, "unparseable");
+			assert.equal(result.path, fs.realpathSync(filePath));
+		}
 	} finally {
 		cleanup(cwd);
 	}
@@ -376,13 +826,19 @@ test("saveRun: dot/dotdot/leading-dot flowName cannot escape the runs root (H1)"
 test("saveRun + loadRun: roundtrip persistence", () => {
 	const cwd = makeTmpCwd();
 	try {
-		const state = mkRunState(cwd, { runId: "test-roundtrip-001" });
+		const state = mkRunState(cwd, {
+			runId: "test-roundtrip-001",
+			flowSourceFile: path.join(cwd, ".pi", "taskflows", "flows", "test-flow.json"),
+			flowSourceDirIdentity: directoryIdentity(cwd),
+		});
 		saveRun(state);
 
 		const loaded = loadRun(cwd, "test-roundtrip-001");
 		assert.ok(loaded, "loadRun should find the saved run");
 		assert.equal(loaded.runId, "test-roundtrip-001");
 		assert.equal(loaded.flowName, "test-flow");
+		assert.equal(loaded.flowSourceFile, state.flowSourceFile);
+		assert.deepEqual(loaded.flowSourceDirIdentity, state.flowSourceDirIdentity);
 		assert.equal(loaded.status, "running");
 	} finally {
 		cleanup(cwd);

--- a/packages/taskflow-dsl/src/build/erase/pipeline.ts
+++ b/packages/taskflow-dsl/src/build/erase/pipeline.ts
@@ -154,7 +154,7 @@ export function eraseSource(sourceText: string, file = "flow.tf.ts"): EraseResul
 			} else {
 				diags.push(diag(file, sf, a1, "TFDSL_FLOW_OPTS_DYNAMIC", `Flow options must be a static JSON object without shorthand or spread properties.`));
 			}
-			const allowedFlowOpts = new Set(["description", "version", "agentScope", "strictInterpolation", "contextSharing", "incremental"]);
+			const allowedFlowOpts = new Set(["description", "version", "agentScope", "strictInterpolation", "contextSharing", "incremental", "scriptCwd"]);
 			for (const [key, value] of Object.entries(flowOpts)) {
 				if (!allowedFlowOpts.has(key)) {
 					diags.push(diag(file, sf, a1, "TFDSL_FLOW_OPTS_UNKNOWN", `Unknown flow option '${key}'.`));
@@ -164,6 +164,7 @@ export function eraseSource(sourceText: string, file = "flow.tf.ts"): EraseResul
 					(key === "description" && typeof value === "string") ||
 					(key === "version" && typeof value === "number") ||
 					(key === "agentScope" && (value === "user" || value === "project" || value === "both")) ||
+					(key === "scriptCwd" && (value === "invocation" || value === "flow")) ||
 					((key === "strictInterpolation" || key === "contextSharing" || key === "incremental") &&
 						typeof value === "boolean");
 				if (!valid) diags.push(diag(file, sf, a1, "TFDSL_FLOW_OPTS_TYPE", `Flow option '${key}' has an invalid static value.`));
@@ -460,6 +461,7 @@ export function eraseSource(sourceText: string, file = "flow.tf.ts"): EraseResul
 	if (typeof flowOpts.strictInterpolation === "boolean") taskflow.strictInterpolation = flowOpts.strictInterpolation;
 	if (typeof flowOpts.contextSharing === "boolean") taskflow.contextSharing = flowOpts.contextSharing;
 	if (typeof flowOpts.incremental === "boolean") taskflow.incremental = flowOpts.incremental;
+	if (flowOpts.scriptCwd === "invocation" || flowOpts.scriptCwd === "flow") taskflow.scriptCwd = flowOpts.scriptCwd;
 	if (topArgs) taskflow.args = topArgs;
 	if (concurrency !== undefined) taskflow.concurrency = concurrency;
 	if (budget) taskflow.budget = budget;

--- a/packages/taskflow-dsl/src/decompile.ts
+++ b/packages/taskflow-dsl/src/decompile.ts
@@ -202,7 +202,7 @@ export function decompileTaskflow(def: Taskflow): string {
 	lines.push(`import { ${importList.join(", ")} } from "taskflow-dsl";`);
 	lines.push(``);
 	const flowOpts: Record<string, unknown> = {};
-	for (const key of ["description", "version", "agentScope", "strictInterpolation", "contextSharing", "incremental"] as const) {
+	for (const key of ["description", "version", "agentScope", "strictInterpolation", "contextSharing", "incremental", "scriptCwd"] as const) {
 		const value = (def as unknown as Record<string, unknown>)[key];
 		if (value !== undefined) flowOpts[key] = value;
 	}

--- a/packages/taskflow-dsl/src/runes.ts
+++ b/packages/taskflow-dsl/src/runes.ts
@@ -49,6 +49,7 @@ export interface FlowOptions {
 	strictInterpolation?: boolean;
 	contextSharing?: boolean;
 	incremental?: boolean;
+	scriptCwd?: "invocation" | "flow";
 }
 
 export interface PhaseOptions<TJson = unknown> {

--- a/packages/taskflow-dsl/test/closure-regressions.test.ts
+++ b/packages/taskflow-dsl/test/closure-regressions.test.ts
@@ -102,6 +102,7 @@ test("closure: decompile preserves ids, collisions, real final, fields, and Flow
 		strictInterpolation: true,
 		contextSharing: true,
 		incremental: true,
+		scriptCwd: "flow",
 		budget: { maxTokens: 1000 },
 		concurrency: 3,
 		phases: [

--- a/packages/taskflow-mcp-core/src/mcp/server.ts
+++ b/packages/taskflow-mcp-core/src/mcp/server.ts
@@ -41,7 +41,7 @@ import {
 	type BackgroundRunFilter,
 	type DetachedRunnerBinding,
 } from "./background.ts";
-import { readFileSync, realpathSync } from "node:fs";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { basename, dirname, join, resolve, relative, isAbsolute } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -53,7 +53,7 @@ import {
 	newRunId,
 	peekRun,
 	saveRun,
-	readDefineFile,
+	readDefineFileWithSource,
 	describeLoadFailure,
 	compileTaskflow,
 	verifyTaskflow,
@@ -65,6 +65,7 @@ import {
 	directoryIdentity,
 	readSubagentSettings,
 	readMeta,
+	readMetaNextTo,
 	saveFlowWithMeta,
 	bumpReuseInSidecar,
 	deriveMeta,
@@ -73,6 +74,7 @@ import {
 	type SearchInput,
 	type RuntimeDeps,
 	type RunState,
+	type DirectoryIdentity,
 	type Taskflow,
 	type VerificationIssue,
 	type TraceEvent,
@@ -728,8 +730,21 @@ const TOOLS: McpTool[] = [
 ];
 
 /** Resolve a flow from params: inline `define` (desugared), `defineFile` (disk), or saved `name`. */
-function resolvePermittedDefineFile(cwd: string, requested: string): string {
+interface PermittedDefineFile {
+	filePath: string;
+	allowedRoots: string[];
+}
+
+function resolvePermittedDefineFile(cwd: string, requested: string): PermittedDefineFile {
 	const lexical = resolve(cwd, requested);
+	try {
+		if (lstatSync(lexical).isSymbolicLink()) {
+			throw new RpcError(RPC.INVALID_PARAMS, `defineFile must not be a symlink: ${requested}`);
+		}
+	} catch (error) {
+		if (error instanceof RpcError) throw error;
+		// Missing/unreadable paths retain the normal loader diagnostic below.
+	}
 	let candidate = lexical;
 	try {
 		candidate = realpathSync(lexical);
@@ -753,25 +768,47 @@ function resolvePermittedDefineFile(cwd: string, requested: string): string {
 			`defineFile must be contained in the server cwd or OS temp directory: ${requested}`,
 		);
 	}
-	return candidate;
+	return { filePath: candidate, allowedRoots: rootCandidates };
 }
 
-function resolveFlow(cwd: string, params: { name?: string; define?: unknown; defineFile?: unknown }): Taskflow {
+interface ResolvedFlow {
+	def: Taskflow;
+	flowSourceFile?: string;
+	flowSourceDirIdentity?: DirectoryIdentity;
+}
+
+function resolveFlowWithSource(cwd: string, params: { name?: string; define?: unknown; defineFile?: unknown }): ResolvedFlow {
+	let flowSourceFile: string | undefined;
+	let flowSourceDirIdentity: DirectoryIdentity | undefined;
 	if (params.define === undefined && typeof params.defineFile === "string" && params.defineFile.trim()) {
-		const filePath = resolvePermittedDefineFile(cwd, params.defineFile);
-		const fromFile = readDefineFile(filePath);
+		const permitted = resolvePermittedDefineFile(cwd, params.defineFile);
+		const fromFile = readDefineFileWithSource(permitted.filePath, permitted.allowedRoots);
 		if (!fromFile.ok) throw new RpcError(RPC.INVALID_PARAMS, describeLoadFailure(fromFile, "defineFile"));
-		params = { ...params, define: fromFile.value };
+		flowSourceFile = fromFile.value.filePath;
+		flowSourceDirIdentity = fromFile.value.sourceDirIdentity;
+		params = { ...params, define: fromFile.value.value };
 	}
 	if (params.define !== undefined && params.define !== null) {
-		return isShorthand(params.define) ? desugar(params.define) : (params.define as Taskflow);
+		return {
+			def: isShorthand(params.define) ? desugar(params.define) : (params.define as Taskflow),
+			flowSourceFile,
+			flowSourceDirIdentity,
+		};
 	}
 	if (params.name) {
 		const r = getFlowDiagnosed(cwd, params.name);
 		if (!r.ok) throw new RpcError(RPC.INVALID_PARAMS, describeLoadFailure(r, `Saved flow "${params.name}"`));
-		return r.value.def;
+		return {
+			def: r.value.def,
+			flowSourceFile: r.value.filePath,
+			flowSourceDirIdentity: r.value.sourceDirIdentity,
+		};
 	}
 	throw new RpcError(RPC.INVALID_PARAMS, "Provide either `name` (a saved flow) or `define` (an inline flow).");
+}
+
+function resolveFlow(cwd: string, params: { name?: string; define?: unknown; defineFile?: unknown }): Taskflow {
+	return resolveFlowWithSource(cwd, params).def;
 }
 
 /** Optional host-identity options for the MCP server (0.2.0 dogfood issue 4).
@@ -795,7 +832,14 @@ export function stampRunIdentity(state: RunState, host?: string): void {
 	if (host) state.host = host;
 }
 
-function mkRunState(def: Taskflow, args: Record<string, unknown>, cwd: string, host?: string): RunState {
+function mkRunState(
+	def: Taskflow,
+	args: Record<string, unknown>,
+	cwd: string,
+	host?: string,
+	flowSourceFile?: string,
+	flowSourceDirIdentity?: DirectoryIdentity,
+): RunState {
 	const state: RunState = {
 		runId: newRunId(def.name ?? "flow"),
 		flowName: def.name ?? "flow",
@@ -806,6 +850,8 @@ function mkRunState(def: Taskflow, args: Record<string, unknown>, cwd: string, h
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		cwd,
+		flowSourceFile,
+		flowSourceDirIdentity,
 		invocationRootSnapshot: directoryIdentity(cwd),
 	};
 	stampRunIdentity(state, host);
@@ -843,7 +889,8 @@ export function makeToolHandlers(
 				args.define === undefined && args.defineFile === undefined && typeof args.name === "string" && args.name.trim()
 					? args.name.trim()
 					: undefined;
-			const def = resolveFlow(cwd, args);
+			const resolvedFlow = resolveFlowWithSource(cwd, args);
+			const def = resolvedFlow.def;
 			const structural = validateTaskflow(def);
 			if (!structural.ok) return textContent(`Flow is invalid:\n- ${structural.errors.join("\n- ")}`, true);
 			const providedArgs = args.args && typeof args.args === "object" && !Array.isArray(args.args)
@@ -881,12 +928,19 @@ export function makeToolHandlers(
 				signal: context?.signal,
 				usageAccounting,
 				cwdBridgeMode: cwdBridgeModeFromEnv(),
-				loadFlow: (name: string) => {
+				loadSavedFlow: (name: string) => {
 					const loaded = getFlowDiagnosed(cwd, name);
-					return loaded.ok ? loaded.value.def : undefined;
+					return loaded.ok ? { def: loaded.value.def, filePath: loaded.value.filePath, sourceDirIdentity: loaded.value.sourceDirIdentity } : undefined;
 				},
 			};
-			const state = mkRunState(def, resolvedArgs, cwd, host);
+			const state = mkRunState(
+				def,
+				resolvedArgs,
+				cwd,
+				host,
+				resolvedFlow.flowSourceFile,
+				resolvedFlow.flowSourceDirIdentity,
+			);
 			if (args.mode === "background") {
 				if (!opts?.detachedRunner) {
 					return textContent(
@@ -1070,6 +1124,10 @@ export function makeToolHandlers(
 				usageAccounting: runner.usageAccounting,
 				cwdBridgeMode: cwdBridgeModeFromEnv(),
 				trace: new FileTraceSink(traceFilePath(runsDir(cwd), child.flowName, child.runId)),
+				loadSavedFlow: (name: string) => {
+					const loaded = getFlowDiagnosed(cwd, name);
+					return loaded.ok ? { def: loaded.value.def, filePath: loaded.value.filePath, sourceDirIdentity: loaded.value.sourceDirIdentity } : undefined;
+				},
 			};
 			const cleanupConfig = {
 				maxKeep: settings.taskflow.maxKeptRuns,
@@ -1188,7 +1246,7 @@ export function makeToolHandlers(
 			const flows = listFlows(cwd);
 			if (flows.length === 0) return textContent("No saved taskflows found from this directory.");
 			const lines = flows.map((f) => {
-				const metaR = readMeta(cwd, f.name);
+				const metaR = readMetaNextTo(f.filePath);
 				const meta = metaR.ok ? metaR.value : undefined;
 				if (meta?.purpose) {
 					const purpose = meta.purpose.length > 20 ? meta.purpose.slice(0, 20) + "…" : meta.purpose;
@@ -1204,7 +1262,7 @@ export function makeToolHandlers(
 			const savedR = getFlowDiagnosed(cwd, name);
 			if (!savedR.ok) return textContent(describeLoadFailure(savedR, `Saved flow "${name}"`), true);
 			const saved = savedR.value;
-			const metaR = readMeta(cwd, name);
+			const metaR = readMetaNextTo(saved.filePath);
 			const meta = metaR.ok ? metaR.value : undefined;
 			if (meta) {
 				const out = { definition: saved.def, library: { purpose: meta.purpose, tags: meta.tags, notes: meta.notes, generality: meta.generality, reuseCount: meta.reuseCount, version: meta.version, phaseSignature: meta.phaseSignature } };

--- a/packages/taskflow-mcp-core/test/jsonrpc-cancellation.test.ts
+++ b/packages/taskflow-mcp-core/test/jsonrpc-cancellation.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough, Writable } from "node:stream";
 import { test } from "node:test";
-import { emptyUsage, type AgentConfig, type SubagentRunner } from "taskflow-core";
+import { emptyUsage, saveRun, type AgentConfig, type RunState, type SubagentRunner } from "taskflow-core";
 import { makeToolHandlers } from "../src/mcp/server.ts";
 import { serveStdio, TRANSPORT_SHUTDOWN_GRACE_MS, type RpcHandler } from "../src/mcp/jsonrpc.ts";
 
@@ -339,6 +339,89 @@ test("taskflow_run resolves typed cwd defaults before validation and execution",
 	} finally {
 		if (previousMode === undefined) delete process.env.TASKFLOW_CWD_BRIDGE_MODE;
 		else process.env.TASKFLOW_CWD_BRIDGE_MODE = previousMode;
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("taskflow_run defineFile carries canonical source into flow-relative scripts", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "taskflow-mcp-flow-source-"));
+	try {
+		const flowDir = join(cwd, ".pi", "taskflows", "flows", "release bundle");
+		await mkdir(flowDir, { recursive: true });
+		const defineFile = join(flowDir, "publish.json");
+		await writeFile(defineFile, JSON.stringify({
+			name: "mcp-define-file-source",
+			scriptCwd: "flow",
+			phases: [{
+				id: "where",
+				type: "script",
+				run: [process.execPath, "-e", "process.stdout.write(process.cwd())"],
+				final: true,
+			}],
+		}), "utf8");
+		const runner: SubagentRunner<AgentConfig> = {
+			runTask: async (_cwd, _agents, agent, task) => ({
+				agent, task, exitCode: 0, output: "unused", stderr: "", usage: emptyUsage(),
+			}),
+		};
+		const tools = makeToolHandlers(cwd, runner);
+		const result = (await tools.taskflow_run?.({ defineFile })) as {
+			isError?: boolean;
+			content?: Array<{ text?: string }>;
+		};
+		const text = result.content?.[0]?.text ?? "";
+		assert.equal(result.isError, false, text);
+		assert.ok(text.includes(flowDir), text);
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("taskflow_resume reloads a saved subflow with atomic source provenance", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "taskflow-mcp-resume-source-"));
+	try {
+		const childDir = join(cwd, ".pi", "taskflows", "flows", "resume-child");
+		await mkdir(childDir, { recursive: true });
+		await writeFile(join(childDir, "child.json"), JSON.stringify({
+			name: "resume-child",
+			scriptCwd: "flow",
+			phases: [{
+				id: "where",
+				type: "script",
+				run: [process.execPath, "-e", "process.stdout.write(process.cwd())"],
+				final: true,
+			}],
+		}), "utf8");
+		const parentDef = {
+			name: "resume-parent",
+			phases: [{ id: "child-phase", type: "flow" as const, use: "resume-child", final: true }],
+		};
+		const state: RunState = {
+			runId: "resume-source-001",
+			flowName: parentDef.name,
+			def: parentDef,
+			args: {},
+			status: "failed",
+			phases: { "child-phase": { id: "child-phase", status: "failed", error: "seed failure" } },
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+			cwd,
+		};
+		saveRun(state);
+		const runner: SubagentRunner<AgentConfig> = {
+			runTask: async (_cwd, _agents, agent, task) => ({
+				agent, task, exitCode: 0, output: "unused", stderr: "", usage: emptyUsage(),
+			}),
+		};
+		const tools = makeToolHandlers(cwd, runner);
+		const result = (await tools.taskflow_resume?.({ runId: state.runId })) as {
+			isError?: boolean;
+			content?: Array<{ text?: string }>;
+		};
+		const text = result.content?.[0]?.text ?? "";
+		assert.equal(result.isError, false, text);
+		assert.ok(text.includes(childDir), text);
+	} finally {
 		await rm(cwd, { recursive: true, force: true });
 	}
 });

--- a/skills-src/taskflow/configuration.md
+++ b/skills-src/taskflow/configuration.md
@@ -30,6 +30,7 @@ Top-level keys of the taskflow definition object.
   "description": "Audit API auth",  // shown in /tf list and the command palette
   "concurrency": 8,                 // default max concurrent subagents (default: 8)
   "agentScope": "user",             // user | project | both (default: user)
+  "scriptCwd": "invocation",        // invocation | flow (default: invocation)
   "args": { /* see §3 */ },
   // 0.2.7: optional terminal hooks (summary payload only — never transcripts)
   // "hooks": { "onComplete": [{ "type": "file", "path": ".taskflow/hooks/last.json" }] },
@@ -44,10 +45,13 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
 | `version` | number | `1` | Informational metadata in 0.2.x; it does not select runtime semantics or migrate a flow. |
+
+Saved definitions remain compatible at `.pi/taskflows/*.json` and may also be organized recursively below `.pi/taskflows/flows/**/*.json`. Legacy top-level files win same-scope duplicate names; nested candidates use deterministic Unicode-scalar path order. Discovery has one shared user/project budget and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition bytes, 1 MiB per definition, or 16 nested levels. Symlinks below trusted storage boundaries are rejected; a configured user agent-directory boundary may itself be a symlink, while project `.pi` remains no-follow. New-flow saves enforce the same boundary policy and revalidate the physical target directory inside the write lock.
 
 ---
 

--- a/skills-src/taskflow/core.md
+++ b/skills-src/taskflow/core.md
@@ -485,6 +485,19 @@ output is exact.
 - A non-zero exit fails the phase (stderr captured); stdout capped at 1 MB.
   No `retry`, no `output: "json"`; **excluded from cross-run cache** (may have
   side effects). Not allowed inside LLM-generated dynamic sub-flows (RCE guard).
+- Top-level `scriptCwd: "flow"` makes script phases run from the canonical saved
+  flow/`defineFile` directory. The default is `"invocation"`; explicit phase
+  `cwd` still wins. Inline definitions cannot claim file provenance and fail
+  closed in `"flow"` mode. The source directory identity is checked again just
+  before spawn, and any inherited cwd-bridge boundary still constrains it.
+- Saved flows may live at legacy `.pi/taskflows/*.json` or recursively below
+  `.pi/taskflows/flows/**/*.json`. Legacy files win same-scope duplicate names;
+  nested candidates use deterministic Unicode-scalar path order. Discovery
+  rejects symlinks below trusted storage boundaries and fails closed above 1,000
+  flows, 10,000 entries, 512 directories, 8 MiB total definitions, 1 MiB per
+  definition, or 16 levels. A configured user agent-directory boundary may be a
+  symlink; project `.pi` remains no-follow. New-flow saves enforce the same
+  boundary policy and revalidate the target directory inside the write lock.
 
 ```jsonc
 { "id": "build", "type": "script", "run": "pnpm run build", "timeout": 120000 },

--- a/website/content/docs/en/syntax/flow-definition.mdx
+++ b/website/content/docs/en/syntax/flow-definition.mdx
@@ -379,6 +379,7 @@ The rest of this page is the exhaustive reference — every top-level field, the
 | `strictInterpolation` | `boolean` | `false` | No | Promote validation warnings to hard errors. |
 | `contextSharing` | `boolean` | `false` | No | Enable the Shared Context Tree for all phases. |
 | `incremental` | `boolean` | `false` | No | Default every phase to cross-run caching. |
+| `scriptCwd` | `"invocation" \| "flow"` | `"invocation"` | No | Default cwd for script phases without an explicit phase `cwd`. `"flow"` requires a saved flow or `defineFile` source and uses that file's directory; inherited cwd-bridge boundaries still constrain the resolved directory. |
 | `phases` | `Phase[]` (`minItems: 1`) | — | **Yes** | Ordered phase definitions. See [Phase Types](/en/docs/syntax/phase-types). |
 
 ### ArgSpec

--- a/website/content/docs/en/syntax/phase-types.mdx
+++ b/website/content/docs/en/syntax/phase-types.mdx
@@ -425,6 +425,18 @@ To pass dynamic values into a script safely, pipe them through `input` (which su
   `script` phases cannot use `retry` or `output: "json"`. `timeout` defaults to `60000` and caps at `300000` ms.
 </Callout>
 
+For co-located script bundles, place the saved definition anywhere below `.pi/taskflows/flows/` and set top-level `scriptCwd: "flow"`. Nested discovery uses locale-independent Unicode-scalar path ordering and one shared user/project budget. Re-saving a discovered nested flow updates that definition and its adjacent metadata in place. Discovery rejects symlinks below the trusted storage boundary through definition leaves and fails closed above 1,000 flows, 10,000 entries, 512 directories, 8 MiB total definition data, 1 MiB per definition, or 16 levels; the configured agent-directory boundary itself may be a symlink for compatible home relocation. New-flow saves enforce the same storage-boundary policy and revalidate the physical target directory inside the write lock. A command such as `["./scripts/prepare.sh"]` then runs from the canonical directory containing that flow JSON, whose filesystem identity is revalidated immediately before spawn. The legacy default is `"invocation"`; a phase-level `cwd` still wins. Inline `define` values fail closed with `scriptCwd: "flow"` because no trusted source file exists, while `defineFile` is supported. An inherited cwd-bridge boundary also constrains the resolved flow source directory.
+
+```json title="flow-relative script bundle"
+{
+  "name": "release",
+  "scriptCwd": "flow",
+  "phases": [
+    { "id": "prepare", "type": "script", "run": ["./scripts/prepare.sh"], "final": true }
+  ]
+}
+```
+
 ## First success wins: `race`
 
 When several approaches can answer the same question and **latency** matters more than waiting for every branch, use `race`. Branches start together; the **first successful** completion becomes the phase output (a fast hard-fail does **not** win). Unlike `parallel` (waits for all) or `tournament` (judges quality after all variants).

--- a/website/content/docs/zh-cn/syntax/flow-definition.mdx
+++ b/website/content/docs/zh-cn/syntax/flow-definition.mdx
@@ -379,6 +379,7 @@ description: 把阶段包成一个 taskflow 的顶层字段。
 | `strictInterpolation` | `boolean` | `false` | 否 | 把校验警告提升为硬错误。 |
 | `contextSharing` | `boolean` | `false` | 否 | 为所有阶段启用共享上下文树。 |
 | `incremental` | `boolean` | `false` | 否 | 把每个阶段默认为跨运行缓存。 |
+| `scriptCwd` | `"invocation" \| "flow"` | `"invocation"` | 否 | 未显式设置阶段 `cwd` 时，脚本阶段使用的默认工作目录。`"flow"` 仅适用于已保存 flow 或 `defineFile`，并使用定义文件所在目录；继承的 cwd bridge 边界仍会约束解析结果。 |
 | `phases` | `Phase[]`（`minItems: 1`） | — | **是** | 有序阶段定义。见[阶段类型](/zh-cn/docs/syntax/phase-types)。 |
 
 ### ArgSpec

--- a/website/content/docs/zh-cn/syntax/phase-types.mdx
+++ b/website/content/docs/zh-cn/syntax/phase-types.mdx
@@ -410,6 +410,18 @@ gate 审查上游输出并给出裁决。`PASS` 让流程继续；`BLOCK` 中止
 }
 ```
 
+要把脚本和已保存的 flow 放在一起，可把定义文件放到 `.pi/taskflows/flows/` 的任意层级，并在 flow 顶层设置 `scriptCwd: "flow"`。运行时会从定义文件所在目录启动没有显式 `cwd` 的脚本阶段；旧的 `.pi/taskflows/*.json` 仍可发现，重新保存已发现的嵌套 flow 会原地更新定义及相邻元数据。默认 `scriptCwd` 仍是 `"invocation"`，因此现有 flow 的工作目录不会改变。嵌套发现按 Unicode 标量路径确定性排序，拒绝可信存储边界以下到定义文件叶子的全部符号链接，并按单个定义 1 MiB、用户与项目合计 8 MiB、1,000 个定义、10,000 个目录项、512 个目录和 16 层深度安全失败；为兼容 home 目录迁移，配置的 agent 目录边界本身可以是符号链接。保存新 flow 时会执行相同的边界策略，并在写锁内重新验证目标目录的物理身份。继承的 cwd bridge 边界也会约束解析出的 flow 来源目录。
+
+```json title="script — 与 flow 放在一起"
+{
+  "name": "release",
+  "scriptCwd": "flow",
+  "phases": [
+    { "id": "prepare", "type": "script", "run": ["./scripts/prepare.sh"] }
+  ]
+}
+```
+
 要安全地把动态值传进脚本，通过 `input` 管道传入（它支持插值），而不是把值插值进 `run`：
 
 ```json title="script — 管道 stdin"


### PR DESCRIPTION
## Summary

Closes #126.

- discover saved flows recursively under the fixed `.pi/taskflows/flows/**/*.json` convention while preserving `.pi/taskflows/*.json`
- add opt-in top-level `scriptCwd: "invocation" | "flow"` with `invocation` as the backward-compatible default
- carry trusted definition provenance through Pi, MCP, classic runtime, event kernel, saved subflows, detached runs, resume/fork, RunState, FlowIR, and the DSL
- keep adjacent metadata working for nested definitions and document the new convention across README, website, and generated host skills

## Compatibility and safety

- legacy top-level definitions win same-scope duplicate names; project scope still overrides user scope
- re-saving a discovered nested flow updates its existing definition and adjacent metadata in place; new flows retain the legacy top-level save location
- explicit phase `cwd` and workspace isolation keep their existing precedence
- inline definitions cannot claim a source path; `scriptCwd: "flow"` fails closed without trusted loader provenance
- discovery skips symlinks and hidden directories, uses Unicode-scalar deterministic ordering, and fails closed at 16 levels / 512 directories / 10,000 entries / 1,000 definitions / 1 MiB per definition / 8 MiB total
- saved-flow and `defineFile` reads use bounded no-follow descriptors with pre/post file identity checks; canonical source path and parent-directory identity are persisted and revalidated before flow-relative script spawn

## Verification

- `pnpm run typecheck`
- `pnpm test` — 2,178 passed, 0 failed, 4 skipped
- `pnpm run build`
- `pnpm run build:website` — 127 static pages
- `pnpm run test:pack`
- `pnpm run test:pack-charterarc`
- Codex basic + comprehensive MCP E2E
- Claude, OpenCode, Grok, and Hermes MCP E2E
- `pnpm audit --prod --audit-level high` — no known vulnerabilities
- targeted regression tests include sabotage proof for source-directory replacement, symlinked storage roots, byte budgets, and legacy-root breadth limits
