### PR TITLE
chore: add HOL plugin scanner GitHub Action

### DIFF
--- a/.github/workflows/plugin-scanner.yml
+++ b/.github/workflows/plugin-scanner.yml
@@ -24,5 +24,6 @@ jobs:
         continue-on-error: true
         with:
           plugin_dir: "."
+          mode: scan
           min_score: 80
           fail_on_severity: high

--- a/.github/workflows/plugin-scanner.yml
+++ b/.github/workflows/plugin-scanner.yml
@@ -1,0 +1,28 @@
+name: Plugin Security Scan
+
+# HOL Plugin Scanner required by hashgraph-online/awesome-ai-plugins.
+# A passing score is not claimed: local verify of origin/main is 74/100 with
+# test-fixture "high" findings. continue-on-error keeps this from blocking
+# taskflow CI until those findings are triaged.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1
+        continue-on-error: true
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/packages/taskflow-hosts/test/publish-verification.test.ts
+++ b/packages/taskflow-hosts/test/publish-verification.test.ts
@@ -138,6 +138,7 @@ test("every repository workflow pins third-party actions to verified full SHAs",
 		["actions/deploy-pages", "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128"],
 		["github/codeql-action/init", "ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd"],
 		["github/codeql-action/analyze", "ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd"],
+		["hashgraph-online/ai-plugin-scanner-action", "55616c962cf86368423f7673b2ecdfdbe613d1af"],
 	]);
 	const files = readdirSync(workflowDir).filter((file) => /\.ya?ml$/.test(file));
 	assert.ok(files.length > 0, "no workflow files found");


### PR DESCRIPTION
## Summary

Add `hashgraph-online/ai-plugin-scanner-action@55616c96` (tag v1.2.515) so awesome-ai-plugins can detect scanner CI (#144).

Local `plugin-scanner scan .` on current main: **74/100**, 0 critical, **12 high** (almost all test fixtures + two shell-interpolation hits). `continue-on-error: true` so this does not block taskflow CI. Not a pass claim. Not GA.

## Test plan

- [x] publish-verification trustedPins includes the new action SHA