### PR TITLE
release: taskflow 0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+## [0.2.10] — 2026-08-12
+
 ### Added
 
 - **Organized saved-flow discovery.** Project and user flows may be nested recursively below the bounded `flows/` convention directory (for example `.pi/taskflows/flows/release/publish.json`) while legacy top-level saved flows remain compatible and take same-scope precedence on duplicate names.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **English** · [简体中文](./README.zh-CN.md)
 
-[Install](#install-on-your-host) · [Quickstart](#60-second-start) · [What's new in 0.2.9](#029-hermes-agent--verify-parity) · [0.2 compiler turn](#02-is-the-compiler-turn) · [Docs](https://heggria.github.io/taskflow/en/docs) · [Examples](./examples)
+[Install](#install-on-your-host) · [Quickstart](#60-second-start) · [What's new in 0.2.10](#0210-organized-portable-saved-flows) · [0.2 compiler turn](#02-is-the-compiler-turn) · [Docs](https://heggria.github.io/taskflow/en/docs) · [Examples](./examples)
 
 </div>
 
@@ -167,6 +167,12 @@ This is real output from a Pi run—not a mock dashboard:
 ```
 
 The layout **is** the DAG. Parallel rails expose concurrency; long edges expose dependencies; the gate explains why downstream work stopped. No separate control plane is required to understand the run.
+
+## 0.2.10: organized, portable saved flows
+
+Saved flows can now be organized below the bounded `.pi/taskflows/flows/**` convention while legacy top-level flows keep their existing precedence and behavior. A file-backed flow may opt into `scriptCwd: "flow"`, making adjacent scripts, templates, and fixtures portable as one reviewable directory bundle.
+
+Discovery, provenance, and persistence remain fail-closed: recursion has shared file/entry/directory/byte/depth budgets, symlinked descendants are excluded, source identity survives foreground/background/resume/subflow paths, and nested definition/sidecar writes revalidate the physical parent through atomic promotion. [Full 0.2.10 notes →](./CHANGELOG.md#0210--2026-08-12)
 
 ## 0.2.9: Hermes Agent + verify parity
 
@@ -371,7 +377,7 @@ claude plugin install claude-taskflow@taskflow
 
 ```bash
 opencode mcp add taskflow -- \
-  npx -y -p opencode-taskflow@0.2.9 opencode-taskflow-mcp
+  npx -y -p opencode-taskflow@0.2.10 opencode-taskflow-mcp
 ```
 
 [OpenCode guide →](https://heggria.github.io/taskflow/en/docs/guides/opencode)
@@ -380,7 +386,7 @@ opencode mcp add taskflow -- \
 
 ```bash
 grok mcp add taskflow -- \
-  npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+  npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 Grok Build support is new in 0.2. Its CLI stream does not report token/cost usage, so budget-declaring flows are rejected rather than silently running without enforcement.
@@ -390,7 +396,7 @@ Grok Build support is new in 0.2. Its CLI stream does not report token/cost usag
 ### Hermes Agent
 
 ```bash
-hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
 # Prefer env in config.yaml (not CLI --env after args — can be stuffed into argv):
 #   mcp_servers.taskflow.env.PI_TASKFLOW_HERMES_UNSAFE_YOLO: "1"   # mutating only
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 [English](./README.md) · **简体中文**
 
-[安装](#安装到你的宿主) · [快速开始](#60-秒开始) · [0.2.9 新能力](#029-hermes-agent--verify-对齐) · [0.2 编译器转身](#02-是编译器转身) · [文档](https://heggria.github.io/taskflow/zh-cn/docs) · [示例](./examples)
+[安装](#安装到你的宿主) · [快速开始](#60-秒开始) · [0.2.10 新能力](#0210可组织可携带的-saved-flow) · [0.2 编译器转身](#02-是编译器转身) · [文档](https://heggria.github.io/taskflow/zh-cn/docs) · [示例](./examples)
 
 </div>
 
@@ -167,6 +167,12 @@ pi install npm:pi-taskflow
 ```
 
 布局**本身就是 DAG**。并行轨道暴露并发，长边暴露依赖，gate 解释下游为什么停止。你不需要另一套控制平面才能看懂运行状态。
+
+## 0.2.10：可组织、可携带的 saved flow
+
+saved flow 现在可以按受限约定放在 `.pi/taskflows/flows/**` 下分目录管理，同时旧顶层 flow 的优先级和行为保持不变。文件来源可信的 flow 可显式设置 `scriptCwd: "flow"`，让相邻的脚本、模板和 fixtures 作为一个目录整体复制、审阅和版本控制。
+
+发现、来源和持久化继续 fail closed：递归扫描共享文件数、entry、目录数、字节和深度预算；排除边界下的 symlink；来源身份贯穿前台、后台、resume 与 subflow；嵌套 definition/sidecar 在 atomic promotion 各阶段重验物理父目录。[完整 0.2.10 说明 →](./CHANGELOG.md#0210--2026-08-12)
 
 ## 0.2.9：Hermes Agent + verify 对齐
 
@@ -366,7 +372,7 @@ claude plugin install claude-taskflow@taskflow
 
 ```bash
 opencode mcp add taskflow -- \
-  npx -y -p opencode-taskflow@0.2.9 opencode-taskflow-mcp
+  npx -y -p opencode-taskflow@0.2.10 opencode-taskflow-mcp
 ```
 
 [OpenCode 指南 →](https://heggria.github.io/taskflow/zh-cn/docs/guides/opencode)
@@ -375,7 +381,7 @@ opencode mcp add taskflow -- \
 
 ```bash
 grok mcp add taskflow -- \
-  npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+  npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 Grok Build 支持在 0.2 首次加入。其 CLI stream 不返回 token/cost 用量，因此声明了预算的 flow 会被拒绝，而不是在无法执行预算约束时静默运行。
@@ -385,7 +391,7 @@ Grok Build 支持在 0.2 首次加入。其 CLI stream 不返回 token/cost 用�
 ### Hermes Agent
 
 ```bash
-hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
 # 优先在 config.yaml 写 env（不要用 CLI --env 塞进 node argv）：
 #   mcp_servers.taskflow.env.PI_TASKFLOW_HERMES_UNSAFE_YOLO: "1"   # 仅 mutating
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,8 +82,8 @@ the matching annotated tag:
 ```sh
 git switch main
 git pull --ff-only origin main
-git tag -a v0.2.9 -m "Release v0.2.9"
-git push origin v0.2.9
+git tag -a v0.2.10 -m "Release v0.2.10"
+git push origin v0.2.10
 ```
 
 `.github/workflows/publish.yml` then performs the complete release transaction:
@@ -126,16 +126,16 @@ publishing missing packages manually.
 
 ## Upgrade and rollback
 
-- Upgrade all host package pins as one transaction to `0.2.9`, restart/reload the
-  host's MCP/plugin registration, and verify `taskflow_version` reports `0.2.9`.
+- Upgrade all host package pins as one transaction to `0.2.10`, restart/reload the
+  host's MCP/plugin registration, and verify `taskflow_version` reports `0.2.10`.
 - This patch does not introduce a run-state migration. Keep `.pi/taskflows/` and
   existing run history in place when upgrading or rolling back.
-- Pi, Codex, Claude Code, OpenCode, and Grok users can roll back by pinning their
-  delivery package to `0.2.8` and restarting the host. Keep all taskflow package
-  versions aligned; do not mix a `0.2.9` adapter with `0.2.8` shared packages.
-- Hermes support begins in `0.2.9`; there is no `hermes-taskflow@0.2.8`. To roll
-  Hermes back, disable/remove its Taskflow MCP entry and restart Hermes rather
-  than attempting to install a nonexistent older package.
+- All six hosts can roll back by pinning their delivery package to `0.2.9` and
+  restarting/reloading the host. Keep all taskflow package versions aligned; do
+  not mix a `0.2.10` adapter with `0.2.9` shared packages.
+- Before rolling back, move any definitions from `.pi/taskflows/flows/**` back to
+  the legacy top-level taskflows directory and remove `scriptCwd: "flow"`; 0.2.9
+  does not discover the nested convention or understand that field.
 
 ## Install (end users)
 
@@ -155,8 +155,8 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (published MCP package)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 
-hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ The runtime has intentional hardening: `realpath`-based path containment, runId 
 
 | Version | Support |
 |---------|---------|
-| Latest npm release (`v0.2.9` for this release) | ✅ Active |
+| Latest npm release (`v0.2.10` for this release) | ✅ Active |
 | Earlier versions | ❌ Unsupported — upgrade to the latest npm release |
 
 ## Disclosure

--- a/docs/claude-mcp.md
+++ b/docs/claude-mcp.md
@@ -35,7 +35,7 @@ Verify:
 
 ```sh
 claude plugin list   # → claude-taskflow@taskflow  installed, enabled
-claude mcp list      # → taskflow … (npx -y -p claude-taskflow@0.2.9 claude-taskflow-mcp)
+claude mcp list      # → taskflow … (npx -y -p claude-taskflow@0.2.10 claude-taskflow-mcp)
 ```
 
 The bundled skill tells Claude Code *when* to reach for the tools (multi-phase

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -31,7 +31,7 @@ globally, and the plugin version binds the exact code that runs. Verify:
 
 ```sh
 codex plugin list   # → taskflow@taskflow  installed, enabled
-codex mcp list      # → taskflow … enabled  (npx -y -p codex-taskflow@0.2.9 codex-taskflow-mcp)
+codex mcp list      # → taskflow … enabled  (npx -y -p codex-taskflow@0.2.10 codex-taskflow-mcp)
 ```
 
 The bundled skill tells Codex *when* to reach for the tools (multi-phase or
@@ -70,7 +70,7 @@ To stop large flows from being cut off, the plugin's `.mcp.json` ships a
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.2.9", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.2.10", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/docs/grok-mcp.md
+++ b/docs/grok-mcp.md
@@ -27,7 +27,7 @@ Official Grok docs used for this integration:
 ## Install (recommended): register the published MCP server
 
 ```sh
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 A public Grok plugin marketplace/source is not published yet. Do not substitute
@@ -179,7 +179,7 @@ grok mcp add taskflow -- grok-taskflow-mcp
 Or with npx (no global install):
 
 ```sh
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 Verify:

--- a/docs/hermes-mcp.md
+++ b/docs/hermes-mcp.md
@@ -15,7 +15,7 @@ Or paste into `~/.hermes/config.yaml` (see `packages/hermes-taskflow/plugin/herm
 mcp_servers:
   taskflow:
     command: "npx"
-    args: ["-y", "-p", "hermes-taskflow@0.2.9", "hermes-taskflow-mcp"]
+    args: ["-y", "-p", "hermes-taskflow@0.2.10", "hermes-taskflow-mcp"]
     env:
       # PI_TASKFLOW_HERMES_UNSAFE_YOLO: "1"  # required for mutating agent phases
     timeout: 600

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **هذه الترجمة قديمة.** يُرجى مراجعة [README بالإنجليزية](../../README.md) للحصول على أحدث المعلومات.
 
-taskflow رسم بياني تصريحي وقابل للتحقق للمهام على Pi وCodex وClaude Code وOpenCode وGrok Build وHermes Agent. خط 0.2.9 يتطلب Node.js ≥ 22.19.0 ويضم 12 نوعًا من المراحل وأكثر من 1500 اختبار. طبقة MCP لا تعتمد على MCP SDK؛ يستخدم core ‏`typebox` كـ peer ويعتمد DSL على TypeScript.
+taskflow رسم بياني تصريحي وقابل للتحقق للمهام على Pi وCodex وClaude Code وOpenCode وGrok Build وHermes Agent. خط 0.2.10 يتطلب Node.js ≥ 22.19.0 ويضم 12 نوعًا من المراحل وأكثر من 1500 اختبار. طبقة MCP لا تعتمد على MCP SDK؛ يستخدم core ‏`typebox` كـ peer ويعتمد DSL على TypeScript.
 
 > **لماذا "taskflow" وليس "workflow"؟** الـ *workflow* (بنمط code-mode) هو برنامج أمري *يتدفق*، ورسمه البياني مخبأ داخل تدفق التحكم. أما الـ *taskflow* فينقل الخطة إلى رسم بياني تصريحي من عقد مهام منفصلة — يمكن التحقق منه ساكنًا وعرضه واستئنافه وحفظه كأمر. نحن نستبدل القدرة التعبيرية بالقابلية للتحقق، عن قصد.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.bn.md
+++ b/docs/i18n/README.bn.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **এই অনুবাদটি পুরোনো।** অনুগ্রহ করে সর্বশেষ তথ্যের জন্য [ইংরেজি README](../../README.md) দেখুন।
 
-taskflow Pi, Codex, Claude Code, OpenCode, Grok Build ও Hermes Agent-এর জন্য একটি ডিক্লারেটিভ, যাচাইযোগ্য টাস্ক গ্রাফ। 0.2.9 লাইনে Node.js ≥ 22.19.0, 12টি phase kind এবং 1500+ পরীক্ষা রয়েছে। MCP layer-এর MCP SDK dependency নেই; core-এর peer `typebox`, আর DSL TypeScript-এর উপর নির্ভরশীল।
+taskflow Pi, Codex, Claude Code, OpenCode, Grok Build ও Hermes Agent-এর জন্য একটি ডিক্লারেটিভ, যাচাইযোগ্য টাস্ক গ্রাফ। 0.2.10 লাইনে Node.js ≥ 22.19.0, 12টি phase kind এবং 1500+ পরীক্ষা রয়েছে। MCP layer-এর MCP SDK dependency নেই; core-এর peer `typebox`, আর DSL TypeScript-এর উপর নির্ভরশীল।
 
 > **কেন "taskflow", "workflow" নয় কেন?** একটি *workflow* (code-mode) হল একটি ইম্পারেটিভ স্ক্রিপ্ট যা *প্রবাহিত হয়*, যার গ্রাফ কন্ট্রোল ফ্লোর মধ্যে লুকানো। একটি *taskflow* পরিকল্পনাকে পৃথক টাস্ক নোডের একটি ডিক্লারেটিভ গ্রাফে সরিয়ে নেয় — যা স্থিরভাবে যাচাই, দৃশ্যমান, পুনরারম্ভ এবং একটি কমান্ড হিসেবে সংরক্ষণ করা যায়। আমরা ইচ্ছাকৃতভাবে এক্সপ্রেসিভনেসকে যাচাইযোগ্যতার বিনিময়ে দিই।
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Esta traducción está desactualizada.** Consulta el [README en inglés](../../README.md) para obtener la información más reciente.
 
-taskflow es un *grafo de tareas* declarativo y verificable para agentes de codificación — funciona en Pi, Codex, Claude Code, OpenCode, Grok Build y Hermes Agent. Línea 0.2.9: Node.js ≥ 22.19.0, 12 tipos de fase y más de 1500 pruebas. La capa MCP no depende de un SDK MCP; core usa `typebox` como peer y el DSL depende de TypeScript.
+taskflow es un *grafo de tareas* declarativo y verificable para agentes de codificación — funciona en Pi, Codex, Claude Code, OpenCode, Grok Build y Hermes Agent. Línea 0.2.10: Node.js ≥ 22.19.0, 12 tipos de fase y más de 1500 pruebas. La capa MCP no depende de un SDK MCP; core usa `typebox` como peer y el DSL depende de TypeScript.
 
 > **¿Por qué "taskflow" y no "workflow"?** Un *workflow* (estilo code-mode) es un script imperativo que *fluye*, con el grafo oculto en el control de flujo. Un *taskflow* mueve el plan a un grafo declarativo de nodos de tarea discretos — que se puede verificar estáticamente, visualizar, reanudar y guardar como un comando. Cambiamos expresividad por verificabilidad, a propósito.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **यह अनुवाद पुराना है।** कृपया नवीनतम जानकारी के लिए [अंग्रेज़ी README](../../README.md) देखें।
 
-taskflow Pi, Codex, Claude Code, OpenCode, Grok Build और Hermes Agent के लिए एक घोषणात्मक, सत्यापन-योग्य टास्क ग्राफ है। 0.2.9 लाइन में Node.js ≥ 22.19.0, 12 phase kinds और 1500+ परीक्षण हैं। MCP layer किसी MCP SDK पर निर्भर नहीं है; core का peer `typebox` है और DSL TypeScript पर निर्भर है।
+taskflow Pi, Codex, Claude Code, OpenCode, Grok Build और Hermes Agent के लिए एक घोषणात्मक, सत्यापन-योग्य टास्क ग्राफ है। 0.2.10 लाइन में Node.js ≥ 22.19.0, 12 phase kinds और 1500+ परीक्षण हैं। MCP layer किसी MCP SDK पर निर्भर नहीं है; core का peer `typebox` है और DSL TypeScript पर निर्भर है।
 
 > **"taskflow" क्यों, "workflow" क्यों नहीं?** एक *workflow* (code-mode) एक आज्ञात्मक स्क्रिप्ट है जो *बहता* है, जिसका ग्राफ कंट्रोल फ़्लो में छिपा होता है। एक *taskflow* योजना को अलग-अलग टास्क नोड्स के एक घोषणात्मक ग्राफ में ले जाता है — जिसे स्थिर रूप से सत्यापित, दृश्य, पुनः शुरू और एक कमांड के रूप में सहेजा जा सकता है। हम जान-बूझकर अभिव्यक्ति को सत्यापन-योग्यता से बदलते हैं।
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.pt.md
+++ b/docs/i18n/README.pt.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Esta tradução está desatualizada.** Consulte o [README em inglês](../../README.md) para obter as informações mais recentes.
 
-taskflow é um *grafo de tarefas* declarativo e verificável para Pi, Codex, Claude Code, OpenCode, Grok Build e Hermes Agent. Linha 0.2.9: Node.js ≥ 22.19.0, 12 tipos de fase e mais de 1500 testes. A camada MCP não depende de um SDK MCP; core usa `typebox` como peer e o DSL depende de TypeScript.
+taskflow é um *grafo de tarefas* declarativo e verificável para Pi, Codex, Claude Code, OpenCode, Grok Build e Hermes Agent. Linha 0.2.10: Node.js ≥ 22.19.0, 12 tipos de fase e mais de 1500 testes. A camada MCP não depende de um SDK MCP; core usa `typebox` como peer e o DSL depende de TypeScript.
 
 > **Por que "taskflow" e não "workflow"?** Um *workflow* (estilo code-mode) é um script imperativo que *flui*, com o grafo escondido no controle de fluxo. Um *taskflow* move o plano para um grafo declarativo de nós de tarefa discretos — que pode ser verificado estaticamente, visualizado, retomado e salvo como um comando. Trocamos expressividade por verificabilidade, de propósito.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Этот перевод устарел.** Пожалуйста, обратитесь к [английскому README](../../README.md) за актуальной информацией.
 
-taskflow — декларативный и проверяемый граф задач для Pi, Codex, Claude Code, OpenCode, Grok Build и Hermes Agent. Линия 0.2.9: Node.js ≥ 22.19.0, 12 типов фаз и более 1500 тестов. Слой MCP не зависит от MCP SDK; core использует peer `typebox`, а DSL зависит от TypeScript.
+taskflow — декларативный и проверяемый граф задач для Pi, Codex, Claude Code, OpenCode, Grok Build и Hermes Agent. Линия 0.2.10: Node.js ≥ 22.19.0, 12 типов фаз и более 1500 тестов. Слой MCP не зависит от MCP SDK; core использует peer `typebox`, а DSL зависит от TypeScript.
 
 > **Почему "taskflow", а не "workflow"?** *Workflow* (в стиле code-mode) — это императивный скрипт, который *течёт*, а его граф спрятан в потоке управления. *Taskflow* переносит план в декларативный граф из дискретных узлов-задач — его можно статически проверить, визуализировать, возобновить и сохранить как команду. Мы осознанно меняем выразительность на проверяемость.
 
@@ -22,7 +22,7 @@ claude plugin install claude-taskflow@taskflow
 opencode mcp add taskflow -- npx -y -p opencode-taskflow opencode-taskflow-mcp
 
 # Grok Build (from monorepo checkout pre-publish, or published source)
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 # or: grok mcp add taskflow -- npx -y -p grok-taskflow grok-taskflow-mcp
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow-monorepo",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"private": true,
 	"description": "Monorepo for the Taskflow engine and DSL, host adapters, delivery packages, documentation, and the private CharterArc experiment.",
 	"type": "module",

--- a/packages/claude-taskflow/package.json
+++ b/packages/claude-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claude-taskflow",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Run taskflow on Claude Code: the npm tarball provides the Claude subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"claude",

--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/claude-taskflow/plugin/.mcp.json
+++ b/packages/claude-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "claude-taskflow@0.2.9", "claude-taskflow-mcp"]
+      "args": ["-y", "-p", "claude-taskflow@0.2.10", "claude-taskflow-mcp"]
     }
   }
 }

--- a/packages/claude-taskflow/test/mcp-server.test.ts
+++ b/packages/claude-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("claude mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-claude");
-	assert.equal(res.result.serverInfo.version, "0.2.9");
+	assert.equal(res.result.serverInfo.version, "0.2.10");
 });
 
 test("claude mcp: tools/list exposes the same taskflow tools as codex", async () => {

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-taskflow",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Run taskflow on OpenAI Codex: the npm tarball provides the Codex subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"codex",

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.2.9", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.2.10", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
+++ b/packages/codex-taskflow/test/e2e-mcp-comprehensive.mts
@@ -30,6 +30,7 @@ import { fileURLToPath } from "node:url";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repo = path.resolve(here, "..");
 const bin = path.join(repo, "dist", "mcp", "bin.js");
+const expectedVersion = JSON.parse(fs.readFileSync(path.join(repo, "package.json"), "utf8")).version;
 
 assert.ok(fs.existsSync(bin), `built bin not found at ${bin} — run: npm run build -w codex-taskflow`);
 
@@ -79,7 +80,7 @@ send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "
 const init = await waitFor(1, "initialize");
 assert.equal(init.result.protocolVersion, "2025-06-18");
 assert.equal(init.result.serverInfo.name, "taskflow-codex");
-assert.equal(init.result.serverInfo.version, "0.2.9");
+assert.equal(init.result.serverInfo.version, expectedVersion);
 ok(`initialize → ${JSON.stringify(init.result.serverInfo)}`);
 
 // notification must NOT produce a response

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -51,7 +51,7 @@ test("mcp: initialize returns the protocol version + serverInfo codex expects", 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-codex");
-	assert.equal(res.result.serverInfo.version, "0.2.9");
+	assert.equal(res.result.serverInfo.version, "0.2.10");
 });
 
 test("mcp: tools/list exposes the taskflow tools with schemas", async () => {

--- a/packages/grok-taskflow/package.json
+++ b/packages/grok-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grok-taskflow",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Run taskflow on Grok Build: the npm tarball provides the Grok subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"grok",

--- a/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
+++ b/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/grok-taskflow/plugin/.mcp.json
+++ b/packages/grok-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "grok-taskflow@0.2.9", "grok-taskflow-mcp"],
+      "args": ["-y", "-p", "grok-taskflow@0.2.10", "grok-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/grok-taskflow/test/mcp-server.test.ts
+++ b/packages/grok-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("grok mcp: initialize returns the protocol version + serverInfo", async () 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-grok");
-	assert.equal(res.result.serverInfo.version, "0.2.9");
+	assert.equal(res.result.serverInfo.version, "0.2.10");
 });
 
 test("grok mcp: tools/list exposes the same taskflow tools as other hosts", async () => {

--- a/packages/hermes-taskflow/package.json
+++ b/packages/hermes-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hermes-taskflow",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Run taskflow on Hermes Agent: a Hermes subagent runner plus an MCP server (and a config scaffold) that exposes the taskflow_* tools to Hermes users.",
 	"keywords": [
 		"hermes",

--- a/packages/hermes-taskflow/plugin/hermes.config.snippet.yaml
+++ b/packages/hermes-taskflow/plugin/hermes.config.snippet.yaml
@@ -14,7 +14,7 @@
 
 taskflow:
   command: "npx"
-  args: ["-y", "-p", "hermes-taskflow@0.2.9", "hermes-taskflow-mcp"]
+  args: ["-y", "-p", "hermes-taskflow@0.2.10", "hermes-taskflow-mcp"]
   env:
     # Uncomment for mutating agent phases (terminal / file write).
     # Leave unset for verify/plan/script-only flows.

--- a/packages/hermes-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/hermes-taskflow/plugin/skills/taskflow/configuration.md
@@ -309,7 +309,7 @@ Notes:
   phases fail closed unless `PI_TASKFLOW_HERMES_UNSAFE_YOLO=1`, which enables
   `--yolo`; their default surface is local `file,terminal`, while explicit web
   aliases may add `web`. Delegation, skills, memory, browser, cron, and other
-  control-plane toolsets are denied in 0.2.9. Optional
+  control-plane toolsets are denied in 0.2.10. Optional
   `PI_TASKFLOW_HERMES_MAX_TURNS` caps child loops (default 64). Quiet mode
   does not stream token/cost accounting, so budgeted flows fail closed at the
   MCP adapter the same way other non-accounting hosts do when costs are

--- a/packages/hermes-taskflow/test/mcp-server.test.ts
+++ b/packages/hermes-taskflow/test/mcp-server.test.ts
@@ -38,7 +38,7 @@ test("hermes mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-hermes");
-	assert.equal(res.result.serverInfo.version, "0.2.9");
+	assert.equal(res.result.serverInfo.version, "0.2.10");
 });
 
 test("hermes mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/opencode-taskflow/package.json
+++ b/packages/opencode-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opencode-taskflow",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Run taskflow on OpenCode: an OpenCode subagent runner plus an MCP server (and an opencode.json config scaffold) that exposes the taskflow_* tools to OpenCode users.",
 	"keywords": [
 		"opencode",

--- a/packages/opencode-taskflow/plugin/opencode.json
+++ b/packages/opencode-taskflow/plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "taskflow": {
       "type": "local",
-      "command": ["npx", "-y", "-p", "opencode-taskflow@0.2.9", "opencode-taskflow-mcp"],
+      "command": ["npx", "-y", "-p", "opencode-taskflow@0.2.10", "opencode-taskflow-mcp"],
       "enabled": true
     }
   },

--- a/packages/opencode-taskflow/test/mcp-server.test.ts
+++ b/packages/opencode-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("opencode mcp: initialize returns the protocol version + serverInfo", async
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-opencode");
-	assert.equal(res.result.serverInfo.version, "0.2.9");
+	assert.equal(res.result.serverInfo.version, "0.2.10");
 });
 
 test("opencode mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
 	"keywords": [
 		"pi-package",

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-core",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, grok-taskflow, and hermes-taskflow.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-dsl/package.json
+++ b/packages/taskflow-dsl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-dsl",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Compile-time TypeScript DSL frontend for taskflow: erase .tf.ts runes to Taskflow JSON, then FlowIR via taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-hosts/package.json
+++ b/packages/taskflow-hosts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-hosts",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Shared host-runner collection for taskflow — the codex, claude, opencode, grok, and hermes SubagentRunner implementations + their argv builders and event-stream parsers. The per-host MCP servers, plugin scaffolds, and bins live in codex-taskflow / claude-taskflow / opencode-taskflow / grok-taskflow / hermes-taskflow; this package holds just the runners so a new host can be added in one place.",
 	"homepage": "https://github.com/heggria/taskflow#readme",
 	"author": "heggria <bshengtao@gmail.com>",

--- a/packages/taskflow-hosts/src/hermes-runner.ts
+++ b/packages/taskflow-hosts/src/hermes-runner.ts
@@ -300,7 +300,7 @@ export function resolveHermesToolsets(
 	if (unmapped.length > 0 || sets.size === 0) {
 		throw new Error(
 			`Hermes tool whitelist [${tools.join(", ")}] did not map safely to supported Hermes toolsets. ` +
-				`0.2.9 permits only local file, terminal, and explicit web aliases; ` +
+				`0.2.10 permits only local file, terminal, and explicit web aliases; ` +
 				`delegation/skills/memory/browser/cron/control-plane tools are denied.`,
 		);
 	}

--- a/packages/taskflow-mcp-core/package.json
+++ b/packages/taskflow-mcp-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-mcp-core",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Host-neutral MCP server for taskflow: a dependency-free stdio JSON-RPC server exposing the taskflow_* tools, plus the DAG SVG/outline renderer. Shared by the codex/claude/opencode/grok/hermes adapters — depends only on taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/skills-src/taskflow/configuration.md
+++ b/skills-src/taskflow/configuration.md
@@ -400,7 +400,7 @@ Notes:
   phases fail closed unless `PI_TASKFLOW_HERMES_UNSAFE_YOLO=1`, which enables
   `--yolo`; their default surface is local `file,terminal`, while explicit web
   aliases may add `web`. Delegation, skills, memory, browser, cron, and other
-  control-plane toolsets are denied in 0.2.9. Optional
+  control-plane toolsets are denied in 0.2.10. Optional
   `PI_TASKFLOW_HERMES_MAX_TURNS` caps child loops (default 64). Quiet mode
   does not stream token/cost accounting, so budgeted flows fail closed at the
   MCP adapter the same way other non-accounting hosts do when costs are

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -25,7 +25,7 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.2.9",
+			eyebrow: "taskflow 0.2.10",
 			title: [
 				"Plan before spend.",
 				"Close the loop after.",
@@ -187,7 +187,7 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.2.9",
+			eyebrow: "taskflow 0.2.10",
 			title: ["花 token 前先计划。", "跑完闭环通知。", "只重算变化部分。"],
 			sub: "taskflow 把多代理编程工作变成可编译的运行时：声明式图、零 token preflight、隔离执行、跑完 hooks、确定性 replay，以及跨 Pi、Codex、Claude Code、OpenCode、Grok、Hermes 的增量重算。",
 			noteKicker: "面向 coding agents 的 compiled runtime",
@@ -341,7 +341,7 @@ export default async function HomePage({
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
 		name: "taskflow",
-		softwareVersion: "0.2.9",
+		softwareVersion: "0.2.10",
 		description: t.hero.sub,
 		applicationCategory: "DeveloperApplication",
 		operatingSystem: "Any",

--- a/website/components/home/install-rail.tsx
+++ b/website/components/home/install-rail.tsx
@@ -44,7 +44,7 @@ const HOSTS: { id: HostId; label: string; command: string; guide: string }[] = [
 		id: "hermes",
 		label: "Hermes",
 		command:
-			"hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp",
+			"hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp",
 		guide: "/docs/guides/hermes",
 	},
 ];

--- a/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: Compile-time .tf.ts authoring — erase runes to Taskflow JSON, the
 S4 adds a **compile-time** TypeScript frontend. You author `*.tf.ts` with **runes** (`agent`, `map`, `race`, …). A CLI erases them to ordinary Taskflow JSON. Hosts still run **JSON** via `taskflow_run` / `/tf run` — there is **no** interpret path and **no** host auto-build of `.tf.ts`.
 
 <Callout type="info">
-  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests are `0.2.9` on this release line; install from npm after the `v0.2.9` publish job, or use a workspace / local path from this monorepo.
+  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests are `0.2.10` on this release line; install from npm after the `v0.2.10` publish job, or use a workspace / local path from this monorepo.
 </Callout>
 
 ## Workflow

--- a/website/content/docs/en/getting-started.mdx
+++ b/website/content/docs/en/getting-started.mdx
@@ -116,7 +116,7 @@ If you have not installed taskflow yet, pick your host:
   </Tab>
   <Tab value="Hermes">
     ```bash title="Register Hermes Agent MCP"
-    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
     ```
     See the [Hermes Agent guide](/en/docs/guides/hermes) for read-only isolation and explicit mutating opt-in.
   </Tab>

--- a/website/content/docs/en/guides/grok-build.mdx
+++ b/website/content/docs/en/guides/grok-build.mdx
@@ -12,7 +12,7 @@ This page walks through install, verify, first run, permissions, and long-runnin
 ### Published MCP package (recommended)
 
 ```bash title="Register taskflow MCP"
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 Requires **Node.js ≥ 22.19.0**. The MCP protocol code has no MCP SDK dependency. A public Grok plugin marketplace/source is not published yet; do not substitute an imaginary source string.
@@ -170,7 +170,7 @@ MCP-driven runs are non-interactive, so an `approval` phase **auto-rejects** (fa
 ```bash title="Manual MCP registration"
 pnpm add -g grok-taskflow
 grok mcp add taskflow -- grok-taskflow-mcp
-# or: grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+# or: grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 ## Remove

--- a/website/content/docs/en/guides/hermes.mdx
+++ b/website/content/docs/en/guides/hermes.mdx
@@ -12,7 +12,7 @@ The full reference lives in [`docs/hermes-mcp.md`](https://github.com/heggria/ta
 ### Published MCP package (after npm publish)
 
 ```bash title="Register taskflow MCP"
-hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
 ```
 
 Or paste into `~/.hermes/config.yaml` / `$HERMES_HOME/config.yaml`:
@@ -21,7 +21,7 @@ Or paste into `~/.hermes/config.yaml` / `$HERMES_HOME/config.yaml`:
 mcp_servers:
   taskflow:
     command: "npx"
-    args: ["-y", "-p", "hermes-taskflow@0.2.9", "hermes-taskflow-mcp"]
+    args: ["-y", "-p", "hermes-taskflow@0.2.10", "hermes-taskflow-mcp"]
     env:
       # Required for mutating agent phases (terminal / file write / coding).
       # PI_TASKFLOW_HERMES_UNSAFE_YOLO: "1"  # required for mutating agent phases

--- a/website/content/docs/en/index.mdx
+++ b/website/content/docs/en/index.mdx
@@ -66,7 +66,7 @@ In **0.2**, that graph became a compiled contract: TypeScript authoring, FlowIR,
   </Tab>
   <Tab value="Hermes Agent">
     ```bash title="Register the Hermes MCP server"
-    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
     ```
 
     Continue with the [Hermes Agent guide](/en/docs/guides/hermes).

--- a/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: 编译期 .tf.ts 写法 —— rune erase 成 Taskflow JSON，再�
 S4 增加**编译期** TypeScript 前端：用 rune（`agent`、`map`、`race`…）写 `*.tf.ts`，CLI erase 成普通 Taskflow JSON。宿主仍通过 `taskflow_run` / `/tf run` 跑 **JSON**——**没有**解释执行路径，也**没有**宿主对 `.tf.ts` 的自动 build。
 
 <Callout type="info">
-  **包状态。** `taskflow-dsl` 在 monorepo 的 `packages/taskflow-dsl`。纯 JSON 作者不需要它。本发布线 manifest 为 `0.2.9`；`v0.2.9` 发布任务完成后可从 npm 安装，或使用本 monorepo 的 workspace / 本地 path。
+  **包状态。** `taskflow-dsl` 在 monorepo 的 `packages/taskflow-dsl`。纯 JSON 作者不需要它。本发布线 manifest 为 `0.2.10`；`v0.2.10` 发布任务完成后可从 npm 安装，或使用本 monorepo 的 workspace / 本地 path。
 </Callout>
 
 ## 工作流

--- a/website/content/docs/zh-cn/getting-started.mdx
+++ b/website/content/docs/zh-cn/getting-started.mdx
@@ -116,7 +116,7 @@ taskflow 让你把多步骤的 agent 工作描述成一张声明式图。你不�
   </Tab>
   <Tab value="Hermes">
     ```bash title="注册 Hermes Agent MCP"
-    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
     ```
     只读隔离与显式可写 opt-in 说明见 [Hermes Agent 指南](/zh-cn/docs/guides/hermes)。
   </Tab>

--- a/website/content/docs/zh-cn/guides/grok-build.mdx
+++ b/website/content/docs/zh-cn/guides/grok-build.mdx
@@ -12,7 +12,7 @@ description: 将 taskflow 作为 Grok Build 插件安装，通过 MCP 编排多�
 ### 已发布 MCP 包（推荐）
 
 ```bash title="注册 taskflow MCP"
-grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.9 grok-taskflow-mcp
+grok mcp add taskflow -- npx -y -p grok-taskflow@0.2.10 grok-taskflow-mcp
 ```
 
 要求 **Node.js ≥ 22.19.0**。MCP 协议代码不依赖 MCP SDK。公共 Grok plugin marketplace/source 尚未发布；不要代入一个不存在的 source。

--- a/website/content/docs/zh-cn/guides/hermes.mdx
+++ b/website/content/docs/zh-cn/guides/hermes.mdx
@@ -12,7 +12,7 @@ description: 在 Hermes Agent 上通过 MCP 安装 taskflow，用隔离的 Herme
 ### 已发布 npm 包（发布后）
 
 ```bash title="注册 taskflow MCP"
-hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
 ```
 
 或写入 `~/.hermes/config.yaml` / `$HERMES_HOME/config.yaml`：
@@ -21,7 +21,7 @@ hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-
 mcp_servers:
   taskflow:
     command: "npx"
-    args: ["-y", "-p", "hermes-taskflow@0.2.9", "hermes-taskflow-mcp"]
+    args: ["-y", "-p", "hermes-taskflow@0.2.10", "hermes-taskflow-mcp"]
     env:
       # 需要写文件/终端的 mutating phase 必须打开
       # PI_TASKFLOW_HERMES_UNSAFE_YOLO: "1"  # required for mutating agent phases

--- a/website/content/docs/zh-cn/index.mdx
+++ b/website/content/docs/zh-cn/index.mdx
@@ -66,7 +66,7 @@ taskflow 是面向 coding-agent 子代理的声明式编排运行时。你定义
   </Tab>
   <Tab value="Hermes Agent">
     ```bash title="注册 Hermes MCP server"
-    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.9 hermes-taskflow-mcp
+    hermes mcp add taskflow --command npx --args -y -p hermes-taskflow@0.2.10 hermes-taskflow-mcp
     ```
 
     继续阅读 [Hermes Agent 指南](/zh-cn/docs/guides/hermes)。


### PR DESCRIPTION
## Summary

- release the organized saved-flow directories and `scriptCwd: "flow"` work as Taskflow 0.2.10
- align the root, all ten publishable packages, plugin manifests, MCP install pins, server-version assertions, website metadata, SECURITY and release/rollback guidance
- keep CharterArc at `0.2.7-experimental.0`
- make the comprehensive built-dist E2E derive its expected server version from the package manifest, preventing future release-version drift

## Release gates

- [x] `pnpm test` — 2184 passed, 0 failed, 4 skipped
- [x] `pnpm run typecheck`
- [x] `pnpm audit --prod --audit-level high` — no known vulnerabilities
- [x] generated skills check
- [x] `pnpm run test:pack` — 10 packages, 27 explicit imports, 74 wildcard exports, 6 bins
- [x] deterministic release tarballs — 10/10 at 0.2.10, exact internal dependency normalization, no `workspace:*`
- [x] `pnpm run test:e2e-codex-mcp-full` — 15/15 against built dist
- [x] website production export — 127 pages
- [x] independent release-diff review — PASS, no blocking or non-blocking findings

## Release identity

- base main: `ffbefc09aeec532e65161288df72e97be9cdcd27`
- release head: `4f90f0d5de0c3a1940dabe0ec38d75ac756ba02b`
- `v0.2.10` does not exist yet
- all ten `package@0.2.10` registry endpoints returned 404 before publication

After this PR is squash-merged, wait for exact main CI, then create annotated `v0.2.10` on the resulting main commit. Publishing remains exclusively tag-driven through `.github/workflows/publish.yml`.
