### PR TITLE
release: taskflow 0.3.0-beta.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+## [0.3.0-beta.1.2] — 2026-08-20
+
+> Hotfix on `0.3.0-beta.1.1`. npm `beta` dist-tag. **Not GA.** Does **not** implement `#137` (`/tf web`) or `#95` (adaptive-authority isolation). Does **not** steal `0.3.0-beta.2`.
+
 ### Added
 
 - **`taskFile` load-time include (issue #143).** A phase or parallel branch may declare `taskFile` instead of `task`. Trusted loaders (`defineFile` / saved flow) resolve the literal path against the definition file's directory (same class of source as `scriptCwd: "flow"`), inline the UTF-8 body into `task`, and delete `taskFile` before validate / interpolate / cache / FlowIR. XOR with `task`; leftover `taskFile` on inline `define` is `TF_TASKFILE_NO_PROVENANCE`; generated sub-flows reject it as `TF_DYNAMIC_RESOURCE_FORBIDDEN`. Path is not interpolated. Include cap is 256 KiB (`taskFile exceeds`). TS DSL: `agent({ taskFile: "prompts/x.md" })` only — a bare `agent({ model })` is not opts-only. Compile XOR keeps both fields. Nested inline `def` is not inlined. `taskflow-dsl` check does not read the file.
@@ -11,6 +15,10 @@ All notable changes to taskflow are documented here. This project follows [Keep 
 ### Chore
 
 - Absorb open Dependabot PRs into this line: pnpm/action-setup 6.0.10 (#129); codeql-action 4.37.7 (#145, #146); Pi 0.84.2 + typebox ^1.3.14 + biome 2.5.8 + @types/node 26.2.0 (#147); next 16.3.1 (#136); lucide-react ^1.31.0 (#135); fumadocs-ui 16.14.4 (#134); fumadocs-mdx 15.2.3 (#133). `fumadocs-core` stays 16.14.0 (no Dependabot PR). Pin workspace `nanoid` override 3.3.17 → 3.3.18 (Dependabot alert #33, GHSA-2v37-7h3g-55p8).
+
+### Notes
+
+- All publishable surfaces aligned to `0.3.0-beta.1.2`.
 
 ## [0.3.0-beta.1.1] — 2026-08-18
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **taskflow is a declarative runtime for coding-agent workflows.** It turns a graph into a verifiable execution contract, runs phases in isolation, and keeps intermediate work out of the host conversation. In the 0.3 candidate, the contract also describes the effects a phase is allowed to propose.
 
-> **Status: 0.3.0-beta.1.1 Trusted Effects beta — beta channel, not GA.** This release candidate is prepared for npm's `beta` channel; the beta ships the Trusted Effects MVP described below. The 0.3-C Control Plane remains a follow-on candidate track; it is not a shipped beta surface.
+> **Status: 0.3.0-beta.1.2 Trusted Effects beta — beta channel, not GA.** This release candidate is prepared for npm's `beta` channel; the beta ships the Trusted Effects MVP described below. The 0.3-C Control Plane remains a follow-on candidate track; it is not a shipped beta surface.
 
 ## The 0.3 idea
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,7 +21,7 @@
 
 **taskflow 是面向 coding-agent 工作流的声明式运行时。** 它把任务图变成可验证的执行合同，让阶段隔离运行，并把中间过程留在宿主对话之外。在 0.3 candidate 中，这份合同还可以描述每个阶段被允许提出的副作用。
 
-> **状态：0.3.0-beta.1.1 Trusted Effects beta——beta channel，尚未 GA。** 当前 release candidate 已准备发布到 npm 的 `beta` channel；beta 包含下文所述的 Trusted Effects MVP。0.3-C Control Plane 仍是后续 candidate 轨道，不是 beta 已交付的产品表面。
+> **状态：0.3.0-beta.1.2 Trusted Effects beta——beta channel，尚未 GA。** 当前 release candidate 已准备发布到 npm 的 `beta` channel；beta 包含下文所述的 Trusted Effects MVP。0.3-C Control Plane 仍是后续 candidate 轨道，不是 beta 已交付的产品表面。
 
 ## 0.3 的核心想法
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ Dependency order: `taskflow-mcp-core`, `taskflow-hosts`, `taskflow-dsl`, `pi-tas
 
 ## One-time repository setup
 
-The beta release path is `v0.3.0-beta.1.1`: merge the reviewed release commit to `main`, then push the tag. `.github/workflows/publish.yml` validates the `0.3.0-beta.*` prerelease family, publishes the same ten packages to npm's `beta` dist-tag with provenance, and creates a prerelease GitHub Release. Do not publish from a workstation.
+The beta release path is `v0.3.0-beta.1.2`: merge the reviewed release commit to `main`, then push the tag. `.github/workflows/publish.yml` validates the `0.3.0-beta.*` prerelease family, publishes the same ten packages to npm's `beta` dist-tag with provenance, and creates a prerelease GitHub Release. Do not publish from a workstation.
 
 ## Pre-flight (always)
 
@@ -77,8 +77,8 @@ the matching annotated tag:
 ```sh
 git switch main
 git pull --ff-only origin main
-git tag -a v0.3.0-beta.1.1 -m "Release v0.3.0-beta.1.1"
-git push origin v0.3.0-beta.1.1
+git tag -a v0.3.0-beta.1.2 -m "Release v0.3.0-beta.1.2"
+git push origin v0.3.0-beta.1.2
 ```
 
 `.github/workflows/publish.yml` then performs the complete release transaction:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ The runtime has intentional hardening: `realpath`-based path containment, runId 
 | Version | Support |
 |---------|---------|
 | Latest stable npm release (`v0.2.10`) | ✅ Active |
-| `0.3.0-beta.1.1` beta channel | ⚠️ Pre-release; test-only support |
+| `0.3.0-beta.1.2` beta channel | ⚠️ Pre-release; test-only support |
 | Earlier versions | ❌ Unsupported — upgrade to the latest npm release |
 
 ## Disclosure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow-monorepo",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"private": true,
 	"description": "Monorepo for the Taskflow engine and DSL, host adapters, delivery packages, documentation, and the private CharterArc experiment.",
 	"type": "module",

--- a/packages/claude-taskflow/package.json
+++ b/packages/claude-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claude-taskflow",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Run taskflow on Claude Code: the npm tarball provides the Claude subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"claude",

--- a/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
+++ b/packages/claude-taskflow/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.3.0-beta.1.1",
+  "version": "0.3.0-beta.1.2",
   "description": "Declarative, verifiable DAG orchestration for Claude Code subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/claude-taskflow/plugin/.mcp.json
+++ b/packages/claude-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "claude-taskflow@0.3.0-beta.1.1", "claude-taskflow-mcp"]
+      "args": ["-y", "-p", "claude-taskflow@0.3.0-beta.1.2", "claude-taskflow-mcp"]
     }
   }
 }

--- a/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/SKILL.md
@@ -163,6 +163,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/packages/claude-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/claude-taskflow/plugin/skills/taskflow/configuration.md
@@ -47,7 +47,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -89,10 +89,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/packages/claude-taskflow/test/mcp-server.test.ts
+++ b/packages/claude-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("claude mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-claude");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.2");
 });
 
 test("claude mcp: tools/list exposes the same taskflow tools as codex", async () => {

--- a/packages/codex-taskflow/package.json
+++ b/packages/codex-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-taskflow",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Run taskflow on OpenAI Codex: the npm tarball provides the Codex subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"codex",

--- a/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
+++ b/packages/codex-taskflow/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.3.0-beta.1.1",
+  "version": "0.3.0-beta.1.2",
   "description": "Declarative, verifiable DAG orchestration for Codex subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/codex-taskflow/plugin/.mcp.json
+++ b/packages/codex-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "codex-taskflow@0.3.0-beta.1.1", "codex-taskflow-mcp"],
+      "args": ["-y", "-p", "codex-taskflow@0.3.0-beta.1.2", "codex-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/SKILL.md
@@ -158,6 +158,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/codex-taskflow/plugin/skills/taskflow/configuration.md
@@ -47,7 +47,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -89,10 +89,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/packages/codex-taskflow/test/mcp-server.test.ts
+++ b/packages/codex-taskflow/test/mcp-server.test.ts
@@ -51,7 +51,7 @@ test("mcp: initialize returns the protocol version + serverInfo codex expects", 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-codex");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.2");
 });
 
 test("mcp: tools/list exposes the taskflow tools with schemas", async () => {

--- a/packages/grok-taskflow/package.json
+++ b/packages/grok-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grok-taskflow",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Run taskflow on Grok Build: the npm tarball provides the Grok subagent runner and MCP server; the plugin is distributed through the repository marketplace.",
 	"keywords": [
 		"grok",

--- a/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
+++ b/packages/grok-taskflow/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "taskflow",
-  "version": "0.3.0-beta.1.1",
+  "version": "0.3.0-beta.1.2",
   "description": "Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, resumable runs, and saveable commands, with intermediate transcripts kept out of your context.",
   "author": {
     "name": "heggria",

--- a/packages/grok-taskflow/plugin/.mcp.json
+++ b/packages/grok-taskflow/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "taskflow": {
       "command": "npx",
-      "args": ["-y", "-p", "grok-taskflow@0.3.0-beta.1.1", "grok-taskflow-mcp"],
+      "args": ["-y", "-p", "grok-taskflow@0.3.0-beta.1.2", "grok-taskflow-mcp"],
       "tool_timeout_sec": 1800
     }
   }

--- a/packages/grok-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/grok-taskflow/plugin/skills/taskflow/SKILL.md
@@ -168,6 +168,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/packages/grok-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/grok-taskflow/plugin/skills/taskflow/configuration.md
@@ -47,7 +47,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -89,10 +89,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/packages/grok-taskflow/test/mcp-server.test.ts
+++ b/packages/grok-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("grok mcp: initialize returns the protocol version + serverInfo", async () 
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-grok");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.2");
 });
 
 test("grok mcp: tools/list exposes the same taskflow tools as other hosts", async () => {

--- a/packages/hermes-taskflow/package.json
+++ b/packages/hermes-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hermes-taskflow",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Run taskflow on Hermes Agent: a Hermes subagent runner plus an MCP server (and a config scaffold) that exposes the taskflow_* tools to Hermes users.",
 	"keywords": [
 		"hermes",

--- a/packages/hermes-taskflow/plugin/hermes.config.snippet.yaml
+++ b/packages/hermes-taskflow/plugin/hermes.config.snippet.yaml
@@ -14,7 +14,7 @@
 
 taskflow:
   command: "npx"
-  args: ["-y", "-p", "hermes-taskflow@0.3.0-beta.1.1", "hermes-taskflow-mcp"]
+  args: ["-y", "-p", "hermes-taskflow@0.3.0-beta.1.2", "hermes-taskflow-mcp"]
   env:
     # Uncomment for mutating agent phases (terminal / file write).
     # Leave unset for verify/plan/script-only flows.

--- a/packages/hermes-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/hermes-taskflow/plugin/skills/taskflow/SKILL.md
@@ -163,6 +163,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/packages/hermes-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/hermes-taskflow/plugin/skills/taskflow/configuration.md
@@ -47,7 +47,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -89,10 +89,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/packages/hermes-taskflow/test/mcp-server.test.ts
+++ b/packages/hermes-taskflow/test/mcp-server.test.ts
@@ -38,7 +38,7 @@ test("hermes mcp: initialize returns the protocol version + serverInfo", async (
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-hermes");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.2");
 });
 
 test("hermes mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/opencode-taskflow/package.json
+++ b/packages/opencode-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opencode-taskflow",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Run taskflow on OpenCode: an OpenCode subagent runner plus an MCP server (and an opencode.json config scaffold) that exposes the taskflow_* tools to OpenCode users.",
 	"keywords": [
 		"opencode",

--- a/packages/opencode-taskflow/plugin/opencode.json
+++ b/packages/opencode-taskflow/plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "taskflow": {
       "type": "local",
-      "command": ["npx", "-y", "-p", "opencode-taskflow@0.3.0-beta.1.1", "opencode-taskflow-mcp"],
+      "command": ["npx", "-y", "-p", "opencode-taskflow@0.3.0-beta.1.2", "opencode-taskflow-mcp"],
       "enabled": true
     }
   },

--- a/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/SKILL.md
@@ -159,6 +159,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/packages/opencode-taskflow/plugin/skills/taskflow/configuration.md
+++ b/packages/opencode-taskflow/plugin/skills/taskflow/configuration.md
@@ -47,7 +47,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -89,10 +89,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/packages/opencode-taskflow/test/mcp-server.test.ts
+++ b/packages/opencode-taskflow/test/mcp-server.test.ts
@@ -45,7 +45,7 @@ test("opencode mcp: initialize returns the protocol version + serverInfo", async
 	assert.equal(res.result.protocolVersion, "2025-06-18");
 	assert.ok(res.result.capabilities.tools, "advertises tools capability");
 	assert.equal(res.result.serverInfo.name, "taskflow-opencode");
-	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.1");
+	assert.equal(res.result.serverInfo.version, "0.3.0-beta.1.2");
 });
 
 test("opencode mcp: tools/list exposes the taskflow tools", async () => {

--- a/packages/pi-taskflow/package.json
+++ b/packages/pi-taskflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-taskflow",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "A declarative, verifiable graph of task nodes for the Pi coding agent — statically verified before it runs, with dynamic fan-out, gates, isolated subagent context, resumable runs, and saveable commands.",
 	"keywords": [
 		"pi-package",

--- a/packages/pi-taskflow/skills/taskflow/SKILL.md
+++ b/packages/pi-taskflow/skills/taskflow/SKILL.md
@@ -136,6 +136,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/packages/pi-taskflow/skills/taskflow/configuration.md
+++ b/packages/pi-taskflow/skills/taskflow/configuration.md
@@ -47,7 +47,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -89,10 +89,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/packages/taskflow-core/package.json
+++ b/packages/taskflow-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-core",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Host-neutral engine for declarative, verifiable task-DAG orchestration — the runtime, DSL, cache, and verification shared by pi-taskflow, codex-taskflow, claude-taskflow, opencode-taskflow, grok-taskflow, and hermes-taskflow.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-dsl/package.json
+++ b/packages/taskflow-dsl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-dsl",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Compile-time TypeScript DSL frontend for taskflow: erase .tf.ts runes to Taskflow JSON, then FlowIR via taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/packages/taskflow-hosts/package.json
+++ b/packages/taskflow-hosts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-hosts",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Shared host-runner collection for taskflow — the codex, claude, opencode, grok, and hermes SubagentRunner implementations + their argv builders and event-stream parsers. The per-host MCP servers, plugin scaffolds, and bins live in codex-taskflow / claude-taskflow / opencode-taskflow / grok-taskflow / hermes-taskflow; this package holds just the runners so a new host can be added in one place.",
 	"homepage": "https://github.com/heggria/taskflow#readme",
 	"author": "heggria <bshengtao@gmail.com>",

--- a/packages/taskflow-mcp-core/package.json
+++ b/packages/taskflow-mcp-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskflow-mcp-core",
-	"version": "0.3.0-beta.1.1",
+	"version": "0.3.0-beta.1.2",
 	"description": "Host-neutral MCP server for taskflow: a dependency-free stdio JSON-RPC server exposing the taskflow_* tools, plus the DAG SVG/outline renderer. Shared by the codex/claude/opencode/grok/hermes adapters — depends only on taskflow-core.",
 	"keywords": [
 		"taskflow",

--- a/skills-src/taskflow/configuration.md
+++ b/skills-src/taskflow/configuration.md
@@ -45,7 +45,7 @@ Top-level keys of the taskflow definition object.
 | `concurrency` | number | `8` | Default fan-out / same-layer parallelism cap. See §4. |
 | `idleTimeout` | number | host default (`300000`) | Flow-level idle watchdog in ms (≥ 1000, or `0` to disable) for all agent-running phases that don't set their own. `0` disables the watchdog but then **every** agent-running phase MUST declare a finite wall `timeout` (≥ 1000) so the flow can never hang. A per-phase `idleTimeout` overrides this. |
 | `agentScope` | `user`\|`project`\|`both` | `user` | Which agent dirs to load. See §6. |
-| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. |
+| `scriptCwd` | `invocation`\|`flow` | `invocation` | Default cwd policy for `script` phases. `flow` requires trusted saved-flow/`defineFile` provenance; explicit phase `cwd` wins, and inherited cwd-bridge boundaries still constrain the resolved source directory. `taskFile` is the same class of load-time trusted source (see §2). |
 | `args` | record | `{}` | Declared invocation arguments. See §3. |
 | `hooks` | object | — | **0.2.7.** Terminal fire-and-forget notifications: `onComplete` / `onFail` / `onBlocked` arrays of `{type:"webhook"\|"file"\|"command", …}`. Payload is summary-only (`taskflow.hook.v1`) — never transcripts. Hook failure never changes run status. `https` or `http://127.0.0.1\|localhost` for webhooks; `command.run` is argv-only (no shell string). |
 | `phases` | array | — | **Required.** The phase DAG. See §2. |
@@ -87,10 +87,11 @@ Keys of each object in `phases[]`. Some only apply to specific `type`s.
 | `id` | all | — | **Required, unique.** Used in `{steps.<id>…}`. |
 | `type` | all | `agent` | One of the **12** phase types (agent, parallel, map, gate, reduce, approval, flow, loop, tournament, script, **race**, **expand**). |
 | `agent` | all | first available | Agent name; resolved from the scoped pool. |
-| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types. |
+| `task` | agent, gate, map, reduce | — | Prompt; supports interpolation. Required for these types unless `taskFile` is set. |
+| `taskFile` | agent, gate, map, reduce, parallel/race branch | — | Load-time include. Literal path relative to the flow definition directory. Trusted loaders inline UTF-8 into `task` and delete the field. XOR with `task`. Path is **not** interpolated. Cap 256 KiB. Not `context`. |
 | `over` | map | — | **Required for map.** Must resolve to an array. |
 | `as` | map | `item` | Loop variable bound per item. |
-| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]`. |
+| `branches` | parallel, race | — | **Required** (≥1 for parallel; ≥2 for race). `[{task, agent?}]` or `{taskFile, agent?}`. |
 | `cancelLosers` | race | `true` | Abort in-flight losers after first **success** (best-effort AbortSignal). |
 | `from` | reduce | — | **Required for reduce.** Phase ids whose outputs are aggregated. `{previous.output}` resolves to **all completed `from[]` outputs** in from-array order (one → raw; many → `### <id>\n\n<output>` sections joined by `\n\n---\n\n`). |
 | `reduceStrategy` | reduce | `one-shot` | `one-shot` = a single reducer call over all aggregated inputs. `tree` = batched intermediate reducer rounds (see `batchSize`); useful when aggregated input would exceed one prompt. `tree` forces the imperative runtime (event kernel falls back). |

--- a/skills-src/taskflow/core.md
+++ b/skills-src/taskflow/core.md
@@ -154,6 +154,24 @@ large definition on every call and keeps a durable draft you can diff. Falls
 back cleanly: precedence is `define` (inline) > `defineFile` (disk) > `name`
 (saved flow).
 
+### Long instructions: `taskFile` (load-time include, not `context`)
+
+A phase or parallel branch may set `taskFile` **instead of** `task`. Trusted
+loaders (`defineFile` / saved flow) resolve the **literal** path against the
+definition directory — same class of source as `scriptCwd: "flow"` — inline the
+UTF-8 body into `task`, and **delete** `taskFile` before validate / interpolate
+/ cache / FlowIR. Runtime never sees `taskFile`.
+
+- XOR with `task`. Path is a static import: **not interpolated**, no `..`, no
+  symlink leaf, must stay physically inside the flow directory. Cap 256 KiB.
+- Inline leftover → `TF_TASKFILE_NO_PROVENANCE`. Generated sub-flows →
+  `TF_DYNAMIC_RESOURCE_FORBIDDEN`.
+- Do **not** put durable instructions in `context`. `context` is cwd-relative,
+  default-truncated at 8k, wrapped as `## File:`, marked unreplayable, and
+  forbidden in dynamic sub-flows.
+- TS DSL: `agent({ taskFile: "prompts/x.md" })`. `taskflow-dsl check` / erase
+  emit the field and do **not** read the file.
+
 ### DSL shape
 
 ```jsonc

--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -10,16 +10,16 @@ export function generateStaticParams() {
 
 const site = {
 	en: {
-		title: "taskflow 0.3.0-beta.1.1 — Trusted Effects beta",
+		title: "taskflow 0.3.0-beta.1.2 — Trusted Effects beta",
 		brand: "taskflow",
 		description:
-		"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1.1; beta channel and not GA.",
+		"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1.2; beta channel and not GA.",
 	},
 	"zh-cn": {
-		title: "taskflow 0.3.0-beta.1.1 — Trusted Effects beta",
+		title: "taskflow 0.3.0-beta.1.2 — Trusted Effects beta",
 		brand: "taskflow",
 		description:
-			"声明 coding-agent effect，验证类型化路径，让已准入的文件修改经过唯一 resource authority。0.3.0-beta.1.1，beta channel，尚未 GA。",
+			"声明 coding-agent effect，验证类型化路径，让已准入的文件修改经过唯一 resource authority。0.3.0-beta.1.2，beta channel，尚未 GA。",
 	},
 } as const;
 

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -25,14 +25,14 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.3.0-beta.1.1 · Trusted Effects beta",
+			eyebrow: "taskflow 0.3.0-beta.1.2 · Trusted Effects beta",
 			title: [
 				"Declare the effect.",
 				"Verify the path.",
 				"Commit through one authority.",
 			],
 			sub: "taskflow turns coding-agent work into a verifiable runtime: explicit graphs, typed effect declarations, isolated execution, resource-controlled filesystem commits, and ledger-backed explanations across six hosts.",
-			noteKicker: "0.3.0-beta.1.1 · beta channel · not GA",
+			noteKicker: "0.3.0-beta.1.2 · beta channel · not GA",
 			noteBody:
 				"An agent can propose content. For admitted declared targets, the resources transaction is the only finalizer. The ControlHost scaffold exists; stores, approvals, receipts, and WebUI remain future follow-on stages, not shipped GA claims.",
 			micro:
@@ -78,7 +78,7 @@ const copy = {
 			],
 		},
 		install: {
-			label: "0.3.0-beta.1.1 host installs — select the beta channel.",
+			label: "0.3.0-beta.1.2 host installs — select the beta channel.",
 			copy: "Copy",
 			copied: "Copied",
 			guide: "Guide",
@@ -187,10 +187,10 @@ const copy = {
 			localeZh: "中文",
 		},
 		hero: {
-			eyebrow: "taskflow 0.3.0-beta.1.1 · Trusted Effects beta",
+			eyebrow: "taskflow 0.3.0-beta.1.2 · Trusted Effects beta",
 			title: ["声明 effect。", "验证路径。", "让一个 authority 负责提交。"],
 			sub: "taskflow 把 coding-agent 工作变成可验证的运行时：显式任务图、类型化 effect 声明、隔离执行、受 resources 控制的文件提交，以及覆盖六个宿主的 ledger-backed 解释。",
-			noteKicker: "0.3.0-beta.1.1 · beta channel · 尚未 GA",
+			noteKicker: "0.3.0-beta.1.2 · beta channel · 尚未 GA",
 			noteBody:
 				"智能体可以提出内容。对于已准入的已声明目标，resources transaction 是唯一最终提交者。ControlHost 目前是脚手架；store、审批、receipt 与 WebUI 仍是后续阶段，不是已交付的 GA 表面。",
 			micro: "Resolve-only 不是 OS sandbox。未声明写入仍取决于宿主策略。",
@@ -235,7 +235,7 @@ const copy = {
 			],
 		},
 		install: {
-			label: "0.3.0-beta.1.1 宿主安装；请显式选择 beta channel。",
+			label: "0.3.0-beta.1.2 宿主安装；请显式选择 beta channel。",
 			copy: "复制",
 			copied: "已复制",
 			guide: "指南",
@@ -341,7 +341,7 @@ export default async function HomePage({
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
 		name: "taskflow",
-		softwareVersion: "0.3.0-beta.1.1",
+		softwareVersion: "0.3.0-beta.1.2",
 		description: t.hero.sub,
 		applicationCategory: "DeveloperApplication",
 		operatingSystem: "Any",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 const title = "taskflow 0.3 — Trusted Effects for Coding Agents";
 const description =
-	"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1.1; beta channel and not GA.";
+	"Declare coding-agent effects, verify typed paths, and commit admitted filesystem changes through one resource authority. 0.3.0-beta.1.2; beta channel and not GA.";
 const canonical = "https://heggria.github.io/taskflow/en/";
 
 export const metadata: Metadata = {

--- a/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/en/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: Compile-time .tf.ts authoring — erase runes to Taskflow JSON, the
 S4 adds a **compile-time** TypeScript frontend. You author `*.tf.ts` with **runes** (`agent`, `map`, `race`, …). A CLI erases them to ordinary Taskflow JSON. Hosts still run **JSON** via `taskflow_run` / `/tf run` — there is **no** interpret path and **no** host auto-build of `.tf.ts`.
 
 <Callout type="info">
-  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1.1` on npm's `beta` channel; install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
+  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1.2` on npm's `beta` channel; install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
 </Callout>
 
 ## Workflow

--- a/website/content/docs/en/getting-started.mdx
+++ b/website/content/docs/en/getting-started.mdx
@@ -6,7 +6,7 @@ description: Run your first taskflow in under five minutes.
 taskflow lets you describe multi-step agent work as a declarative graph. Instead of writing a script that calls subagents one by one, you declare the nodes and edges — and the runtime handles fan-out, retries, caching, and resume.
 
 <Callout type="info">
-  This guide covers the stable 0.2.x host installation path. For **0.3.0-beta.1.1**, start with the [Trusted Effects overview](/en/docs/trusted-effects) and select npm's `beta` channel; beta is not GA.
+  This guide covers the stable 0.2.x host installation path. For **0.3.0-beta.1.2**, start with the [Trusted Effects overview](/en/docs/trusted-effects) and select npm's `beta` channel; beta is not GA.
 </Callout>
 
 The fastest way to see it is to run something.

--- a/website/content/docs/en/index.mdx
+++ b/website/content/docs/en/index.mdx
@@ -3,7 +3,7 @@ title: taskflow 0.3 Documentation
 description: "Trusted Effects for coding-agent workflows: declare effects, verify typed paths, and commit admitted filesystem changes through one resource authority."
 ---
 
-> **0.3.0-beta.1.1 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release. The 0.3-C Control Plane remains a follow-on candidate track.
+> **0.3.0-beta.1.2 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release. The 0.3-C Control Plane remains a follow-on candidate track.
 
 taskflow is a declarative runtime for coding-agent workflows. It turns a graph into a verifiable execution contract, runs phases in isolation, and keeps intermediate transcripts out of the host conversation. The 0.3 candidate adds **Trusted Effects**: a typed declaration and resource-controlled commit path for admitted filesystem effects.
 

--- a/website/content/docs/en/trusted-effects.mdx
+++ b/website/content/docs/en/trusted-effects.mdx
@@ -2,7 +2,7 @@
 title: Trusted Effects
 ---
 
-> **0.3.0-beta.1.1 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release; npm publication is still a release gate.
+> **0.3.0-beta.1.2 — beta channel candidate, not GA.** This page describes the Trusted Effects MVP prepared for the beta release; npm publication is still a release gate.
 
 Trusted Effects makes a phase's side effects explicit. The model may propose content, but for an admitted declared filesystem target, the **resources transaction is the only finalizer**.
 

--- a/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
+++ b/website/content/docs/zh-cn/compiler-runtime/typescript-dsl.mdx
@@ -8,7 +8,7 @@ description: 编译期 .tf.ts 写法 —— rune erase 成 Taskflow JSON，再�
 S4 增加**编译期** TypeScript 前端：用 rune（`agent`、`map`、`race`…）写 `*.tf.ts`，CLI erase 成普通 Taskflow JSON。宿主仍通过 `taskflow_run` / `/tf run` 跑 **JSON**——**没有**解释执行路径，也**没有**宿主对 `.tf.ts` 的自动 build。
 
 <Callout type="info">
-  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1.1` on npm's `beta` channel; after publication, install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
+  **Package status.** `taskflow-dsl` lives in the monorepo (`packages/taskflow-dsl`). It is **not** required for JSON authors. Package manifests target `0.3.0-beta.1.2` on npm's `beta` channel; after publication, install with `npm install taskflow-dsl@beta`, or use a workspace / local path from this monorepo.
 </Callout>
 
 ## 工作流

--- a/website/content/docs/zh-cn/getting-started.mdx
+++ b/website/content/docs/zh-cn/getting-started.mdx
@@ -6,7 +6,7 @@ description: 五分钟内运行你的第一个 taskflow。
 taskflow 让你把多步骤的 agent 工作描述成一张声明式图。你不需要写一个一个调用子代理的脚本，只需声明节点和边——运行时会替你处理 fan-out、重试、缓存和续跑。
 
 <Callout type="info">
-  本指南介绍稳定的 0.2.x 宿主安装路径。对于 **0.3.0-beta.1.1**，请从 [Trusted Effects 总览](/zh-cn/docs/trusted-effects) 开始，并显式选择 npm 的 `beta` channel；beta 尚未 GA。
+  本指南介绍稳定的 0.2.x 宿主安装路径。对于 **0.3.0-beta.1.2**，请从 [Trusted Effects 总览](/zh-cn/docs/trusted-effects) 开始，并显式选择 npm 的 `beta` channel；beta 尚未 GA。
 </Callout>
 
 要最快地感受它，先跑一个看看。

--- a/website/content/docs/zh-cn/index.mdx
+++ b/website/content/docs/zh-cn/index.mdx
@@ -3,7 +3,7 @@ title: taskflow 0.3 文档
 description: "面向 coding-agent 工作流的 Trusted Effects：声明 effect，验证类型化路径，让已准入的文件修改经过唯一 resource authority。"
 ---
 
-> **0.3.0-beta.1.1——beta channel candidate，尚未 GA。** 这个页面描述为 beta 发布准备的 Trusted Effects MVP；0.3-C Control Plane 仍是后续 candidate 轨道。
+> **0.3.0-beta.1.2——beta channel candidate，尚未 GA。** 这个页面描述为 beta 发布准备的 Trusted Effects MVP；0.3-C Control Plane 仍是后续 candidate 轨道。
 
 taskflow 是面向 coding-agent 工作流的声明式运行时。它把任务图变成可验证的执行合同，让阶段隔离运行，并把中间 transcript 留在宿主对话之外。0.3 candidate 增加了 **Trusted Effects**：为已准入的文件 effect 提供类型化声明与受 resources 控制的提交路径。
 

--- a/website/content/docs/zh-cn/trusted-effects.mdx
+++ b/website/content/docs/zh-cn/trusted-effects.mdx
@@ -2,7 +2,7 @@
 title: Trusted Effects
 ---
 
-> **0.3.0-beta.1.1——beta channel candidate，尚未 GA。** 本页描述为 beta 发布准备的 Trusted Effects MVP；npm 发布仍是发版闸门。
+> **0.3.0-beta.1.2——beta channel candidate，尚未 GA。** 本页描述为 beta 发布准备的 Trusted Effects MVP；npm 发布仍是发版闸门。
 
 Trusted Effects 把阶段的副作用写进合同。模型可以提出内容，但对于已准入的已声明文件目标，**resources transaction 是唯一最终提交者**。
 


### PR DESCRIPTION
## Summary

Cut `0.3.0-beta.1.2` after #148 landed `taskFile` on main.

- Ten published packages + plugin/MCP pins aligned to `0.3.0-beta.1.2`
- CHANGELOG `[0.3.0-beta.1.2] — 2026-08-20`
- skills-src teaches `taskFile` as load-time include (not `context`)
- Website / README / SECURITY / RELEASE point at the new beta

## Honesty

Does **not** implement `#137` (`/tf web`) or `#95` (adaptive-authority isolation).
Does **not** steal `0.3.0-beta.2` / `#142`.

## Test plan

- [x] skills-build + host mcp-server version tests
- [x] website docs:check
- [ ] CI packed consumer + test matrix on this PR

After merge + CI green on main: annotated tag `v0.3.0-beta.1.2` (publish.yml only).