### PR TITLE
fix: Windows detached runs and static docs search (0.3.0-beta.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         run: node --conditions=development --experimental-strip-types --test packages/taskflow-core/test/runner-process.test.ts
       - name: Project storage boundary tests
         run: node --conditions=development --experimental-strip-types --test packages/taskflow-core/test/store.test.ts
+      - name: Windows detached runner specifier + Pi invocation (#139)
+        env:
+          PI_TASKFLOW_BUILTIN_AGENTS_DIR: ""
+        run: node --conditions=development --experimental-strip-types --test packages/taskflow-core/test/module-specifier.test.ts packages/pi-taskflow/test/pi-invocation.test.ts packages/pi-taskflow/test/detached-runner-module.test.ts
 
   test:
     name: test (node ${{ matrix.node }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to taskflow are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [Unreleased]
+
+## [0.3.0-beta.1.1] — 2026-08-18
+
+> Hotfix on `0.3.0-beta.1`. npm `beta` dist-tag. **Not GA.** Does **not** implement `#137` (`/tf web`) or `#95` (adaptive-authority isolation).
+
+### Fixed
+
+- **Windows detached runs (issue #139).** `detached-runner` now converts host `runnerModule` filesystem paths to `file://` specifiers before dynamic `import()`, so a native `C:\\…\\runner.js` is no longer rejected as protocol `c:`. The Pi adapter re-enters the installed `dist/cli.js` via `process.execPath` (and serializes `PI_TASKFLOW_PI_ENTRY` into the detached child) instead of `spawn("pi")` / `spawn("pi.cmd")`, which are ENOENT/EINVAL on npm's Windows shims.
+- **Docs search 404 (issue #138).** Static GitHub Pages export now pre-renders the Fumadocs search index (`/api/search`) and the client loads it with `type: 'static'`.
+
+### Notes
+
+- All publishable surfaces aligned to `0.3.0-beta.1.1`.
+
 ## [0.3.0-beta.1] — 2026-08-13
 
 > **Pre-release candidate:** `0.3.0-beta.1` is prepared for npm's `beta` dist-tag. It is **not GA**. The 0.3-C Control Plane remains a follow-on candidate track, not part of this beta's shipped product definition.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **taskflow is a declarative runtime for coding-agent workflows.** It turns a graph into a verifiable execution contract, runs phases in isolation, and keeps intermediate work out of the host conversation. In the 0.3 candidate, the contract also describes the effects a phase is allowed to propose.
 
-> **Status: 0.3.0-beta.1 Trusted Effects beta — beta channel, not GA.** This release candidate is prepared for npm's `beta` channel; the beta ships the Trusted Effects MVP described below. The 0.3-C Control Plane remains a follow-on candidate track; it is not a shipped beta surface.
+> **Status: 0.3.0-beta.1.1 Trusted Effects beta — beta channel, not GA.** This release candidate is prepared for npm's `beta` channel; the beta ships the Trusted Effects MVP described below. The 0.3-C Control Plane remains a follow-on candidate track; it is not a shipped beta surface.
 
 ## The 0.3 idea
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,7 +21,7 @@
 
 **taskflow 是面向 coding-agent 工作流的声明式运行时。** 它把任务图变成可验证的执行合同，让阶段隔离运行，并把中间过程留在宿主对话之外。在 0.3 candidate 中，这份合同还可以描述每个阶段被允许提出的副作用。
 
-> **状态：0.3.0-beta.1 Trusted Effects beta——beta channel，尚未 GA。** 当前 release candidate 已准备发布到 npm 的 `beta` channel；beta 包含下文所述的 Trusted Effects MVP。0.3-C Control Plane 仍是后续 candidate 轨道，不是 beta 已交付的产品表面。
+> **状态：0.3.0-beta.1.1 Trusted Effects beta——beta channel，尚未 GA。** 当前 release candidate 已准备发布到 npm 的 `beta` channel；beta 包含下文所述的 Trusted Effects MVP。0.3-C Control Plane 仍是后续 candidate 轨道，不是 beta 已交付的产品表面。
 
 ## 0.3 的核心想法
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ Dependency order: `taskflow-mcp-core`, `taskflow-hosts`, `taskflow-dsl`, `pi-tas
 
 ## One-time repository setup
 
-The beta release path is `v0.3.0-beta.1`: merge the reviewed release commit to `main`, then push the tag. `.github/workflows/publish.yml` validates the `0.3.0-beta.*` prerelease family, publishes the same ten packages to npm's `beta` dist-tag with provenance, and creates a prerelease GitHub Release. Do not publish from a workstation.
+The beta release path is `v0.3.0-beta.1.1`: merge the reviewed release commit to `main`, then push the tag. `.github/workflows/publish.yml` validates the `0.3.0-beta.*` prerelease family, publishes the same ten packages to npm's `beta` dist-tag with provenance, and creates a prerelease GitHub Release. Do not publish from a workstation.
 
 ## Pre-flight (always)
 
@@ -77,8 +77,8 @@ the matching annotated tag:
 ```sh
 git switch main
 git pull --ff-only origin main
-git tag -a v0.3.0-beta.1 -m "Release v0.3.0-beta.1"
-git push origin v0.3.0-beta.1
+git tag -a v0.3.0-beta.1.1 -m "Release v0.3.0-beta.1.1"
+git push origin v0.3.0-beta.1.1
 ```
 
 `.github/workflows/publish.yml` then performs the complete release transaction:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ The runtime has intentional hardening: `realpath`-based path containment, runId 
 | Version | Support |
 |---------|---------|
 | Latest stable npm release (`v0.2.10`) | ✅ Active |
-| `0.3.0-beta.1` beta channel | ⚠️ Pre-release; test-only support |
+| `0.3.0-beta.1.1` beta channel | ⚠️ Pre-release; test-only support |
 | Earlier versions | ❌ Unsupported — upgrade to the latest npm release |
 
 ## Disclosure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow-monorepo",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"private": true,
 	"description": "Monorepo for the Taskflow engine and DSL, host adapters, delivery packages, documentation, and the private CharterArc experiment.",
 	"type": "module",

--- a/packages/claude-taskflow/package.json
+++ b/packages/claude-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claude-taskflow",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Run taskflow on Claude Code: the npm tarball provides the Claude subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"claude",

--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.1.1",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/claude-taskflow/plugin/.mcp.json
+++ b/packages/claude-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "claude-taskflow@0.3.0-beta.1", "claude-taskflow-mcp"]
+      "args": ["-y", "-p", "claude-taskflow@0.3.0-beta.1.1", "claude-taskflow-mcp"]
     }
   }
 }

--- a/packages/claude-taskflow/test/mcp-server.test.ts
+++ b/packages/claude-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("claude mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-claude");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
 });
 
 test("claude mcp: tools/list exposes the same taskflow tools as codex", async () => {

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-taskflow",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Run taskflow on OpenAI Codex: the npm tarball provides the Codex subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"codex",

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.1.1",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.3.0-beta.1", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.3.0-beta.1.1", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -51,7 +51,7 @@ test("mcp: initialize returns the protocol version + serverInfo codex expects", 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-codex");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
 });
 
 test("mcp: tools/list exposes the taskflow tools with schemas", async () => {

--- a/packages/grok-taskflow/package.json
+++ b/packages/grok-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grok-taskflow",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Run taskflow on Grok Build: the npm tarball provides the Grok subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"grok",

--- a/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
+++ b/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.1.1",
   "description": "Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/grok-taskflow/plugin/.mcp.json
+++ b/packages/grok-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "grok-taskflow@0.3.0-beta.1", "grok-taskflow-mcp"],
+      "args": ["-y", "-p", "grok-taskflow@0.3.0-beta.1.1", "grok-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/grok-taskflow/test/mcp-server.test.ts
+++ b/packages/grok-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("grok mcp: initialize returns the protocol version + serverInfo", async () 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-grok");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
 });
 
 test("grok mcp: tools/list exposes the same taskflow tools as other hosts", async () => {

--- a/packages/hermes-taskflow/package.json
+++ b/packages/hermes-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hermes-taskflow",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Run taskflow on Hermes Agent: a Hermes subagent runner plus an MCP server (and a config scaffold) that exposes the taskflow_* tools to Hermes users.",
 	"keywords": [
 		"hermes",

--- a/packages/hermes-taskflow/plugin/hermes.config.snippet.yaml
+++ b/packages/hermes-taskflow/plugin/hermes.config.snippet.yaml
@@ -14,7 +14,7 @@
 
 taskflow:
   command: "npx"
-  args: ["-y", "-p", "hermes-taskflow@0.3.0-beta.1", "hermes-taskflow-mcp"]
+  args: ["-y", "-p", "hermes-taskflow@0.3.0-beta.1.1", "hermes-taskflow-mcp"]
   env:
     # Uncomment for mutating agent phases (terminal / file write).
     # Leave unset for verify/plan/script-only flows.

--- a/packages/hermes-taskflow/test/mcp-server.test.ts
+++ b/packages/hermes-taskflow/test/mcp-server.test.ts
@@ -38,7 +38,7 @@ test("hermes mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-hermes");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
 });
 
 test("hermes mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/opencode-taskflow/package.json
+++ b/packages/opencode-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opencode-taskflow",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Run taskflow on OpenCode: an OpenCode subagent runner plus an MCP server (and an opencode.json config scaffold) that exposes the taskflow_* tools to OpenCode users.",
 	"keywords": [
 		"opencode",

--- a/packages/opencode-taskflow/plugin/opencode.json
+++ b/packages/opencode-taskflow/plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "taskflow": {
       "type": "local",
-      "command": ["npx", "-y", "-p", "opencode-taskflow@0.3.0-beta.1", "opencode-taskflow-mcp"],
+      "command": ["npx", "-y", "-p", "opencode-taskflow@0.3.0-beta.1.1", "opencode-taskflow-mcp"],
       "enabled": true
     }
   },

--- a/packages/opencode-taskflow/test/mcp-server.test.ts
+++ b/packages/opencode-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("opencode mcp: initialize returns the protocol version + serverInfo", async
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-opencode");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
 });
 
 test("opencode mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
 	"keywords": [
 		"pi-package",

--- a/packages/pi-taskflow/src/index.ts
+++ b/packages/pi-taskflow/src/index.ts
@@ -28,7 +28,7 @@ import {
 import { Type, type TObject } from "typebox";
 import { type AgentScope, discoverAgents, readSubagentSettings, shouldSyncBuiltinAgentsToProject, syncBuiltinAgentsToProject } from "taskflow-core";
 import { renderRunResult, summarizeRun } from "./render.ts";
-import { createPiSubagentRunner, runnerModulePath } from "./runner.ts";
+import { createPiSubagentRunner, PI_TASKFLOW_PI_ENTRY_ENV, resolveParentPiCliEntry, runnerModulePath } from "./runner.ts";
 import { RunHistoryComponent, type RunHistoryResult } from "./runs-view.ts";
 import { ApprovalViewComponent, type ApprovalChoice } from "./approval-view.ts";
 import {
@@ -1527,10 +1527,13 @@ export default function (pi: ExtensionAPI) {
 					// that pipe couples its lifetime back to the host session. The child
 					// persists import/runtime failures on __detach__, while this parent still
 					// records spawn/early-exit failures below.
+					const childEnv: NodeJS.ProcessEnv = { ...process.env, TASKFLOW_DETACHED_RUNNER: "1" };
+					const parentPiEntry = resolveParentPiCliEntry();
+					if (parentPiEntry) childEnv[PI_TASKFLOW_PI_ENTRY_ENV] = parentPiEntry;
 					const child = spawn(process.execPath, [runnerScript, tmpFile], {
 						detached: true,
 						stdio: "ignore",
-						env: { ...process.env, TASKFLOW_DETACHED_RUNNER: "1" },
+						env: childEnv,
 					});
 					spawnedChild = child;
 					// Race-safe crash guard: if the child dies before reaching a terminal

--- a/packages/pi-taskflow/src/runner.ts
+++ b/packages/pi-taskflow/src/runner.ts
@@ -91,22 +91,111 @@ async function writePromptToTempFile(filePath: string, prompt: string): Promise<
 	});
 }
 
-function getPiInvocation(args: string[]): { command: string; args: string[] } {
-	// Explicit override (used by tests and unusual launch setups).
-	const override = process.env.PI_TASKFLOW_PI_BIN;
-	if (override) return { command: override, args };
+/** Parent serializes this so a detached child can re-enter the same Pi JS CLI. */
+export const PI_TASKFLOW_PI_ENTRY_ENV = "PI_TASKFLOW_PI_ENTRY";
 
-	const currentScript = process.argv[1];
+const PI_CLI_SCRIPT = /(?:^|[\\/])(?:cli|pi)\.(?:js|mjs|cjs)$/;
+const WINDOWS_NPM_SHIM = /\.(cmd|bat|ps1)$/i;
+
+export type PiInvocationProbe = {
+	overrideBin?: string;
+	entry?: string;
+	currentScript?: string;
+	execPath?: string;
+	platform?: NodeJS.Platform;
+	existsSync?: (p: string) => boolean;
+	resolveInstalledCli?: () => string | undefined;
+};
+
+/**
+ * Locate the installed `pi` JS CLI. `@earendil-works/pi-coding-agent` only
+ * exports `.` and `./rpc-entry` — `import.meta.resolve("…/package.json")`
+ * (and `createRequire().resolve` of the same) throws ERR_PACKAGE_PATH_NOT_EXPORTED.
+ * Resolve the public `.` entry, then walk up to the package.json that owns it.
+ */
+export function defaultResolveInstalledPiCli(exists: (p: string) => boolean = (candidate) => fs.existsSync(candidate)): string | undefined {
+	try {
+		const entryPath = fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"));
+		let dir = path.dirname(entryPath);
+		for (let i = 0; i < 8; i++) {
+			const pkgPath = path.join(dir, "package.json");
+			if (exists(pkgPath)) {
+				const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as {
+					name?: string;
+					bin?: string | Record<string, string>;
+				};
+				if (pkg.name === "@earendil-works/pi-coding-agent") {
+					const rel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.pi;
+					if (!rel) return undefined;
+					const abs = path.resolve(dir, rel);
+					return exists(abs) ? abs : undefined;
+				}
+			}
+			const parent = path.dirname(dir);
+			if (parent === dir) break;
+			dir = parent;
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Absolute JS entry of the Pi CLI that launched this process (or the installed
+ * `@earendil-works/pi-coding-agent` bin). Used to spawn subagents via
+ * `process.execPath` so Windows never has to `spawn("pi")` / `spawn("pi.cmd")`.
+ */
+export function resolveParentPiCliEntry(probe: PiInvocationProbe = {}): string | undefined {
+	const exists = probe.existsSync ?? ((p) => fs.existsSync(p));
+	const currentScript = probe.currentScript ?? process.argv[1];
 	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
-	// Only re-exec the current script if it actually looks like the pi CLI entry.
-	const looksLikePi = currentScript ? /(?:^|[\\/])(?:cli|pi)\.(?:js|mjs|cjs)$/.test(currentScript) : false;
-	if (currentScript && !isBunVirtualScript && looksLikePi && fs.existsSync(currentScript)) {
-		return { command: process.execPath, args: [currentScript, ...args] };
+	if (currentScript && !isBunVirtualScript && PI_CLI_SCRIPT.test(currentScript) && exists(currentScript)) {
+		return currentScript;
+	}
+	const resolve = probe.resolveInstalledCli ?? (() => defaultResolveInstalledPiCli(exists));
+	return resolve() ?? undefined;
+}
+
+export function getPiInvocation(args: string[], probe: PiInvocationProbe = {}): { command: string; args: string[] } {
+	const exists = probe.existsSync ?? ((p) => fs.existsSync(p));
+	const platform = probe.platform ?? process.platform;
+	const execPath = probe.execPath ?? process.execPath;
+	const override = probe.overrideBin !== undefined ? probe.overrideBin : process.env.PI_TASKFLOW_PI_BIN;
+	if (override) {
+		if (WINDOWS_NPM_SHIM.test(override)) {
+			throw new Error(
+				`PI_TASKFLOW_PI_BIN points at a Windows npm shim (${override}). ` +
+					"Node spawn() cannot launch .cmd/.ps1 without a shell (ENOENT/EINVAL). " +
+					`Set PI_TASKFLOW_PI_BIN to a real executable, or ${PI_TASKFLOW_PI_ENTRY_ENV} to the installed dist/cli.js.`,
+			);
+		}
+		return { command: override, args };
 	}
 
-	const execName = path.basename(process.execPath).toLowerCase();
+	const entry = (probe.entry !== undefined ? probe.entry : process.env[PI_TASKFLOW_PI_ENTRY_ENV])?.trim();
+	if (entry && exists(entry)) {
+		return { command: execPath, args: [entry, ...args] };
+	}
+
+	const parent = resolveParentPiCliEntry({
+		currentScript: probe.currentScript ?? process.argv[1],
+		existsSync: exists,
+		resolveInstalledCli: probe.resolveInstalledCli,
+	});
+	if (parent) return { command: execPath, args: [parent, ...args] };
+
+	const pathFor = platform === "win32" ? path.win32 : path.posix;
+	const execName = pathFor.basename(execPath).toLowerCase();
 	const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
-	if (!isGenericRuntime) return { command: process.execPath, args };
+	if (!isGenericRuntime) return { command: execPath, args };
+	if (platform === "win32") {
+		throw new Error(
+			"Unable to resolve the Pi CLI JavaScript entry on Windows. " +
+				"Detached runs cannot spawn the npm `pi.cmd` shim (Node spawn ENOENT/EINVAL). " +
+				`Set ${PI_TASKFLOW_PI_ENTRY_ENV} to the installed dist/cli.js, or PI_TASKFLOW_PI_BIN to a real executable.`,
+		);
+	}
 	return { command: "pi", args };
 }
 
@@ -451,6 +540,11 @@ export function createPiSubagentRunner(raw: unknown = DEFAULT_PI_CHILD_SETTINGS)
  * `import.meta.url` is always the executing file's real path (src/runner.ts in
  * dev, dist/runner.js in prod), so this is correct under both conditions with
  * no extension guessing.
+ *
+ * The returned value is a filesystem path, not an ESM specifier. On Windows
+ * `import(C:\\…)` is protocol `c:` (issue #139). Callers that dynamically
+ * import this path must run it through `toModuleImportSpecifier` first;
+ * `detached-runner` already does.
  */
 export function runnerModulePath(): string {
 	return fileURLToPath(import.meta.url);

--- a/packages/pi-taskflow/test/detached-runner-module.test.ts
+++ b/packages/pi-taskflow/test/detached-runner-module.test.ts
@@ -28,13 +28,14 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { toModuleImportSpecifier } from "../../taskflow-core/src/module-specifier.ts";
 import { runnerModulePath, piSubagentRunner } from "../src/runner.ts";
 
 test("detached runnerModule: self-reported path exists and exports a SubagentRunner", async () => {
 	const p = runnerModulePath();
 	assert.ok(existsSync(p), `runnerModulePath() must exist on disk: ${p}`);
 	// The detached-runner does exactly this dynamic import — replicate it.
-	const mod = await import(p);
+	const mod = await import(toModuleImportSpecifier(p));
 	const runner = mod["piSubagentRunner"];
 	assert.ok(runner && typeof runner.runTask === "function",
 		"dynamic import of runnerModulePath() must expose piSubagentRunner.runTask");
@@ -56,7 +57,7 @@ test("detached runnerModule: compiled index.js must not resolve relative .ts spe
 test("detached runnerModule: compiled dist/runner.js (if built) is itself a valid runnerModule", async () => {
 	const distRunner = fileURLToPath(new URL("../dist/runner.js", import.meta.url));
 	if (!existsSync(distRunner)) return; // dist not built in this checkout — covered in CI's build job
-	const mod = await import(distRunner);
+	const mod = await import(toModuleImportSpecifier(distRunner));
 	assert.ok(mod.piSubagentRunner && typeof mod.piSubagentRunner.runTask === "function",
 		"dist/runner.js must export piSubagentRunner.runTask");
 	assert.equal(typeof mod.runnerModulePath, "function", "dist/runner.js must export runnerModulePath");

--- a/packages/pi-taskflow/test/pi-invocation.test.ts
+++ b/packages/pi-taskflow/test/pi-invocation.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression for issue #139 blocker 2: after the runner module loads, the
+ * detached child falls back to `spawn("pi", …)`. A native npm install exposes
+ * Pi through Windows shims (`pi.cmd` / `pi.ps1`); `spawn("pi")` is ENOENT and
+ * `spawn("pi.cmd")` without a shell is EINVAL on Node 24.
+ *
+ * Detached argv[1] is the detached-runner script, not the Pi CLI, so the
+ * existing "re-exec current script if it looks like pi" branch never fires.
+ * The child must re-enter the installed Pi JS CLI via `process.execPath`.
+ */
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	PI_TASKFLOW_PI_ENTRY_ENV,
+	defaultResolveInstalledPiCli,
+	getPiInvocation,
+	resolveParentPiCliEntry,
+} from "../src/runner.ts";
+
+const ARGS = ["--mode", "json", "-p", "Task: Return OK."];
+const NODE_WIN = "C:\\Program Files\\nodejs\\node.exe";
+const NODE_POSIX = "/usr/bin/node";
+const PI_CLI = "C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\@earendil-works\\pi-coding-agent\\dist\\cli.js";
+const DETACHED_RUNNER = "C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\taskflow-core\\dist\\detached-runner.js";
+
+test("getPiInvocation: override bin still wins", () => {
+	const got = getPiInvocation(ARGS, {
+		overrideBin: "/tmp/fake-pi",
+		platform: "win32",
+		execPath: NODE_WIN,
+		currentScript: DETACHED_RUNNER,
+	});
+	assert.deepEqual(got, { command: "/tmp/fake-pi", args: ARGS });
+});
+
+test("getPiInvocation: Windows npm shim override is rejected (no shell, no EINVAL)", () => {
+	assert.throws(
+		() => getPiInvocation(ARGS, {
+			overrideBin: "C:\\Users\\x\\AppData\\Roaming\\npm\\pi.cmd",
+			platform: "win32",
+			execPath: NODE_WIN,
+			currentScript: DETACHED_RUNNER,
+		}),
+		/pi\.cmd|shim|EINVAL|PI_TASKFLOW_PI_ENTRY/i,
+	);
+});
+
+test("getPiInvocation: serialized parent Pi CLI is re-entered via execPath", () => {
+	const got = getPiInvocation(ARGS, {
+		entry: PI_CLI,
+		platform: "win32",
+		execPath: NODE_WIN,
+		currentScript: DETACHED_RUNNER,
+		existsSync: (p) => p === PI_CLI,
+	});
+	assert.deepEqual(got, { command: NODE_WIN, args: [PI_CLI, ...ARGS] });
+});
+
+test("getPiInvocation: detached Windows child resolves installed dist/cli.js, never spawn(pi)", () => {
+	const got = getPiInvocation(ARGS, {
+		platform: "win32",
+		execPath: NODE_WIN,
+		currentScript: DETACHED_RUNNER,
+		existsSync: (p) => p === PI_CLI,
+		resolveInstalledCli: () => PI_CLI,
+	});
+	assert.equal(got.command, NODE_WIN);
+	assert.equal(got.args[0], PI_CLI);
+	assert.deepEqual(got.args.slice(1), ARGS);
+	assert.notEqual(got.command, "pi");
+	assert.doesNotMatch(got.command, /\.cmd$/i);
+});
+
+test("getPiInvocation: Windows without a JS entry fails closed (no bare pi)", () => {
+	assert.throws(
+		() => getPiInvocation(ARGS, {
+			platform: "win32",
+			execPath: NODE_WIN,
+			currentScript: DETACHED_RUNNER,
+			existsSync: () => false,
+			resolveInstalledCli: () => undefined,
+		}),
+		/Windows|file:\/\/|shim|PI_TASKFLOW_PI_ENTRY|dist\/cli\.js/i,
+	);
+});
+
+test("getPiInvocation: POSIX fallback to bare pi is unchanged", () => {
+	const got = getPiInvocation(ARGS, {
+		platform: "linux",
+		execPath: NODE_POSIX,
+		currentScript: "/opt/taskflow-core/dist/detached-runner.js",
+		existsSync: () => false,
+		resolveInstalledCli: () => undefined,
+	});
+	assert.deepEqual(got, { command: "pi", args: ARGS });
+});
+
+test("getPiInvocation: current script that looks like the Pi CLI is re-exec'd", () => {
+	const got = getPiInvocation(ARGS, {
+		platform: "win32",
+		execPath: NODE_WIN,
+		currentScript: PI_CLI,
+		existsSync: (p) => p === PI_CLI,
+	});
+	assert.deepEqual(got, { command: NODE_WIN, args: [PI_CLI, ...ARGS] });
+});
+
+test("resolveParentPiCliEntry: prefers the live Pi CLI script", () => {
+	const got = resolveParentPiCliEntry({
+		currentScript: PI_CLI,
+		existsSync: (p) => p === PI_CLI,
+	});
+	assert.equal(got, PI_CLI);
+});
+
+test("resolveParentPiCliEntry: ignores detached-runner argv[1]", () => {
+	const got = resolveParentPiCliEntry({
+		currentScript: DETACHED_RUNNER,
+		existsSync: () => true,
+		resolveInstalledCli: () => PI_CLI,
+	});
+	assert.equal(got, PI_CLI);
+});
+
+test("pi host serializes PI_TASKFLOW_PI_ENTRY into the detached child env", () => {
+	const src = readFileSync(
+		path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../src/index.ts"),
+		"utf8",
+	);
+	assert.match(src, new RegExp(PI_TASKFLOW_PI_ENTRY_ENV));
+	assert.match(src, /resolveParentPiCliEntry/);
+});
+
+test("defaultResolveInstalledPiCli: walks from the public package entry, not package.json subpath", () => {
+	const got = defaultResolveInstalledPiCli();
+	if (!got) {
+		// Peer not installed in this checkout — production still fail-closes on win32.
+		return;
+	}
+	assert.match(got, /cli\.(js|mjs|cjs)$/);
+	assert.ok(existsSync(got), got);
+	assert.doesNotMatch(got, /\.(cmd|bat|ps1)$/i);
+});
+
+test("package.json subpath of pi-coding-agent is not exported (the dead-code trap)", async () => {
+	// Runtime-built so tsc does not resolve the unexported package.json subpath.
+	const subpath = "@earendil-works/pi-coding-agent/" + "package.json";
+	await assert.rejects(
+		() => import(subpath, { with: { type: "json" } }),
+		(err: NodeJS.ErrnoException) => {
+			assert.equal(err.code, "ERR_PACKAGE_PATH_NOT_EXPORTED");
+			return true;
+		},
+	);
+});

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-core",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, grok-taskflow, and hermes-taskflow.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-core/src/detached-runner.ts
+++ b/packages/taskflow-core/src/detached-runner.ts
@@ -40,6 +40,7 @@ import {
 import { FileTraceSink } from "./trace.ts";
 import type { RuntimeDeps } from "./runtime.ts";
 import type { SubagentRunner } from "./host/runner-types.ts";
+import { toModuleImportSpecifier } from "./module-specifier.ts";
 
 interface DetachContext {
 	runId: string;
@@ -213,7 +214,7 @@ try {
 	let runnerLoadError: string | undefined;
 	if (ctx.runnerModule) {
 		try {
-			const runnerMod = await import(ctx.runnerModule);
+			const runnerMod = await import(toModuleImportSpecifier(ctx.runnerModule));
 			const exportName = ctx.runnerFactoryExport ?? ctx.runnerExport ?? "piSubagentRunner";
 			const exported = runnerMod[exportName];
 			const runner = ctx.runnerFactoryExport && typeof exported === "function"

--- a/packages/taskflow-core/src/index.ts
+++ b/packages/taskflow-core/src/index.ts
@@ -51,6 +51,7 @@ export * from "./library/types.ts";
 export * from "./library/meta.ts";
 export * from "./library/search.ts";
 export * from "./runner-core.ts";
+export * from "./module-specifier.ts";
 export * from "./host/runner-types.ts";
 export * from "./flowir/index.ts";
 export * from "./trace.ts";

--- a/packages/taskflow-core/src/module-specifier.ts
+++ b/packages/taskflow-core/src/module-specifier.ts
@@ -1,0 +1,50 @@
+/**
+ * Turn a filesystem path or already-valid ESM specifier into something
+ * `import()` will accept on every platform.
+ *
+ * Node's ESM loader only accepts `file:`, `data:`, and `node:` URLs. A native
+ * Windows path such as `C:\\…\\runner.js` is parsed as protocol `c:` and
+ * rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME (issue #139). `pathToFileURL`
+ * is correct for the *current* platform, but unit tests and docs also need
+ * drive-letter / UNC strings to convert when the process itself is POSIX.
+ *
+ * Drive/UNC conversion goes through `URL.pathname` so `#` / `?` / spaces are
+ * percent-encoded (a raw `new URL("file:///C:/a#b")` would treat `#` as a
+ * fragment and import the truncated path).
+ */
+import { pathToFileURL } from "node:url";
+
+const WINDOWS_DRIVE = /^[A-Za-z]:[\\/]/;
+const WINDOWS_UNC = /^[\\/]{2}[^\\/]/;
+
+function windowsDriveToFileUrl(windowsPath: string): string {
+	const normalized = windowsPath.replace(/\\/g, "/");
+	const url = new URL("file:///");
+	url.pathname = `/${normalized}`;
+	return url.href;
+}
+
+function windowsUncToFileUrl(windowsPath: string): string {
+	const normalized = windowsPath.replace(/\\/g, "/").replace(/^\/+/, "");
+	const slash = normalized.indexOf("/");
+	const host = slash === -1 ? normalized : normalized.slice(0, slash);
+	const rest = slash === -1 ? "/" : normalized.slice(slash);
+	const url = new URL("file://");
+	url.host = host;
+	url.pathname = rest || "/";
+	return url.href;
+}
+
+export function toModuleImportSpecifier(moduleRef: string): string {
+	const trimmed = moduleRef.trim();
+	if (
+		trimmed.startsWith("file:") ||
+		trimmed.startsWith("data:") ||
+		trimmed.startsWith("node:")
+	) {
+		return trimmed;
+	}
+	if (WINDOWS_DRIVE.test(trimmed)) return windowsDriveToFileUrl(trimmed);
+	if (WINDOWS_UNC.test(trimmed)) return windowsUncToFileUrl(trimmed);
+	return pathToFileURL(trimmed).href;
+}

--- a/packages/taskflow-core/test/module-specifier.test.ts
+++ b/packages/taskflow-core/test/module-specifier.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression for issue #139: detached-runner dynamically imports the host
+ * runner module path the parent serialized. On native Windows that value is a
+ * drive-letter filesystem path (`C:\\…\\runner.js`). Node's ESM loader treats
+ * `C:` as a URL scheme and rejects it with ERR_UNSUPPORTED_ESM_URL_SCHEME.
+ *
+ * The helper must turn filesystem paths into `file://` URLs and leave already-
+ * valid ESM specifiers alone. detached-runner must call the helper — a raw
+ * `import(ctx.runnerModule)` is the bug.
+ */
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { toModuleImportSpecifier } from "../src/module-specifier.ts";
+
+test("toModuleImportSpecifier: Windows drive-letter path becomes a file URL", () => {
+	assert.equal(
+		toModuleImportSpecifier("C:\\Users\\x\\pi-taskflow\\dist\\runner.js"),
+		"file:///C:/Users/x/pi-taskflow/dist/runner.js",
+	);
+	assert.equal(
+		toModuleImportSpecifier("D:/a/taskflow/packages/pi-taskflow/dist/runner.js"),
+		"file:///D:/a/taskflow/packages/pi-taskflow/dist/runner.js",
+	);
+});
+
+test("toModuleImportSpecifier: POSIX absolute path becomes a file URL", () => {
+	const posix = "/home/x/pi-taskflow/dist/runner.js";
+	// On win32 this is a drive-relative path; pathToFileURL prefixes the
+	// current drive (CI windows-latest saw file:///D:/home/x/...). On POSIX
+	// it is a real absolute path. Match the helper's pathToFileURL fallback.
+	assert.equal(toModuleImportSpecifier(posix), pathToFileURL(posix).href);
+});
+
+test("toModuleImportSpecifier: file/data/node specifiers are left alone", () => {
+	assert.equal(
+		toModuleImportSpecifier("file:///C:/Users/x/runner.js"),
+		"file:///C:/Users/x/runner.js",
+	);
+	assert.equal(toModuleImportSpecifier("node:fs"), "node:fs");
+	assert.equal(toModuleImportSpecifier("data:text/javascript,export default 1"), "data:text/javascript,export default 1");
+});
+
+test("toModuleImportSpecifier: drive-letter is NOT treated as an ESM scheme", () => {
+	const spec = toModuleImportSpecifier("C:\\tmp\\runner.js");
+	assert.match(spec, /^file:/);
+	assert.doesNotMatch(spec, /^c:/i);
+});
+
+test("toModuleImportSpecifier: Windows paths percent-encode # ? and spaces", () => {
+	assert.equal(
+		toModuleImportSpecifier("C:\\Program Files\\x\\a#b\\runner.js"),
+		"file:///C:/Program%20Files/x/a%23b/runner.js",
+	);
+	assert.equal(
+		toModuleImportSpecifier("C:\\tmp\\a?b.js"),
+		"file:///C:/tmp/a%3Fb.js",
+	);
+});
+
+test("toModuleImportSpecifier: UNC path becomes a file URL", () => {
+	assert.equal(
+		toModuleImportSpecifier("\\\\server\\share\\runner.js"),
+		"file://server/share/runner.js",
+	);
+});
+
+test("toModuleImportSpecifier: live path round-trips through dynamic import", async () => {
+	const here = fileURLToPath(import.meta.url);
+	const spec = toModuleImportSpecifier(here);
+	assert.equal(spec, pathToFileURL(here).href);
+	const mod = await import(spec);
+	assert.equal(typeof mod, "object");
+});
+
+test("drive-letter strings are rejected by the ESM loader (the #139 symptom)", async () => {
+	// Runtime-built so tsc does not try to resolve the Windows path as a module.
+	const driveLetterPath = ["C:", "\\Users\\x\\pi-taskflow\\dist\\runner.js"].join("");
+	await assert.rejects(
+		() => import(driveLetterPath),
+		(err: NodeJS.ErrnoException) => {
+			assert.equal(err.code, "ERR_UNSUPPORTED_ESM_URL_SCHEME");
+			assert.match(String(err.message), /protocol 'c:'/i);
+			return true;
+		},
+	);
+});
+
+test("detached-runner imports runnerModule through toModuleImportSpecifier", () => {
+	const src = readFileSync(
+		path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../src/detached-runner.ts"),
+		"utf8",
+	);
+	assert.match(src, /toModuleImportSpecifier/);
+	assert.doesNotMatch(
+		src,
+		/await import\(\s*ctx\.runnerModule\s*\)/,
+		"raw import(ctx.runnerModule) is the Windows ESM scheme bug",
+	);
+});
+
+test("helper module exists next to detached-runner (not only in tests)", () => {
+	const helper = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../src/module-specifier.ts");
+	assert.ok(existsSync(helper), helper);
+});

--- a/packages/taskflow-dsl/package.json
+++ b/packages/taskflow-dsl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-dsl",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Compile-time TypeScript DSL frontend for taskflow: erase .tf.ts runes to Taskflow JSON, then FlowIR via taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-hosts/package.json
+++ b/packages/taskflow-hosts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-hosts",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Shared host-runner collection for taskflow — the codex, claude, opencode, grok, and hermes SubagentRunner implementations + their argv builders and event-stream parsers. The per-host MCP servers, plugin scaffolds, and bins live in codex-taskflow / claude-taskflow / opencode-taskflow / grok-taskflow / hermes-taskflow; this package holds just the runners so a new host can be added in one place.",
 	"homepage": "https://github.com/heggria/taskflow#readme",
 	"author": "heggria <bshengtao@gmail.com>",

--- a/packages/taskflow-mcp-core/package.json
+++ b/packages/taskflow-mcp-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-mcp-core",
-	"version": "0.3.0-beta.1",
+	"version": "0.3.0-beta.1.1",
 	"description": "Host-neutral MCP server for taskflow: a dependency-free stdio JSON-RPC server exposing the taskflow_* tools, plus the DAG SVG/outline renderer. Shared by the codex/claude/opencode/grok/hermes adapters — depends only on taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -10,16 +10,16 @@ export function generateStaticParams() {
 
 const site = {
 	en: {
-		title: "taskflow 0.3.0-beta.1 — Trusted Effects beta",
+		title: "taskflow 0.3.0-beta.1.1 — Trusted Effects beta",
 		brand: "taskflow",
 		description:
-		"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1; beta channel and not GA.",
+		"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1.1; beta channel and not GA.",
 	},
 	"zh-cn": {
-		title: "taskflow 0.3.0-beta.1 — Trusted Effects beta",
+		title: "taskflow 0.3.0-beta.1.1 — Trusted Effects beta",
 		brand: "taskflow",
 		description:
-			"声明 coding-agent effect，验证类型化路径，让已准入的文件修改经过唯一 resource authority。0.3.0-beta.1，beta channel，尚未 GA。",
+			"声明 coding-agent effect，验证类型化路径，让已准入的文件修改经过唯一 resource authority。0.3.0-beta.1.1，beta channel，尚未 GA。",
 	},
 } as const;
 

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -25,14 +25,14 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.3.0-beta.1 · Trusted Effects beta",
+			eyebrow: "taskflow 0.3.0-beta.1.1 · Trusted Effects beta",
 			title: [
 				"Declare the effect.",
 				"Verify the path.",
 				"Commit through one authority.",
 			],
 			sub: "taskflow turns coding-agent work into a verifiable runtime: explicit graphs, typed effect declarations, isolated execution, resource-controlled filesystem commits, and ledger-backed explanations across six hosts.",
-			noteKicker: "0.3.0-beta.1 · beta channel · not GA",
+			noteKicker: "0.3.0-beta.1.1 · beta channel · not GA",
 			noteBody:
 				"An agent can propose content. For admitted declared targets, the resources transaction is the only finalizer. The ControlHost scaffold exists; stores, approvals, receipts, and WebUI remain future follow-on stages, not shipped GA claims.",
 			micro:
@@ -78,7 +78,7 @@ const copy = {
 			],
 		},
 		install: {
-			label: "0.3.0-beta.1 host installs — select the beta channel.",
+			label: "0.3.0-beta.1.1 host installs — select the beta channel.",
 			copy: "Copy",
 			copied: "Copied",
 			guide: "Guide",
@@ -187,10 +187,10 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.3.0-beta.1 · Trusted Effects beta",
+			eyebrow: "taskflow 0.3.0-beta.1.1 · Trusted Effects beta",
 			title: ["声明 effect。", "验证路径。", "让一个 authority 负责提交。"],
 			sub: "taskflow 把 coding-agent 工作变成可验证的运行时：显式任务图、类型化 effect 声明、隔离执行、受 resources 控制的文件提交，以及覆盖六个宿主的 ledger-backed 解释。",
-			noteKicker: "0.3.0-beta.1 · beta channel · 尚未 GA",
+			noteKicker: "0.3.0-beta.1.1 · beta channel · 尚未 GA",
 			noteBody:
 				"智能体可以提出内容。对于已准入的已声明目标，resources transaction 是唯一最终提交者。ControlHost 目前是脚手架；store、审批、receipt 与 WebUI 仍是后续阶段，不是已交付的 GA 表面。",
 			micro: "Resolve-only 不是 OS sandbox。未声明写入仍取决于宿主策略。",
@@ -235,7 +235,7 @@ const copy = {
 			],
 		},
 		install: {
-			label: "0.3.0-beta.1 宿主安装；请显式选择 beta channel。",
+			label: "0.3.0-beta.1.1 宿主安装；请显式选择 beta channel。",
 			copy: "复制",
 			copied: "已复制",
 			guide: "指南",
@@ -341,7 +341,7 @@ export default async function HomePage({
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
 		name: "taskflow",
-		softwareVersion: "0.3.0-beta.1",
+		softwareVersion: "0.3.0-beta.1.1",
 		description: t.hero.sub,
 		applicationCategory: "DeveloperApplication",
 		operatingSystem: "Any",

--- a/website/app/api/search/route.ts
+++ b/website/app/api/search/route.ts
@@ -1,0 +1,13 @@
+import { createFromSource } from "fumadocs-core/search/server";
+import { source } from "@/lib/source";
+
+// The site is statically exported (`output: "export"`) to GitHub Pages, so
+// there is no runtime server. `staticGET` pre-renders the full search index
+// (zbsearch) into a static JSON file at build time; the client loads it with
+// the `type: "static"` search dialog (see app/layout.tsx) and searches in the
+// browser, so the Cmd+K / search dialog never hits a 404 endpoint.
+//
+// See https://fumadocs.dev/docs/headless/search/orama#static-export
+export const revalidate = false;
+
+export const { staticGET: GET } = createFromSource(source);

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -18,10 +18,13 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+	const searchApi = `${process.env.TASKFLOW_BASE_PATH ?? ""}/api/search`;
 	return (
 		<html lang="en" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable}`}>
 			<body className="flex min-h-screen flex-col antialiased">
-				<RootProvider>{children}</RootProvider>
+				<RootProvider search={{ options: { type: "static", api: searchApi } }}>
+					{children}
+				</RootProvider>
 			</body>
 		</html>
 	);

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 const title = "taskflow 0.3 — Trusted Effects for Coding Agents";
 const description =
-	"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1; beta channel and not GA.";
+	"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1.1; beta channel and not GA.";
 const canonical = "https://heggria.github.io/taskflow/en/";
 
 export const metadata: Metadata = {

--- a/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: Compile-time .tf.ts authoring — erase runes to Taskflow JSON, the
 S4 adds a **compile-time** TypeScript frontend. You author `*.tf.ts` with **runes** (`agent`, `map`, `race`, …). A CLI erases them to ordinary Taskflow JSON. Hosts still run **JSON** via `taskflow_run` / `/tf run` — there is **no** interpret path and **no** host auto-build of `.tf.ts`.
 
 <Callout type="info">
-  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1` on npm's `beta` channel; install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
+  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1.1` on npm's `beta` channel; install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
 </Callout>
 
 ## Workflow

--- a/website/content/docs/en/getting-started.mdx
+++ b/website/content/docs/en/getting-started.mdx
@@ -6,7 +6,7 @@ description: Run your first taskflow in under five minutes.
 taskflow lets you describe multi-step agent work as a declarative graph. Instead of writing a script that calls subagents one by one, you declare the nodes and edges — and the runtime handles fan-out, retries, caching, and resume.
 
 <Callout type="info">
-  This guide covers the stable 0.2.x host installation path. For **0.3.0-beta.1**, start with the [Trusted Effects overview](/en/docs/trusted-effects) and select npm's `beta` channel; beta is not GA.
+  This guide covers the stable 0.2.x host installation path. For **0.3.0-beta.1.1**, start with the [Trusted Effects overview](/en/docs/trusted-effects) and select npm's `beta` channel; beta is not GA.
 </Callout>
 
 The fastest way to see it is to run something.

--- a/website/content/docs/en/index.mdx
+++ b/website/content/docs/en/index.mdx
@@ -3,7 +3,7 @@ title: taskflow 0.3 Documentation
 description: "Trusted Effects for coding-agent workflows: declare effects, verify typed paths, and commit admitted filesystem changes through one resource authority."
 ---
 
-> **0.3.0-beta.1 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release. The 0.3-C Control Plane remains a follow-on candidate track.
+> **0.3.0-beta.1.1 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release. The 0.3-C Control Plane remains a follow-on candidate track.
 
 taskflow is a declarative runtime for coding-agent workflows. It turns a graph into a verifiable execution contract, runs phases in isolation, and keeps intermediate transcripts out of the host conversation. The 0.3 candidate adds **Trusted Effects**: a typed declaration and resource-controlled commit path for admitted filesystem effects.
 

--- a/website/content/docs/en/trusted-effects.mdx
+++ b/website/content/docs/en/trusted-effects.mdx
@@ -2,7 +2,7 @@
 title: Trusted Effects
 ---
 
-> **0.3.0-beta.1 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release; npm publication is still a release gate.
+> **0.3.0-beta.1.1 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release; npm publication is still a release gate.
 
 Trusted Effects makes a phase's side effects explicit. The model may propose content, but for an admitted declared filesystem target, the **resources transaction is the only finalizer**.
 

--- a/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: 编译期 .tf.ts 写法 —— rune erase 成 Taskflow JSON，再�
 S4 增加**编译期** TypeScript 前端：用 rune（`agent`、`map`、`race`…）写 `*.tf.ts`，CLI erase 成普通 Taskflow JSON。宿主仍通过 `taskflow_run` / `/tf run` 跑 **JSON**——**没有**解释执行路径，也**没有**宿主对 `.tf.ts` 的自动 build。
 
 <Callout type="info">
-  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1` on npm's `beta` channel; after publication, install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
+  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1.1` on npm's `beta` channel; after publication, install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
 </Callout>
 
 ## 工作流

--- a/website/content/docs/zh-cn/getting-started.mdx
+++ b/website/content/docs/zh-cn/getting-started.mdx
@@ -6,7 +6,7 @@ description: 五分钟内运行你的第一个 taskflow。
 taskflow 让你把多步骤的 agent 工作描述成一张声明式图。你不需要写一个一个调用子代理的脚本，只需声明节点和边——运行时会替你处理 fan-out、重试、缓存和续跑。
 
 <Callout type="info">
-  本指南介绍稳定的 0.2.x 宿主安装路径。对于 **0.3.0-beta.1**，请从 [Trusted Effects 总览](/zh-cn/docs/trusted-effects) 开始，并显式选择 npm 的 `beta` channel；beta 尚未 GA。
+  本指南介绍稳定的 0.2.x 宿主安装路径。对于 **0.3.0-beta.1.1**，请从 [Trusted Effects 总览](/zh-cn/docs/trusted-effects) 开始，并显式选择 npm 的 `beta` channel；beta 尚未 GA。
 </Callout>
 
 要最快地感受它，先跑一个看看。

--- a/website/content/docs/zh-cn/index.mdx
+++ b/website/content/docs/zh-cn/index.mdx
@@ -3,7 +3,7 @@ title: taskflow 0.3 文档
 description: "面向 coding-agent 工作流的 Trusted Effects：声明 effect，验证类型化路径，让已准入的文件修改经过唯一 resource authority。"
 ---
 
-> **0.3.0-beta.1——beta channel candidate，尚未 GA。** 这个页面描述为 beta 发布准备的 Trusted Effects MVP；0.3-C Control Plane 仍是后续 candidate 轨道。
+> **0.3.0-beta.1.1——beta channel candidate，尚未 GA。** 这个页面描述为 beta 发布准备的 Trusted Effects MVP；0.3-C Control Plane 仍是后续 candidate 轨道。
 
 taskflow 是面向 coding-agent 工作流的声明式运行时。它把任务图变成可验证的执行合同，让阶段隔离运行，并把中间 transcript 留在宿主对话之外。0.3 candidate 增加了 **Trusted Effects**：为已准入的文件 effect 提供类型化声明与受 resources 控制的提交路径。
 

--- a/website/content/docs/zh-cn/trusted-effects.mdx
+++ b/website/content/docs/zh-cn/trusted-effects.mdx
@@ -2,7 +2,7 @@
 title: Trusted Effects
 ---
 
-> **0.3.0-beta.1——beta channel candidate，尚未 GA。** 本页描述为 beta 发布准备的 Trusted Effects MVP；npm 发布仍是发版闸门。
+> **0.3.0-beta.1.1——beta channel candidate，尚未 GA。** 本页描述为 beta 发布准备的 Trusted Effects MVP；npm 发布仍是发版闸门。
 
 Trusted Effects 把阶段的副作用写进合同。模型可以提出内容，但对于已准入的已声明文件目标，**resources transaction 是唯一最终提交者**。
 


### PR DESCRIPTION
## Summary

One commit, two honestly shippable bugs, version freeze to **`0.3.0-beta.1.1`**. **Does not implement #137 (WebUI) or #95 (deferred security isolation).**

- **#139** Native Windows detached runs die twice: `import(C:\\...\\runner.js)` is protocol `c:`, then `spawn("pi")` / `spawn("pi.cmd")` is ENOENT/EINVAL on npm shims.
  - `toModuleImportSpecifier` at the detached-runner import site (filesystem path stays a path; `#`/`?`/spaces percent-encoded).
  - Re-enter installed `dist/cli.js` via `process.execPath`. Walk up from the public package entry — `package.json` is **not** in `exports` (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
  - Serialize `PI_TASKFLOW_PI_ENTRY`. Fail closed on win32 instead of spawning the shim.
  - New tests also run on the `windows-latest` process-supervisor job.
  - CI follow-up: tsc no longer sees literal `import()` of a drive-letter path or the unexported `package.json` subpath. POSIX-looking paths on win32 follow `pathToFileURL` (drive-relative).
- **#138** Docs search 404 on GitHub Pages: `staticGET` index + client `type: "static"`.

## Version

Honest hotfix tag after merge + CI green: **`0.3.0-beta.1.1`**.
Do **not** steal `0.3.0-beta.2` (Control Plane). npm dist-tag `beta`. Not GA.

## Test plan

- [x] `module-specifier` + `pi-invocation` + `detached-runner-module` (25/25 local)
- [x] sabotage: raw `import(ctx.runnerModule)` and bare `spawn("pi")` on win32 turn the new tests red
- [ ] CI `test` + `process supervisor (windows-latest)` on this SHA
- [ ] After merge: Pages search no longer 404

Closes #139
Closes #138